### PR TITLE
fix: harden auth, transfers, jobs, and UI state

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -56,10 +56,13 @@ For local-only testing, `auth_bypass_localhost` is enabled by default. Do not ex
 | `max_read_many_total_bytes` | `LOCAL_SHELL_MCP_MAX_READ_MANY_TOTAL_BYTES` | `5000000` |  |
 | `max_todos` | `LOCAL_SHELL_MCP_MAX_TODOS` | `1000` |  |
 | `max_todo_bytes` | `LOCAL_SHELL_MCP_MAX_TODO_BYTES` | `1000000` |  |
+| `max_job_log_bytes` | `LOCAL_SHELL_MCP_MAX_JOB_LOG_BYTES` | `10000000` | Maximum retained output bytes for each long-running job attempt. |
 | `max_audit_tail_bytes` | `LOCAL_SHELL_MCP_MAX_AUDIT_TAIL_BYTES` | `1000000` |  |
 | `max_audit_log_bytes` | `LOCAL_SHELL_MCP_MAX_AUDIT_LOG_BYTES` | `20000000` |  |
 | `max_tmp_files` | `LOCAL_SHELL_MCP_MAX_TMP_FILES` | `500` |  |
 | `max_tmp_bytes` | `LOCAL_SHELL_MCP_MAX_TMP_BYTES` | `50000000` |  |
+| `max_transfer_archive_entries` | `LOCAL_SHELL_MCP_MAX_TRANSFER_ARCHIVE_ENTRIES` | `100000` | Maximum entries accepted while unpacking a transferred directory archive. |
+| `max_transfer_unpacked_bytes` | `LOCAL_SHELL_MCP_MAX_TRANSFER_UNPACKED_BYTES` | `10000000000` | Maximum declared expanded bytes accepted for a transferred directory archive. |
 | `max_concurrent_commands` | `LOCAL_SHELL_MCP_MAX_CONCURRENT_COMMANDS` | `4` |  |
 | `max_tmux_sessions` | `LOCAL_SHELL_MCP_MAX_TMUX_SESSIONS` | `16` |  |
 

--- a/docs/reference/configuration.zh-Hant.md
+++ b/docs/reference/configuration.zh-Hant.md
@@ -56,10 +56,13 @@ LOCAL_SHELL_MCP_OAUTH_JWT_SECRET=change-me-long-random-secret
 | `max_read_many_total_bytes` | `LOCAL_SHELL_MCP_MAX_READ_MANY_TOTAL_BYTES` | `5000000` | 批量讀取總字節上限。 |
 | `max_todos` | `LOCAL_SHELL_MCP_MAX_TODOS` | `1000` | todo 記錄最大數量。 |
 | `max_todo_bytes` | `LOCAL_SHELL_MCP_MAX_TODO_BYTES` | `1000000` | todo 數據最大字節數。 |
+| `max_job_log_bytes` | `LOCAL_SHELL_MCP_MAX_JOB_LOG_BYTES` | `10000000` | 每次長任務運行保留的最大輸出字節數。 |
 | `max_audit_tail_bytes` | `LOCAL_SHELL_MCP_MAX_AUDIT_TAIL_BYTES` | `1000000` | `audit_tail` 最大返回字節數。 |
 | `max_audit_log_bytes` | `LOCAL_SHELL_MCP_MAX_AUDIT_LOG_BYTES` | `20000000` | 審計日誌文件大小上限。 |
 | `max_tmp_files` | `LOCAL_SHELL_MCP_MAX_TMP_FILES` | `500` | 臨時文件最大數量。 |
 | `max_tmp_bytes` | `LOCAL_SHELL_MCP_MAX_TMP_BYTES` | `50000000` | 臨時文件總字節上限。 |
+| `max_transfer_archive_entries` | `LOCAL_SHELL_MCP_MAX_TRANSFER_ARCHIVE_ENTRIES` | `100000` | 解包目錄傳輸歸檔時允許的最大成員數量。 |
+| `max_transfer_unpacked_bytes` | `LOCAL_SHELL_MCP_MAX_TRANSFER_UNPACKED_BYTES` | `10000000000` | 目錄傳輸歸檔允許聲明的最大解壓後總字節數。 |
 | `max_concurrent_commands` | `LOCAL_SHELL_MCP_MAX_CONCURRENT_COMMANDS` | `4` | 併發命令數量上限。 |
 | `max_tmux_sessions` | `LOCAL_SHELL_MCP_MAX_TMUX_SESSIONS` | `16` | tmux session 數量上限。 |
 

--- a/docs/reference/configuration.zh.md
+++ b/docs/reference/configuration.zh.md
@@ -56,10 +56,13 @@ LOCAL_SHELL_MCP_OAUTH_JWT_SECRET=change-me-long-random-secret
 | `max_read_many_total_bytes` | `LOCAL_SHELL_MCP_MAX_READ_MANY_TOTAL_BYTES` | `5000000` | 批量读取总字节上限。 |
 | `max_todos` | `LOCAL_SHELL_MCP_MAX_TODOS` | `1000` | todo 记录最大数量。 |
 | `max_todo_bytes` | `LOCAL_SHELL_MCP_MAX_TODO_BYTES` | `1000000` | todo 数据最大字节数。 |
+| `max_job_log_bytes` | `LOCAL_SHELL_MCP_MAX_JOB_LOG_BYTES` | `10000000` | 每次长任务运行保留的最大输出字节数。 |
 | `max_audit_tail_bytes` | `LOCAL_SHELL_MCP_MAX_AUDIT_TAIL_BYTES` | `1000000` | `audit_tail` 最大返回字节数。 |
 | `max_audit_log_bytes` | `LOCAL_SHELL_MCP_MAX_AUDIT_LOG_BYTES` | `20000000` | 审计日志文件大小上限。 |
 | `max_tmp_files` | `LOCAL_SHELL_MCP_MAX_TMP_FILES` | `500` | 临时文件最大数量。 |
 | `max_tmp_bytes` | `LOCAL_SHELL_MCP_MAX_TMP_BYTES` | `50000000` | 临时文件总字节上限。 |
+| `max_transfer_archive_entries` | `LOCAL_SHELL_MCP_MAX_TRANSFER_ARCHIVE_ENTRIES` | `100000` | 解包目录传输归档时允许的最大成员数量。 |
+| `max_transfer_unpacked_bytes` | `LOCAL_SHELL_MCP_MAX_TRANSFER_UNPACKED_BYTES` | `10000000000` | 目录传输归档允许声明的最大解压后总字节数。 |
 | `max_concurrent_commands` | `LOCAL_SHELL_MCP_MAX_CONCURRENT_COMMANDS` | `4` | 并发命令数量上限。 |
 | `max_tmux_sessions` | `LOCAL_SHELL_MCP_MAX_TMUX_SESSIONS` | `16` | tmux session 数量上限。 |
 

--- a/src/local_shell_mcp/agent_bridge/registry.py
+++ b/src/local_shell_mcp/agent_bridge/registry.py
@@ -28,7 +28,7 @@ def make_unique_tool_name(prefix: str, raw_name: str, seen: set[str]) -> str:
     base_name = f"{_sanitize_name(prefix)}__{_sanitize_name(raw_name)}"
     candidate = base_name
     if candidate in seen:
-        digest = hashlib.sha1(raw_name.encode("utf-8")).hexdigest()[:8]
+        digest = hashlib.sha1(raw_name.encode("utf-8"), usedforsecurity=False).hexdigest()[:8]
         candidate = f"{base_name}__{digest}"
         counter = 2
         while candidate in seen:

--- a/src/local_shell_mcp/audit.py
+++ b/src/local_shell_mcp/audit.py
@@ -34,6 +34,8 @@ def _trim_audit_log(path: Path, max_bytes: int) -> None:
     tmp = path.with_name(f".{path.name}.{os.getpid()}.{threading.get_ident()}.tmp")
     try:
         tmp.write_bytes(data)
+        with contextlib.suppress(OSError):
+            tmp.chmod(0o600)
         tmp.replace(path)
     finally:
         with contextlib.suppress(OSError):
@@ -65,9 +67,12 @@ def audit(event: str, **fields: Any) -> None:
     with _AUDIT_LOCK:
         path.parent.mkdir(parents=True, exist_ok=True)
         _trim_audit_log(path, settings.max_audit_log_bytes)
-        with path.open("a", encoding="utf-8") as f:
+        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        with os.fdopen(descriptor, "a", encoding="utf-8") as f:
             f.write(encoded)
             f.flush()
+        with contextlib.suppress(OSError):
+            path.chmod(0o600)
 
 
 def _operation_type(record: dict[str, Any]) -> str:

--- a/src/local_shell_mcp/audit.py
+++ b/src/local_shell_mcp/audit.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import json
 import os
+import re
 import threading
 import time
 from collections.abc import Iterator
@@ -15,6 +16,84 @@ from .settings import get_settings
 
 _AUDIT_ENABLED: ContextVar[bool] = ContextVar("local_shell_mcp_audit_enabled", default=True)
 _AUDIT_LOCK = threading.Lock()
+_AUDIT_REDACTED = "<redacted>"
+_AUDIT_OPAQUE_FIELDS = {
+    "code",
+    "command",
+    "content",
+    "data_b64",
+    "explanation",
+    "input_text",
+    "javascript",
+    "patch",
+    "purpose",
+    "repo_url",
+    "script",
+}
+_AUDIT_SECRET_FIELDS = {
+    "access",
+    "authorization",
+    "client_secret",
+    "cookie",
+    "oauth_admin_pin",
+    "oauth_jwt_secret",
+    "password",
+    "passwd",
+    "pin",
+    "secret",
+    "set-cookie",
+    "token",
+}
+_AUDIT_TOKEN_PATTERN = re.compile(
+    r"(?i)(?:bearer\s+)[A-Za-z0-9._~+/=-]+|gh[pousr]_[A-Za-z0-9_]{20,}"
+)
+_AUDIT_MAX_STRING = 2_000
+
+
+def _audit_configured_secrets(settings: Any) -> tuple[str, ...]:
+    values = []
+    for name in ("oauth_admin_pin", "oauth_jwt_secret"):
+        value = getattr(settings, name, None)
+        if isinstance(value, str) and len(value) >= 8:
+            values.append(value)
+    return tuple(values)
+
+
+def _redact_audit_text(value: str, configured_secrets: tuple[str, ...]) -> str:
+    redacted = value
+    for secret in configured_secrets:
+        redacted = redacted.replace(secret, _AUDIT_REDACTED)
+    redacted = _AUDIT_TOKEN_PATTERN.sub(_AUDIT_REDACTED, redacted)
+    if len(redacted) > _AUDIT_MAX_STRING:
+        redacted = redacted[:_AUDIT_MAX_STRING] + "…<truncated>"
+    return redacted
+
+
+def _sanitize_audit_value(
+    value: Any, configured_secrets: tuple[str, ...], field_name: str | None = None
+) -> Any:
+    normalized = (field_name or "").casefold()
+    if normalized in _AUDIT_OPAQUE_FIELDS or normalized in _AUDIT_SECRET_FIELDS:
+        return _AUDIT_REDACTED
+    if normalized.endswith(("_password", "_passwd", "_secret", "_authorization")):
+        return _AUDIT_REDACTED
+    if normalized.endswith("_token") and normalized != "token_id":
+        return _AUDIT_REDACTED
+    if isinstance(value, str):
+        return _redact_audit_text(value, configured_secrets)
+    if isinstance(value, dict):
+        return {
+            str(name): _sanitize_audit_value(item, configured_secrets, str(name))
+            for name, item in list(value.items())[:100]
+        }
+    if isinstance(value, (list, tuple)):
+        return [
+            _sanitize_audit_value(item, configured_secrets)
+            for item in list(value)[:100]
+        ]
+    if isinstance(value, (int, float, bool)) or value is None:
+        return value
+    return _redact_audit_text(repr(value), configured_secrets)
 
 
 def _trim_audit_log(path: Path, max_bytes: int) -> None:
@@ -57,10 +136,14 @@ def audit(event: str, **fields: Any) -> None:
     if not _AUDIT_ENABLED.get():
         return
     settings = get_settings()
+    configured_secrets = _audit_configured_secrets(settings)
     record = {
         "ts": time.time(),
-        "event": event,
-        **fields,
+        "event": _redact_audit_text(event, configured_secrets),
+        **{
+            name: _sanitize_audit_value(value, configured_secrets, name)
+            for name, value in fields.items()
+        },
     }
     path: Path = settings.audit_log_path
     encoded = json.dumps(record, ensure_ascii=False, default=str) + "\n"

--- a/src/local_shell_mcp/auth.py
+++ b/src/local_shell_mcp/auth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ipaddress
 import json
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -163,6 +164,45 @@ def _is_localhost(request: Request) -> bool:
     return host in {"127.0.0.1", "::1", "localhost"}
 
 
+def _host_header_is_loopback(request: Request) -> bool:
+    value = request.headers.get("host", "").strip()
+    if not value:
+        return False
+    if value.startswith("["):
+        end = value.find("]")
+        host = value[1:end] if end >= 0 else value.strip("[]")
+    else:
+        host = value.split(":", 1)[0]
+    if host.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def _is_direct_localhost_request(request: Request) -> bool:
+    """Return whether an HTTP request came directly from a loopback client.
+
+    Reverse proxies commonly connect to the service over loopback. Requiring a loopback
+    Host header and rejecting forwarding metadata prevents that proxy hop from inheriting
+    the local development bypass for a public client.
+    """
+
+    forwarded_headers = (
+        "forwarded",
+        "x-forwarded-for",
+        "x-forwarded-host",
+        "x-forwarded-proto",
+        "x-real-ip",
+    )
+    return (
+        _is_localhost(request)
+        and _host_header_is_loopback(request)
+        and not any(request.headers.get(name) for name in forwarded_headers)
+    )
+
+
 def _extract_token(request: Request) -> str | None:
     auth = request.headers.get("authorization")
     if auth and auth.lower().startswith("bearer "):
@@ -200,7 +240,11 @@ def verify_request(request: Request) -> Principal:
         and has_valid_ui_local_token(request)
     ):
         return Principal(email="localhost", subject="native-tui", claims={"auth": "native-tui"})
-    if settings.auth_bypass_localhost and _is_localhost(request) and settings.mode == "http":
+    if (
+        settings.auth_bypass_localhost
+        and settings.mode == "http"
+        and _is_direct_localhost_request(request)
+    ):
         return Principal(email="localhost", subject="localhost", claims={"auth": "localhost-bypass"})
     if settings.auth_mode == "oauth":
         principal = _verify_oauth(request, settings)

--- a/src/local_shell_mcp/downloads.py
+++ b/src/local_shell_mcp/downloads.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import mimetypes
 import os
 import secrets
+import stat
 import threading
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, BinaryIO
+from urllib.parse import quote
 
 from starlette.requests import Request
-from starlette.responses import FileResponse, JSONResponse, Response
+from starlette.responses import JSONResponse, Response, StreamingResponse
 from starlette.routing import Route
 
 from .audit import audit
@@ -18,7 +21,7 @@ from .fs_ops import relative_display, resolve_path
 from .settings import get_settings
 
 _DOWNLOAD_PREFIX = "/download"
-_DOWNLOAD_STORE_VERSION = 1
+_DOWNLOAD_STORE_VERSION = 2
 _STORE_LOCK = threading.RLock()
 
 
@@ -47,7 +50,14 @@ def _read_store_locked() -> dict[str, Any]:
         return _empty_store()
     if not isinstance(data, dict) or not isinstance(data.get("links"), dict):
         return _empty_store()
-    data.setdefault("version", _DOWNLOAD_STORE_VERSION)
+    if data.get("version") != _DOWNLOAD_STORE_VERSION:
+        audit(
+            "download_store_version_reset",
+            path=str(path),
+            stored_version=data.get("version"),
+            expected_version=_DOWNLOAD_STORE_VERSION,
+        )
+        return _empty_store()
     return data
 
 
@@ -56,6 +66,8 @@ def _write_store_locked(store: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(f".tmp-{os.getpid()}-{secrets.token_hex(4)}")
     tmp.write_text(json.dumps(store, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
+    with contextlib.suppress(OSError):
+        tmp.chmod(0o600)
     os.replace(tmp, path)
 
 
@@ -89,8 +101,12 @@ def _coerce_max_downloads(max_downloads: int | None) -> int:
 
 def _safe_filename(filename: str | None, source: Path) -> str:
     candidate = Path(filename).name if filename else source.name
-    candidate = candidate.strip().replace("\x00", "")
-    return candidate or "download"
+    candidate = "".join(
+        character
+        for character in candidate.strip()
+        if ord(character) >= 32 and ord(character) != 127
+    )
+    return candidate[:255] or "download"
 
 
 def _link_summary(token: str, link: dict[str, Any]) -> dict[str, Any]:
@@ -106,6 +122,12 @@ def _link_summary(token: str, link: dict[str, Any]) -> dict[str, Any]:
         "downloads": link.get("downloads", 0),
         "max_downloads": link.get("max_downloads", 0),
     }
+
+
+def _token_id(token: str) -> str:
+    import hashlib
+
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
 
 
 def _prune_locked(store: dict[str, Any], now: float | None = None) -> bool:
@@ -133,10 +155,13 @@ def create_share_link(
         raise PermissionError("disabled")
 
     resolved = resolve_path(path, must_exist=True)
-    if not resolved.is_file():
-        raise ValueError(f"Not a regular file: {path}")
+    try:
+        with _open_download_file(resolved) as handle:
+            source_stat = os.fstat(handle.fileno())
+    except (OSError, ValueError) as exc:
+        raise ValueError(f"Not a regular file: {path}") from exc
 
-    size = resolved.stat().st_size
+    size = source_stat.st_size
     if settings.file_download_max_file_bytes > 0 and size > settings.file_download_max_file_bytes:
         raise ValueError(f"File is too large: {size}")
 
@@ -149,6 +174,8 @@ def create_share_link(
         "display_path": relative_display(resolved),
         "filename": _safe_filename(filename, resolved),
         "bytes": size,
+        "device": int(source_stat.st_dev),
+        "inode": int(source_stat.st_ino),
         "created_at": now,
         "expires_at": now + ttl,
         "downloads": 0,
@@ -161,7 +188,12 @@ def create_share_link(
         store["links"][token] = link
         _write_store_locked(store)
 
-    audit("download_link_created", path=link["display_path"], token=token, expires_at=link["expires_at"])
+    audit(
+        "download_link_created",
+        path=link["display_path"],
+        token_id=_token_id(token),
+        expires_at=link["expires_at"],
+    )
     return _link_summary(token, link)
 
 
@@ -183,7 +215,7 @@ def revoke_share_link(token: str) -> dict[str, Any]:
         if removed is not None:
             _write_store_locked(store)
     if removed is not None:
-        audit("download_link_revoked", path=removed.get("display_path"), token=token)
+        audit("download_link_revoked", path=removed.get("display_path"), token_id=_token_id(token))
     return {"revoked": removed is not None, "token": token}
 
 
@@ -191,7 +223,26 @@ def _error_response(status_code: int, error: str, message: str) -> JSONResponse:
     return JSONResponse({"ok": False, "error": error, "message": message}, status_code=status_code)
 
 
-def _claim_download(token: str, *, consume: bool) -> tuple[Path, dict[str, Any]] | Response:
+def _open_download_file(path: Path) -> BinaryIO:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_BINARY"):
+        flags |= os.O_BINARY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(path, flags)
+    try:
+        file_stat = os.fstat(descriptor)
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise ValueError("download target is not a regular file")
+        return os.fdopen(descriptor, "rb")
+    except Exception:
+        os.close(descriptor)
+        raise
+
+
+def _claim_download(
+    token: str, *, consume: bool
+) -> tuple[BinaryIO, Path, dict[str, Any]] | Response:
     settings = get_settings()
     if not settings.file_download_enabled:
         return _error_response(404, "download_disabled", "File downloads are disabled")
@@ -215,22 +266,70 @@ def _claim_download(token: str, *, consume: bool) -> tuple[Path, dict[str, Any]]
             _write_store_locked(store)
             return _error_response(410, "download_exhausted", "Link has reached its use limit")
 
-        path = Path(str(link.get("path", ""))).resolve(strict=False)
-        if not path.exists() or not path.is_file():
+        try:
+            path = resolve_path(str(link.get("path", "")), must_exist=True)
+            handle = _open_download_file(path)
+        except (FileNotFoundError, OSError, PermissionError, ValueError):
             store.get("links", {}).pop(token, None)
             _write_store_locked(store)
             return _error_response(404, "download_missing", "The target file no longer exists")
 
-        if settings.file_download_max_file_bytes > 0 and path.stat().st_size > settings.file_download_max_file_bytes:
-            return _error_response(403, "download_too_large", "The target file exceeds the configured size limit")
+        opened_stat = os.fstat(handle.fileno())
+        if (
+            int(link.get("device", -1)) != int(opened_stat.st_dev)
+            or int(link.get("inode", -1)) != int(opened_stat.st_ino)
+        ):
+            handle.close()
+            store.get("links", {}).pop(token, None)
+            _write_store_locked(store)
+            return _error_response(
+                410,
+                "download_changed",
+                "The target file changed after the link was created",
+            )
+
+        size = opened_stat.st_size
+        if (
+            settings.file_download_max_file_bytes > 0
+            and size > settings.file_download_max_file_bytes
+        ):
+            handle.close()
+            return _error_response(
+                403,
+                "download_too_large",
+                "The target file exceeds the configured size limit",
+            )
 
         if consume:
             link["downloads"] = downloads + 1
             link["last_download_at"] = now
             store["links"][token] = link
-            _write_store_locked(store)
+            try:
+                _write_store_locked(store)
+            except Exception:
+                handle.close()
+                raise
 
-    return path, link
+    return handle, path, link
+
+
+def _content_disposition(filename: str) -> str:
+    fallback = (
+        filename.encode("ascii", errors="ignore")
+        .decode("ascii")
+        .replace('"', "")
+        or "download"
+    )
+    encoded = quote(filename, safe="")
+    return f"attachment; filename=\"{fallback}\"; filename*=UTF-8''{encoded}"
+
+
+def _file_chunks(handle: BinaryIO, chunk_size: int = 64 * 1024):  # noqa: ANN201
+    try:
+        while chunk := handle.read(chunk_size):
+            yield chunk
+    finally:
+        handle.close()
 
 
 async def download_endpoint(request: Request) -> Response:
@@ -239,15 +338,27 @@ async def download_endpoint(request: Request) -> Response:
     if isinstance(claimed, Response):
         return claimed
 
-    path, link = claimed
-    media_type = mimetypes.guess_type(link.get("filename") or path.name)[0] or "application/octet-stream"
-    audit("download_link_served", path=link.get("display_path"), token=token, method=request.method)
-    return FileResponse(
-        path,
-        media_type=media_type,
-        filename=link.get("filename") or path.name,
-        headers={"Cache-Control": "private, no-store"},
+    handle, path, link = claimed
+    media_type = (
+        mimetypes.guess_type(link.get("filename") or path.name)[0]
+        or "application/octet-stream"
     )
+    filename = link.get("filename") or path.name
+    headers = {
+        "Cache-Control": "private, no-store",
+        "Content-Disposition": _content_disposition(filename),
+        "Content-Length": str(os.fstat(handle.fileno()).st_size),
+    }
+    audit(
+        "download_link_served",
+        path=link.get("display_path"),
+        token_id=_token_id(token),
+        method=request.method,
+    )
+    if request.method.upper() == "HEAD":
+        handle.close()
+        return Response(status_code=200, media_type=media_type, headers=headers)
+    return StreamingResponse(_file_chunks(handle), media_type=media_type, headers=headers)
 
 
 def download_routes() -> list[Route]:

--- a/src/local_shell_mcp/fs_ops.py
+++ b/src/local_shell_mcp/fs_ops.py
@@ -11,6 +11,7 @@ import tempfile
 import threading
 from collections.abc import Iterator
 from contextlib import ExitStack, contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 
 from .settings import get_settings
@@ -26,7 +27,15 @@ class FileConflictError(RuntimeError):
 
 
 _PATH_LOCKS_GUARD = threading.Lock()
-_PATH_LOCKS: dict[str, threading.RLock] = {}
+
+
+@dataclass
+class _ThreadPathLock:
+    lock: threading.RLock
+    users: int = 0
+
+
+_PATH_LOCKS: dict[str, _ThreadPathLock] = {}
 
 
 def _sha256_file(path: Path) -> str:
@@ -37,47 +46,65 @@ def _sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
-def _thread_lock_for(path: Path) -> threading.RLock:
+def _thread_lock_for(path: Path) -> tuple[str, _ThreadPathLock]:
     key = str(path)
     with _PATH_LOCKS_GUARD:
-        return _PATH_LOCKS.setdefault(key, threading.RLock())
+        entry = _PATH_LOCKS.get(key)
+        if entry is None:
+            entry = _ThreadPathLock(threading.RLock())
+            _PATH_LOCKS[key] = entry
+        entry.users += 1
+        return key, entry
+
+
+def _release_thread_lock(key: str, entry: _ThreadPathLock) -> None:
+    with _PATH_LOCKS_GUARD:
+        entry.users -= 1
+        if entry.users <= 0 and _PATH_LOCKS.get(key) is entry:
+            _PATH_LOCKS.pop(key, None)
 
 
 @contextmanager
 def _path_lock(path: Path) -> Iterator[None]:
-    """Serialize mutations to a path across threads and cooperating processes."""
+    """Serialize mutations using bounded process-lock shards and transient thread locks."""
 
-    thread_lock = _thread_lock_for(path)
-    with thread_lock:
-        lock_dir = get_settings().state_dir / "locks"
-        lock_dir.mkdir(parents=True, exist_ok=True)
-        lock_name = hashlib.sha256(str(path).encode("utf-8")).hexdigest() + ".lock"
-        lock_path = lock_dir / lock_name
-        with lock_path.open("a+b") as handle:
-            if handle.tell() == 0 and handle.seek(0, os.SEEK_END) == 0:
-                handle.write(b"\0")
-                handle.flush()
-            handle.seek(0)
-            if os.name == "nt":
-                import msvcrt
-
-                msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
-            else:
-                import fcntl
-
-                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
-            try:
-                yield
-            finally:
+    key, entry = _thread_lock_for(path)
+    try:
+        with entry.lock:
+            lock_dir = get_settings().state_dir / "locks"
+            lock_dir.mkdir(parents=True, exist_ok=True)
+            digest = hashlib.sha256(str(path).encode("utf-8")).hexdigest()
+            lock_path = lock_dir / f"shard-{digest[:2]}.lock"
+            with lock_path.open("a+b") as handle:
+                with contextlib.suppress(OSError):
+                    lock_path.chmod(0o600)
+                handle.seek(0, os.SEEK_END)
+                if handle.tell() == 0:
+                    handle.write(b"\0")
+                    handle.flush()
                 handle.seek(0)
                 if os.name == "nt":
                     import msvcrt
 
-                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
                 else:
                     import fcntl
 
-                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+                try:
+                    yield
+                finally:
+                    handle.seek(0)
+                    if os.name == "nt":
+                        import msvcrt
+
+                        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                    else:
+                        import fcntl
+
+                        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    finally:
+        _release_thread_lock(key, entry)
 
 
 @contextmanager

--- a/src/local_shell_mcp/human_ui.py
+++ b/src/local_shell_mcp/human_ui.py
@@ -911,6 +911,12 @@ def run_tui_cli(argv: list[str] | None = None) -> None:
     raise SystemExit(completed.returncode)
 
 
+def _idle_timeout_remaining(
+    last_activity: float, idle_timeout: float, now: float
+) -> float:
+    return max(0.0, idle_timeout - max(0.0, now - last_activity))
+
+
 async def ui_terminal_websocket(websocket: WebSocket) -> None:
     if not _authorize_websocket(websocket):
         await websocket.close(code=4401, reason="OAuth authentication required")
@@ -954,25 +960,47 @@ async def ui_terminal_websocket(websocket: WebSocket) -> None:
         await websocket.close(code=1011, reason=detail[:120])
         return
 
+    loop = asyncio.get_running_loop()
+    last_activity = loop.time()
+
     async def sender() -> None:
+        nonlocal last_activity
         while True:
             data = await process.read()
             if not data:
                 return
+            last_activity = loop.time()
             await websocket.send_bytes(data)
 
     async def receiver() -> None:
-        nonlocal cols, rows
+        nonlocal cols, rows, last_activity
         idle_timeout = max(0, settings.ui_terminal_idle_timeout_s)
         while True:
             if idle_timeout:
+                remaining = _idle_timeout_remaining(
+                    last_activity, idle_timeout, loop.time()
+                )
+                if remaining <= 0:
+                    await websocket.close(
+                        code=4408, reason="WebUI terminal session idle timeout"
+                    )
+                    return
                 try:
-                    message = await asyncio.wait_for(websocket.receive(), timeout=idle_timeout)
+                    message = await asyncio.wait_for(
+                        websocket.receive(), timeout=remaining
+                    )
                 except TimeoutError:
-                    await websocket.close(code=4408, reason="WebUI terminal session idle timeout")
+                    if _idle_timeout_remaining(
+                        last_activity, idle_timeout, loop.time()
+                    ) > 0:
+                        continue
+                    await websocket.close(
+                        code=4408, reason="WebUI terminal session idle timeout"
+                    )
                     return
             else:
                 message = await websocket.receive()
+            last_activity = loop.time()
             if message["type"] == "websocket.disconnect":
                 return
             if message.get("bytes") is not None:

--- a/src/local_shell_mcp/jobs.py
+++ b/src/local_shell_mcp/jobs.py
@@ -1,20 +1,32 @@
 from __future__ import annotations
 
+import argparse
 import contextlib
 import json
+import os
 import re
+import shlex
+import subprocess
+import sys
 import time
 import uuid
 from pathlib import Path
-from typing import Any
+from typing import Any, BinaryIO
 
 from .audit import audit
+from .fs_ops import resolve_path
 from .settings import get_settings
-from .shell_ops import kill_shell, list_shells, read_shell, start_shell
+from .shell_ops import (
+    check_command_policy,
+    kill_shell,
+    list_shells,
+    read_shell,
+    start_shell,
+)
 
 JOB_STORE_FILE_NAME = "jobs.json"
-JOB_STORE_VERSION = 1
-TERMINAL_STATUSES = {"exited", "stopped", "lost"}
+JOB_STORE_VERSION = 2
+TERMINAL_STATUSES = {"succeeded", "failed", "exited", "stopped", "lost"}
 
 
 def _utc() -> float:
@@ -23,6 +35,12 @@ def _utc() -> float:
 
 def _job_store_path() -> Path:
     return get_settings().state_dir / JOB_STORE_FILE_NAME
+
+
+def _job_runtime_dir() -> Path:
+    path = get_settings().state_dir / "jobs"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
 
 
 def _load_store() -> dict[str, Any]:
@@ -38,7 +56,10 @@ def _load_store() -> dict[str, Any]:
     jobs = data.get("jobs")
     if not isinstance(jobs, list):
         jobs = []
-    return {"version": JOB_STORE_VERSION, "jobs": [job for job in jobs if isinstance(job, dict)]}
+    return {
+        "version": JOB_STORE_VERSION,
+        "jobs": [job for job in jobs if isinstance(job, dict)],
+    }
 
 
 def _save_store(store: dict[str, Any]) -> None:
@@ -61,15 +82,111 @@ def _shell_safe_name(value: str) -> str:
 
 
 def _active_session_ids(shells: dict[str, Any]) -> set[str]:
-    return {str(item.get("session_id")) for item in shells.get("sessions", []) if item.get("session_id")}
+    return {
+        str(item.get("session_id"))
+        for item in shells.get("sessions", [])
+        if item.get("session_id")
+    }
 
 
-def _refresh_job_status(job: dict[str, Any], active_sessions: set[str], now: float | None = None) -> dict[str, Any]:
+def _private_write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    with contextlib.suppress(OSError):
+        path.chmod(0o600)
+
+
+def _attempt_paths(job_id: str, attempt: int) -> dict[str, Path]:
+    root = _job_runtime_dir()
+    stem = f"{job_id}-attempt-{attempt}"
+    return {
+        "command": root / f"{stem}.command",
+        "log": root / f"{stem}.log",
+        "status": root / f"{stem}.status.json",
+    }
+
+
+def _runner_argv(paths: dict[str, Path], cwd: Path) -> list[str]:
+    settings = get_settings()
+    arguments = [
+        "job-runner",
+        "--command-file",
+        str(paths["command"]),
+        "--log-file",
+        str(paths["log"]),
+        "--status-file",
+        str(paths["status"]),
+        "--cwd",
+        str(cwd),
+        "--shell",
+        settings.shell_executable,
+        "--max-log-bytes",
+        str(max(1, settings.max_job_log_bytes)),
+    ]
+    if getattr(sys, "frozen", False):
+        return [sys.executable, *arguments]
+    return [sys.executable, "-m", "local_shell_mcp.main", *arguments]
+
+
+def _prepare_attempt(
+    job_id: str, attempt: int, command: str, cwd: str
+) -> tuple[dict[str, Path], str]:
+    check_command_policy(command)
+    resolved_cwd = resolve_path(cwd, must_exist=True)
+    paths = _attempt_paths(job_id, attempt)
+    _private_write_text(paths["command"], command)
+    paths["log"].unlink(missing_ok=True)
+    paths["status"].unlink(missing_ok=True)
+    return paths, shlex.join(_runner_argv(paths, resolved_cwd))
+
+
+def _read_status(job: dict[str, Any]) -> dict[str, Any] | None:
+    raw_path = job.get("status_path")
+    if not raw_path:
+        return None
+    try:
+        payload = json.loads(Path(str(raw_path)).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _refresh_job_status(
+    job: dict[str, Any], active_sessions: set[str], now: float | None = None
+) -> dict[str, Any]:
     status = str(job.get("status") or "unknown")
+    if status != "running":
+        return job
+    status_payload = _read_status(job)
     session_id = str(job.get("session_id") or "")
-    if status == "running" and session_id not in active_sessions:
-        job["status"] = "exited"
-        job["updated_at"] = now or _utc()
+    if status_payload is None and session_id in active_sessions:
+        return job
+
+    updated = now or _utc()
+    if status_payload is None:
+        job.update(
+            {
+                "status": "lost",
+                "updated_at": updated,
+                "completed_at": updated,
+                "exit_code": None,
+                "error": "job session exited without a completion record",
+            }
+        )
+        return job
+
+    exit_code = status_payload.get("exit_code")
+    job.update(
+        {
+            "status": "succeeded" if exit_code == 0 else "failed",
+            "updated_at": float(status_payload.get("completed_at") or updated),
+            "completed_at": float(status_payload.get("completed_at") or updated),
+            "exit_code": exit_code,
+            "error": status_payload.get("error"),
+            "log_truncated": bool(status_payload.get("log_truncated", False)),
+            "output_bytes": int(status_payload.get("output_bytes") or 0),
+        }
+    )
     return job
 
 
@@ -85,6 +202,11 @@ def _public_job(job: dict[str, Any]) -> dict[str, Any]:
         "created_at": job.get("created_at"),
         "updated_at": job.get("updated_at"),
         "last_started_at": job.get("last_started_at"),
+        "completed_at": job.get("completed_at"),
+        "exit_code": job.get("exit_code"),
+        "error": job.get("error"),
+        "log_truncated": bool(job.get("log_truncated", False)),
+        "output_bytes": int(job.get("output_bytes") or 0),
         "attempts": job.get("attempts", 1),
     }
 
@@ -96,11 +218,35 @@ def _find_job(store: dict[str, Any], job_id: str) -> dict[str, Any]:
     raise KeyError(f"job not found: {job_id}")
 
 
-async def start_job(command: str, cwd: str = ".", name: str | None = None) -> dict[str, Any]:
+def _read_log_tail(path: str | None, lines: int) -> str:
+    if not path:
+        return ""
+    target = Path(path)
+    if not target.is_file():
+        return ""
+    max_bytes = max(1, get_settings().max_job_log_bytes)
+    size = target.stat().st_size
+    with target.open("rb") as handle:
+        if size > max_bytes:
+            handle.seek(size - max_bytes)
+        data = handle.read(max_bytes)
+    text = data.decode("utf-8", errors="replace")
+    if lines > 0:
+        split = text.splitlines()
+        text = "\n".join(split[-max(1, lines) :])
+        if data.endswith((b"\n", b"\r")) and text:
+            text += "\n"
+    return text
+
+
+async def start_job(
+    command: str, cwd: str = ".", name: str | None = None
+) -> dict[str, Any]:
     job_id = _new_job_id()
     display_name = name or job_id
+    paths, runner_command = _prepare_attempt(job_id, 1, command, cwd)
     shell_name = _shell_safe_name(f"{display_name}-{job_id}")
-    shell = await start_shell(cwd, shell_name, command)
+    shell = await start_shell(cwd, shell_name, runner_command)
     now = _utc()
     job = {
         "job_id": job_id,
@@ -110,15 +256,20 @@ async def start_job(command: str, cwd: str = ".", name: str | None = None) -> di
         "cwd": cwd,
         "session_id": shell["session_id"],
         "backend": shell.get("backend"),
+        "command_path": str(paths["command"]),
+        "log_path": str(paths["log"]),
+        "status_path": str(paths["status"]),
         "created_at": now,
         "updated_at": now,
         "last_started_at": now,
+        "completed_at": None,
+        "exit_code": None,
         "attempts": 1,
     }
     store = _load_store()
     store["jobs"].append(job)
     _save_store(store)
-    audit("job_start", job_id=job_id, session=shell["session_id"], cwd=cwd, command=command)
+    audit("job_start", job_id=job_id, session=shell["session_id"], cwd=cwd)
     return _public_job(job)
 
 
@@ -128,7 +279,11 @@ async def list_jobs(include_finished: bool = True) -> dict[str, Any]:
     now = _utc()
     jobs = [_refresh_job_status(job, active, now) for job in store.get("jobs", [])]
     _save_store(store)
-    rows = [_public_job(job) for job in jobs if include_finished or job.get("status") not in TERMINAL_STATUSES]
+    rows = [
+        _public_job(job)
+        for job in jobs
+        if include_finished or job.get("status") not in TERMINAL_STATUSES
+    ]
     rows.sort(key=lambda item: float(item.get("created_at") or 0), reverse=True)
     counts: dict[str, int] = {}
     for job in jobs:
@@ -142,18 +297,24 @@ async def tail_job(job_id: str, lines: int = 200) -> dict[str, Any]:
     active = _active_session_ids(await list_shells())
     job = _refresh_job_status(_find_job(store, job_id), active)
     _save_store(store)
-    result = {"job": _public_job(job), "output": ""}
-    if job.get("status") != "running":
-        result["message"] = "job is not running; shell output is no longer available"
-        return result
-    try:
-        tail = await read_shell(str(job["session_id"]), lines)
-    except Exception as exc:
-        job["status"] = "lost"
-        job["updated_at"] = _utc()
-        _save_store(store)
-        return {"job": _public_job(job), "output": "", "message": str(exc)}
-    result["output"] = tail.get("output", "")
+    output = _read_log_tail(job.get("log_path"), lines)
+    if not output and job.get("status") == "running":
+        try:
+            tail = await read_shell(str(job["session_id"]), lines)
+            output = str(tail.get("output", ""))
+        except Exception as exc:
+            job["status"] = "lost"
+            job["updated_at"] = _utc()
+            job["completed_at"] = job["updated_at"]
+            job["error"] = str(exc)
+            _save_store(store)
+    result = {"job": _public_job(job), "output": output}
+    if job.get("status") in TERMINAL_STATUSES:
+        result["message"] = (
+            f"job completed with exit code {job.get('exit_code')}"
+            if job.get("exit_code") is not None
+            else f"job is {job.get('status')}"
+        )
     return result
 
 
@@ -169,6 +330,8 @@ async def stop_job(job_id: str) -> dict[str, Any]:
         stderr = str(result.get("stderr") or "")
         job["status"] = "stopped" if killed else "lost"
         job["updated_at"] = _utc()
+        job["completed_at"] = job["updated_at"]
+        job["exit_code"] = None
     _save_store(store)
     audit("job_stop", job_id=job_id, session=job.get("session_id"), killed=killed)
     return {"job": _public_job(job), "killed": killed, "stderr": stderr}
@@ -181,19 +344,138 @@ async def retry_job(job_id: str) -> dict[str, Any]:
     if job.get("status") == "running":
         raise RuntimeError(f"job is still running: {job_id}")
     attempts = int(job.get("attempts") or 1) + 1
-    shell_name = _shell_safe_name(f"{job.get('name') or job_id}-{job_id}-{attempts}")
-    shell = await start_shell(str(job.get("cwd") or "."), shell_name, str(job["command"]))
+    paths, runner_command = _prepare_attempt(
+        job_id, attempts, str(job["command"]), str(job.get("cwd") or ".")
+    )
+    shell_name = _shell_safe_name(
+        f"{job.get('name') or job_id}-{job_id}-{attempts}"
+    )
+    shell = await start_shell(
+        str(job.get("cwd") or "."), shell_name, runner_command
+    )
     now = _utc()
     job.update(
         {
             "status": "running",
             "session_id": shell["session_id"],
             "backend": shell.get("backend"),
+            "command_path": str(paths["command"]),
+            "log_path": str(paths["log"]),
+            "status_path": str(paths["status"]),
             "updated_at": now,
             "last_started_at": now,
+            "completed_at": None,
+            "exit_code": None,
+            "error": None,
+            "log_truncated": False,
+            "output_bytes": 0,
             "attempts": attempts,
         }
     )
     _save_store(store)
-    audit("job_retry", job_id=job_id, session=shell["session_id"], attempts=attempts)
+    audit(
+        "job_retry",
+        job_id=job_id,
+        session=shell["session_id"],
+        attempts=attempts,
+    )
     return _public_job(job)
+
+
+def _runner_shell_args(shell: str, command: str) -> list[str]:
+    name = Path(shell).name.lower()
+    powershell = "power" + "shell"
+    if name in {powershell + ".exe", powershell, "pwsh.exe", "pwsh"}:
+        return [shell, "-NoProfile", "-NonInteractive", "-Command", command]
+    if name in {"cmd.exe", "cmd"}:
+        return [shell, "/S", "/C", command]
+    return [shell, "-lc", command]
+
+
+def _compact_log(handle: BinaryIO, max_bytes: int) -> bool:
+    handle.flush()
+    size = handle.tell()
+    if size <= max_bytes:
+        return False
+    handle.seek(max(0, size - max_bytes))
+    tail = handle.read(max_bytes)
+    handle.seek(0)
+    handle.write(tail)
+    handle.truncate()
+    handle.seek(0, os.SEEK_END)
+    handle.flush()
+    return True
+
+
+def _write_runner_status(path: Path, payload: dict[str, Any]) -> None:
+    temporary = path.with_name(path.name + f".{uuid.uuid4().hex}.tmp")
+    try:
+        _private_write_text(temporary, json.dumps(payload, indent=2, sort_keys=True))
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def run_job_runner_cli(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--command-file", required=True)
+    parser.add_argument("--log-file", required=True)
+    parser.add_argument("--status-file", required=True)
+    parser.add_argument("--cwd", required=True)
+    parser.add_argument("--shell", required=True)
+    parser.add_argument("--max-log-bytes", type=int, required=True)
+    args = parser.parse_args(argv)
+
+    command_path = Path(args.command_file)
+    log_path = Path(args.log_file)
+    status_path = Path(args.status_file)
+    max_log_bytes = max(1, int(args.max_log_bytes))
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    output_bytes = 0
+    truncated = False
+    exit_code: int | None = None
+    error: str | None = None
+    try:
+        command = command_path.read_text(encoding="utf-8")
+        process = subprocess.Popen(  # noqa: S603
+            _runner_shell_args(args.shell, command),
+            cwd=args.cwd,
+            env=os.environ.copy(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        if process.stdout is None:
+            raise RuntimeError("job process did not expose stdout")
+        with log_path.open("w+b") as log:
+            with contextlib.suppress(OSError):
+                log_path.chmod(0o600)
+            while True:
+                chunk = process.stdout.read(65536)
+                if not chunk:
+                    break
+                output_bytes += len(chunk)
+                sys.stdout.buffer.write(chunk)
+                sys.stdout.buffer.flush()
+                log.write(chunk)
+                log.flush()
+                if log.tell() > max_log_bytes * 2:
+                    truncated = _compact_log(log, max_log_bytes) or truncated
+            exit_code = process.wait()
+            truncated = _compact_log(log, max_log_bytes) or truncated
+    except BaseException as exc:  # noqa: BLE001
+        error = f"{type(exc).__name__}: {exc}"
+        print(error, file=sys.stderr, flush=True)
+        if exit_code is None:
+            exit_code = 127
+    finally:
+        _write_runner_status(
+            status_path,
+            {
+                "completed_at": _utc(),
+                "exit_code": exit_code,
+                "error": error,
+                "log_truncated": truncated,
+                "output_bytes": output_bytes,
+            },
+        )
+    raise SystemExit(exit_code if exit_code is not None else 127)

--- a/src/local_shell_mcp/main.py
+++ b/src/local_shell_mcp/main.py
@@ -99,6 +99,11 @@ def run_http() -> None:
 
 def main(argv: list[str] | None = None) -> None:
     argv = sys.argv[1:] if argv is None else list(argv)
+    if argv and argv[0] == "job-runner":
+        from .jobs import run_job_runner_cli
+
+        run_job_runner_cli(argv[1:])
+        return
     if argv and argv[0] == "worker":
         from .remote import run_worker_cli
 

--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -16,6 +16,7 @@ import sys
 import tarfile
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 import uuid
 from dataclasses import dataclass, field
@@ -940,7 +941,7 @@ def _worker_post_json_with_urllib(url: str, body: bytes, headers: dict[str, str]
         method="POST",
     )
     try:
-        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # nosec B310  # URL validated by _worker_post_json.
             response_body = response.read().decode("utf-8", errors="replace")
             status_code = response.status
     except urllib.error.HTTPError as exc:
@@ -950,6 +951,9 @@ def _worker_post_json_with_urllib(url: str, body: bytes, headers: dict[str, str]
 
 
 def _worker_post_json(url: str, payload: dict[str, Any], headers: dict[str, str] | None = None, timeout: float | None = None) -> dict[str, Any]:
+    parsed = urllib.parse.urlsplit(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("worker server URL must use absolute HTTP(S)")
     body = json.dumps(payload).encode("utf-8")
     request_headers = headers or {}
     if shutil.which("curl"):

--- a/src/local_shell_mcp/search_ops.py
+++ b/src/local_shell_mcp/search_ops.py
@@ -142,10 +142,11 @@ def tree_sync(cwd: str = ".", depth: int = 3, max_entries: int = 500) -> dict:
                 return
             rel = path.relative_to(base)
             indent = "  " * (len(rel.parts) - 1)
-            suffix = "/" if path.is_dir() else ""
+            is_directory = path.is_dir() and not path.is_symlink()
+            suffix = "/" if is_directory else ""
             rows.append(f"{indent}{path.name}{suffix}")
             count += 1
-            if path.is_dir():
+            if is_directory:
                 walk(path, current_depth + 1)
             if count >= limit:
                 truncated = True

--- a/src/local_shell_mcp/settings.py
+++ b/src/local_shell_mcp/settings.py
@@ -151,6 +151,7 @@ if _PYDANTIC_AVAILABLE:
         max_read_many_total_bytes: int = 5_000_000
         max_todos: int = 1_000
         max_todo_bytes: int = 1_000_000
+        max_job_log_bytes: int = 10_000_000
         max_audit_tail_bytes: int = 1_000_000
         max_audit_log_bytes: int = 20_000_000
         max_tmp_files: int = 500
@@ -340,6 +341,7 @@ else:
         max_read_many_total_bytes: int = 5_000_000
         max_todos: int = 1_000
         max_todo_bytes: int = 1_000_000
+        max_job_log_bytes: int = 10_000_000
         max_audit_tail_bytes: int = 1_000_000
         max_audit_log_bytes: int = 20_000_000
         max_tmp_files: int = 500

--- a/src/local_shell_mcp/settings.py
+++ b/src/local_shell_mcp/settings.py
@@ -155,6 +155,8 @@ if _PYDANTIC_AVAILABLE:
         max_audit_log_bytes: int = 20_000_000
         max_tmp_files: int = 500
         max_tmp_bytes: int = 50_000_000
+        max_transfer_archive_entries: int = 100_000
+        max_transfer_unpacked_bytes: int = 10_000_000_000
         max_concurrent_commands: int = 4
         max_tmux_sessions: int = 16
 
@@ -342,6 +344,8 @@ else:
         max_audit_log_bytes: int = 20_000_000
         max_tmp_files: int = 500
         max_tmp_bytes: int = 50_000_000
+        max_transfer_archive_entries: int = 100_000
+        max_transfer_unpacked_bytes: int = 10_000_000_000
         max_concurrent_commands: int = 4
         max_tmux_sessions: int = 16
 

--- a/src/local_shell_mcp/shell_ops.py
+++ b/src/local_shell_mcp/shell_ops.py
@@ -81,13 +81,42 @@ def public_run_shell_timeout(timeout_s: int | None) -> int:
     return max(1, min(timeout_s or PUBLIC_RUN_SHELL_DEFAULT_TIMEOUT_S, PUBLIC_RUN_SHELL_TIMEOUT_CAP_S))
 
 
-def clamp_output(stdout: str, stderr: str, max_output_bytes: int | None = None) -> tuple[str, str, bool]:
-    limit = _effective_output_limit(max_output_bytes)
-    encoded_len = len(stdout.encode()) + len(stderr.encode())
-    if encoded_len <= limit:
+def _shared_tail_bytes(
+    stdout: bytes, stderr: bytes, limit: int
+) -> tuple[bytes, bytes, bool]:
+    total = len(stdout) + len(stderr)
+    if total <= limit:
         return stdout, stderr, False
-    half = max(1, limit // 2)
-    return stdout[-half:], stderr[-half:], True
+
+    stdout_keep = min(len(stdout), limit // 2)
+    stderr_keep = min(len(stderr), limit // 2)
+    remaining = limit - stdout_keep - stderr_keep
+    if remaining > 0:
+        stdout_extra = min(remaining, len(stdout) - stdout_keep)
+        stdout_keep += stdout_extra
+        remaining -= stdout_extra
+    if remaining > 0:
+        stderr_keep += min(remaining, len(stderr) - stderr_keep)
+
+    return (
+        stdout[-stdout_keep:] if stdout_keep else b"",
+        stderr[-stderr_keep:] if stderr_keep else b"",
+        True,
+    )
+
+
+def clamp_output(
+    stdout: str, stderr: str, max_output_bytes: int | None = None
+) -> tuple[str, str, bool]:
+    limit = _effective_output_limit(max_output_bytes)
+    stdout_bytes, stderr_bytes, truncated = _shared_tail_bytes(
+        stdout.encode(), stderr.encode(), limit
+    )
+    return (
+        stdout_bytes.decode(errors="replace"),
+        stderr_bytes.decode(errors="replace"),
+        truncated,
+    )
 
 
 def _effective_output_limit(max_output_bytes: int | None = None) -> int:
@@ -227,9 +256,8 @@ async def run_shell(command: str, cwd: str = ".", timeout_s: int | None = None, 
     timed_out = False
     termination_error = ""
     output_limit = _effective_output_limit(max_output_bytes)
-    per_stream_limit = max(1, output_limit // 2)
-    stdout_tail = TailBuffer(per_stream_limit, bytearray())
-    stderr_tail = TailBuffer(per_stream_limit, bytearray())
+    stdout_tail = TailBuffer(output_limit, bytearray())
+    stderr_tail = TailBuffer(output_limit, bytearray())
     reader_tasks: list[asyncio.Task[None]] = []
 
     async def spawn_and_wait() -> None:
@@ -277,11 +305,14 @@ async def run_shell(command: str, cwd: str = ".", timeout_s: int | None = None, 
     if termination_error:
         stderr_tail.append(termination_error.encode())
 
-    stdout_b = bytes(stdout_tail.data)
-    stderr_b = bytes(stderr_tail.data)
+    stdout_b, stderr_b, total_truncated = _shared_tail_bytes(
+        bytes(stdout_tail.data), bytes(stderr_tail.data), output_limit
+    )
     stdout = stdout_b.decode(errors="replace")
     stderr = stderr_b.decode(errors="replace")
-    truncated = stdout_tail.truncated or stderr_tail.truncated
+    truncated = (
+        stdout_tail.truncated or stderr_tail.truncated or total_truncated
+    )
     duration_ms = int((time.time() - start) * 1000)
     result = CommandResult(
         ok=(proc is not None and proc.returncode == 0 and not timed_out),

--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -384,17 +384,56 @@ def _remove_remote_tools_when_disabled(mcp: FastMCP) -> None:
             tools.pop(name, None)
 
 
-def _install_full_container_auto_approval_hints(mcp: FastMCP) -> None:
-    if not get_settings().allow_full_container:
-        return
-    for tool in mcp._tool_manager._tools.values():  # noqa: SLF001
-        if tool.annotations and tool.annotations.readOnlyHint:
-            continue
+OPEN_WORLD_TOOL_NAMES = {
+    "browser_eval_tool",
+    "browser_get_text_tool",
+    "browser_pdf_tool",
+    "browser_screenshot_tool",
+    "create_file_link",
+    "git_clone_tool",
+    "git_fetch_tool",
+    "git_pull_tool",
+    "git_push_tool",
+    "playwright_install_tool",
+    "playwright_run_script_tool",
+    "revoke_file_link",
+    "run_python_tool",
+    "run_shell_tool",
+    "shell_send",
+    "shell_start",
+    "job_start",
+    "job_retry",
+}
+
+READ_ONLY_OPEN_WORLD_TOOL_NAMES = {
+    "browser_get_text_tool",
+    "remote_browser_get_text_tool",
+}
+
+NON_DESTRUCTIVE_MUTATION_TOOL_NAMES = {
+    "create_file_link",
+    "git_clone_tool",
+    "git_commit_tool",
+    "remote_invite",
+}
+
+
+def _install_tool_annotations(mcp: FastMCP) -> None:
+    """Attach conservative, semantically accurate MCP safety annotations."""
+
+    for name, tool in mcp._tool_manager._tools.items():  # noqa: SLF001
+        existing_read_only = bool(
+            tool.annotations and tool.annotations.readOnlyHint
+        )
+        read_only = existing_read_only or name in READ_ONLY_OPEN_WORLD_TOOL_NAMES
+        open_world = name.startswith("remote_") or name in OPEN_WORLD_TOOL_NAMES
         tool.annotations = ToolAnnotations(
-            readOnlyHint=False,
-            destructiveHint=False,
-            idempotentHint=False,
-            openWorldHint=False,
+            readOnlyHint=read_only,
+            destructiveHint=not (
+                read_only or name in NON_DESTRUCTIVE_MUTATION_TOOL_NAMES
+            ),
+            idempotentHint=read_only,
+            openWorldHint=open_world,
         )
 
 
@@ -1688,6 +1727,6 @@ def build_mcp() -> FastMCP:
         return await _remote_call(machine, "playwright_run_script_tool", {"script": script, "cwd": cwd, "timeout_s": timeout_s}, timeout_s)
 
     _remove_remote_tools_when_disabled(mcp)
-    _install_full_container_auto_approval_hints(mcp)
+    _install_tool_annotations(mcp)
     _install_mcp_tool_watchdogs(mcp)
     return mcp

--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -171,6 +171,19 @@ OAUTH_SECURITY_SCHEMES = [_oauth_security_scheme(ALL_OAUTH_SCOPES)]
 NOAUTH_SECURITY_SCHEMES = [{"type": "noauth"}]
 PUBLIC_TOOL_TIMEOUT_S = PUBLIC_RUN_SHELL_TIMEOUT_CAP_S
 SENSITIVE_TOOL_ARG_FRAGMENTS = ("token", "secret", "password", "passwd", "pin", "jwt", "key")
+OPAQUE_AUDIT_TOOL_ARGS = {
+    "code",
+    "command",
+    "content",
+    "data_b64",
+    "explanation",
+    "input_text",
+    "javascript",
+    "patch",
+    "purpose",
+    "repo_url",
+    "script",
+}
 MAX_AUDIT_TOOL_ARG_STRING = 500
 
 
@@ -237,7 +250,11 @@ def _redact_audit_value(value: Any) -> Any:
         out: dict[str, Any] = {}
         for name, item in list(value.items())[:50]:
             name_s = str(name)
-            if any(fragment in name_s.lower() for fragment in SENSITIVE_TOOL_ARG_FRAGMENTS):
+            name_lower = name_s.lower()
+            if (
+                name_lower in OPAQUE_AUDIT_TOOL_ARGS
+                or any(fragment in name_lower for fragment in SENSITIVE_TOOL_ARG_FRAGMENTS)
+            ):
                 out[name_s] = "<redacted>"
             else:
                 out[name_s] = _redact_audit_value(item)
@@ -309,11 +326,16 @@ def _install_mcp_tool_watchdogs(mcp: FastMCP) -> None:
             require_current_scopes(__required_scopes)
             arguments = _audit_tool_arguments(args, kwargs)
             audit_context = {}
-            if isinstance(arguments, dict):
-                if arguments.get("machine"):
-                    audit_context["machine"] = arguments["machine"]
-                if arguments.get("session_id"):
-                    audit_context["session"] = arguments["session_id"]
+            keyword_args = (
+                arguments.get("keyword_args", {})
+                if isinstance(arguments, dict)
+                else {}
+            )
+            if isinstance(keyword_args, dict):
+                if keyword_args.get("machine"):
+                    audit_context["machine"] = keyword_args["machine"]
+                if keyword_args.get("session_id"):
+                    audit_context["session"] = keyword_args["session_id"]
             audit(
                 "mcp_tool_call_start",
                 tool=__tool_name,

--- a/src/local_shell_mcp/transfer_ops.py
+++ b/src/local_shell_mcp/transfer_ops.py
@@ -2,15 +2,19 @@ from __future__ import annotations
 
 import base64
 import binascii
+import contextlib
 import hashlib
+import json
 import os
 import shutil
 import tarfile
+import tempfile
 import uuid
 from pathlib import Path
 from typing import Any
 
-from .fs_ops import relative_display, resolve_path, temp_dir
+from .fs_ops import _path_lock, _path_locks, relative_display, resolve_path, temp_dir
+from .settings import get_settings
 
 DEFAULT_TRANSFER_CHUNK_BYTES = 1024 * 1024
 MAX_TRANSFER_CHUNK_BYTES = 4 * 1024 * 1024
@@ -89,30 +93,75 @@ def transfer_read_chunk(path: str, offset: int = 0, chunk_size: int | None = Non
 
 def _transfer_temp_path(dst: Path, transfer_id: str) -> Path:
     safe_id = "".join(ch for ch in transfer_id if ch.isalnum() or ch in "-_")
-    if not safe_id:
-        raise ValueError("transfer_id is empty")
+    if not safe_id or safe_id != transfer_id:
+        raise ValueError("transfer_id contains unsupported characters")
     return dst.parent / f".{dst.name}.{_TRANSFER_TMP_MARKER}-{safe_id}.tmp"
 
 
-def transfer_begin_write(path: str, overwrite: bool = True, expected_bytes: int | None = None) -> dict[str, Any]:
-    dst = resolve_path(path)
-    if dst.exists() and dst.is_dir():
-        raise IsADirectoryError(str(dst))
-    if dst.exists() and not overwrite:
-        raise FileExistsError(str(dst))
-    if expected_bytes is not None and int(expected_bytes) < 0:
+def _transfer_metadata_path(tmp: Path) -> Path:
+    return tmp.with_name(tmp.name + ".json")
+
+
+def _write_transfer_metadata(tmp: Path, metadata: dict[str, Any]) -> None:
+    path = _transfer_metadata_path(tmp)
+    temporary = path.with_name(path.name + f".{uuid.uuid4().hex}.tmp")
+    try:
+        temporary.write_text(
+            json.dumps(metadata, indent=2, sort_keys=True), encoding="utf-8"
+        )
+        with contextlib.suppress(OSError):
+            temporary.chmod(0o600)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _read_transfer_metadata(tmp: Path) -> dict[str, Any]:
+    path = _transfer_metadata_path(tmp)
+    try:
+        metadata = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"transfer metadata is missing or invalid: {path}") from exc
+    if not isinstance(metadata, dict):
+        raise ValueError(f"transfer metadata is invalid: {path}")
+    return metadata
+
+
+def transfer_begin_write(
+    path: str, overwrite: bool = True, expected_bytes: int | None = None
+) -> dict[str, Any]:
+    dst = resolve_path(path, follow_final_symlink=False)
+    expected = None if expected_bytes is None else int(expected_bytes)
+    if expected is not None and expected < 0:
         raise ValueError("expected_bytes must be >= 0")
     dst.parent.mkdir(parents=True, exist_ok=True)
-    transfer_id = uuid.uuid4().hex
-    tmp = _transfer_temp_path(dst, transfer_id)
-    with tmp.open("wb"):
-        pass
+    with _path_lock(dst):
+        if os.path.lexists(dst) and dst.is_dir() and not dst.is_symlink():
+            raise IsADirectoryError(str(dst))
+        if os.path.lexists(dst) and not overwrite:
+            raise FileExistsError(str(dst))
+        transfer_id = uuid.uuid4().hex
+        tmp = _transfer_temp_path(dst, transfer_id)
+        with tmp.open("xb"):
+            pass
+        try:
+            _write_transfer_metadata(
+                tmp,
+                {
+                    "destination": str(dst),
+                    "overwrite": bool(overwrite),
+                    "expected_bytes": expected,
+                },
+            )
+        except Exception:
+            tmp.unlink(missing_ok=True)
+            raise
     return {
         "path": relative_display(dst),
         "temp_path": relative_display(tmp),
         "transfer_id": transfer_id,
-        "created": not dst.exists(),
-        "expected_bytes": expected_bytes,
+        "created": not os.path.lexists(dst),
+        "expected_bytes": expected,
     }
 
 
@@ -123,10 +172,8 @@ def transfer_write_chunk(
     data_b64: str,
     expected_sha256: str | None = None,
 ) -> dict[str, Any]:
-    dst = resolve_path(path)
+    dst = resolve_path(path, follow_final_symlink=False)
     tmp = _transfer_temp_path(dst, transfer_id)
-    if not tmp.exists():
-        raise FileNotFoundError(str(tmp))
     start = int(offset)
     if start < 0:
         raise ValueError("offset must be >= 0")
@@ -137,9 +184,17 @@ def transfer_write_chunk(
     digest = hashlib.sha256(data).hexdigest()
     if expected_sha256 and digest != expected_sha256:
         raise ValueError("chunk sha256 mismatch")
-    with tmp.open("r+b") as fh:
-        fh.seek(start)
-        fh.write(data)
+    with _path_lock(tmp):
+        if not tmp.exists():
+            raise FileNotFoundError(str(tmp))
+        metadata = _read_transfer_metadata(tmp)
+        expected = metadata.get("expected_bytes")
+        if expected is not None and start + len(data) > int(expected):
+            raise ValueError("chunk exceeds expected transfer size")
+        with tmp.open("r+b") as fh:
+            fh.seek(start)
+            fh.write(data)
+            fh.flush()
     return {
         "path": relative_display(dst),
         "temp_path": relative_display(tmp),
@@ -155,17 +210,30 @@ def transfer_finish_write(
     expected_bytes: int | None = None,
     expected_sha256: str | None = None,
 ) -> dict[str, Any]:
-    dst = resolve_path(path)
+    dst = resolve_path(path, follow_final_symlink=False)
     tmp = _transfer_temp_path(dst, transfer_id)
-    if not tmp.exists():
-        raise FileNotFoundError(str(tmp))
-    size = tmp.stat().st_size
-    if expected_bytes is not None and size != int(expected_bytes):
-        raise ValueError(f"size mismatch: expected {expected_bytes}, got {size}")
-    digest = _sha256_file(tmp) if expected_sha256 else None
-    if expected_sha256 and digest != expected_sha256:
-        raise ValueError("file sha256 mismatch")
-    os.replace(tmp, dst)
+    metadata_path = _transfer_metadata_path(tmp)
+    with _path_locks([dst, tmp]):
+        if not tmp.exists():
+            raise FileNotFoundError(str(tmp))
+        metadata = _read_transfer_metadata(tmp)
+        expected = (
+            int(expected_bytes)
+            if expected_bytes is not None
+            else metadata.get("expected_bytes")
+        )
+        if expected is not None:
+            expected = int(expected)
+        size = tmp.stat().st_size
+        if expected is not None and size != expected:
+            raise ValueError(f"size mismatch: expected {expected}, got {size}")
+        digest = _sha256_file(tmp) if expected_sha256 else None
+        if expected_sha256 and digest != expected_sha256:
+            raise ValueError("file sha256 mismatch")
+        if not bool(metadata.get("overwrite", True)) and os.path.lexists(dst):
+            raise FileExistsError(str(dst))
+        os.replace(tmp, dst)
+        metadata_path.unlink(missing_ok=True)
     return {
         "path": relative_display(dst),
         "bytes": size,
@@ -175,13 +243,20 @@ def transfer_finish_write(
 
 
 def transfer_abort_write(path: str, transfer_id: str) -> dict[str, Any]:
-    dst = resolve_path(path)
+    dst = resolve_path(path, follow_final_symlink=False)
     tmp = _transfer_temp_path(dst, transfer_id)
+    metadata_path = _transfer_metadata_path(tmp)
     deleted = False
-    if tmp.exists():
-        tmp.unlink()
-        deleted = True
-    return {"path": relative_display(dst), "temp_path": relative_display(tmp), "deleted": deleted}
+    with _path_lock(tmp):
+        if tmp.exists():
+            tmp.unlink()
+            deleted = True
+        metadata_path.unlink(missing_ok=True)
+    return {
+        "path": relative_display(dst),
+        "temp_path": relative_display(tmp),
+        "deleted": deleted,
+    }
 
 
 def transfer_alloc_temp_path(suffix: str = ".bin") -> dict[str, Any]:
@@ -222,21 +297,50 @@ def transfer_pack_dir(path: str, compression: str = "gz") -> dict[str, Any]:
 
 
 def _safe_members(tar: tarfile.TarFile, dst: Path) -> list[tarfile.TarInfo]:
+    settings = get_settings()
     base = dst.resolve(strict=False)
-    members: list[tarfile.TarInfo] = []
-    for member in tar.getmembers():
+    members = tar.getmembers()
+    max_entries = max(1, settings.max_transfer_archive_entries)
+    if len(members) > max_entries:
+        raise ValueError(
+            f"archive contains {len(members)} entries; max is {max_entries}"
+        )
+    total_bytes = 0
+    seen_paths: set[str] = set()
+    safe: list[tarfile.TarInfo] = []
+    for member in members:
         member_path = Path(member.name)
         if member_path.is_absolute() or ".." in member_path.parts:
             raise ValueError(f"unsafe archive member path: {member.name}")
         if member.issym() or member.islnk() or member.isdev():
             raise ValueError(f"unsupported archive member type: {member.name}")
+        if getattr(member, "sparse", None):
+            raise ValueError(f"sparse archive members are not supported: {member.name}")
+        normalized_name = str(member_path)
+        if normalized_name in seen_paths:
+            raise ValueError(f"duplicate archive member path: {member.name}")
+        seen_paths.add(normalized_name)
+        if member.isfile():
+            total_bytes += max(0, int(member.size))
+            max_bytes = max(1, settings.max_transfer_unpacked_bytes)
+            if total_bytes > max_bytes:
+                raise ValueError(
+                    f"archive expands to more than {max_bytes} bytes"
+                )
         target = (dst / member.name).resolve(strict=False)
         try:
             target.relative_to(base)
         except ValueError as exc:
             raise ValueError(f"archive member escapes destination: {member.name}") from exc
-        members.append(member)
-    return members
+        safe.append(member)
+    return safe
+
+
+def _remove_existing_path(path: Path) -> None:
+    if path.is_dir() and not path.is_symlink():
+        shutil.rmtree(path)
+    else:
+        path.unlink(missing_ok=True)
 
 
 def transfer_unpack_archive(
@@ -248,43 +352,77 @@ def transfer_unpack_archive(
     archive = resolve_path(archive_path, must_exist=True)
     if not archive.is_file():
         raise FileNotFoundError(str(archive))
-    dst = resolve_path(dst_path)
-    if dst.exists():
-        if dst.is_file():
-            if not overwrite:
-                raise FileExistsError(str(dst))
-            dst.unlink()
-        elif dst.is_dir():
-            if not overwrite and any(dst.iterdir()):
-                raise FileExistsError(f"destination directory is not empty: {dst}")
-            if overwrite:
-                shutil.rmtree(dst)
-        else:
-            raise FileExistsError(str(dst))
-    dst.mkdir(parents=True, exist_ok=True)
-    with tarfile.open(archive, "r:*") as tar:
-        members = _safe_members(tar, dst)
-        for member in members:
-            target = dst / member.name
-            if member.isdir():
-                target.mkdir(parents=True, exist_ok=True)
-                continue
-            if member.isfile():
-                target.parent.mkdir(parents=True, exist_ok=True)
-                source = tar.extractfile(member)
-                if source is None:
-                    raise ValueError(f"archive member has no file data: {member.name}")
-                with source, target.open("wb") as out:
-                    shutil.copyfileobj(source, out)
-                os.chmod(target, member.mode & 0o777)
-                continue
-            raise ValueError(f"unsupported archive member type: {member.name}")
-    if cleanup_archive:
-        archive.unlink(missing_ok=True)
-    return {
-        "path": relative_display(dst),
-        "archive_path": relative_display(archive),
-        "entries": len(members),
-        "completed": True,
-        "archive_deleted": cleanup_archive,
-    }
+    dst = resolve_path(dst_path, follow_final_symlink=False)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(
+        tempfile.mkdtemp(prefix=f".{dst.name}.unpack-", dir=str(dst.parent))
+    )
+    backup: Path | None = None
+    members: list[tarfile.TarInfo] = []
+    committed = False
+    try:
+        with tarfile.open(archive, "r:*") as tar:
+            members = _safe_members(tar, staging)
+            for member in members:
+                target = staging / member.name
+                if member.isdir():
+                    target.mkdir(parents=True, exist_ok=True)
+                    continue
+                if member.isfile():
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    source = tar.extractfile(member)
+                    if source is None:
+                        raise ValueError(
+                            f"archive member has no file data: {member.name}"
+                        )
+                    with source, target.open("xb") as out:
+                        shutil.copyfileobj(source, out)
+                    os.chmod(target, member.mode & 0o777)
+                    continue
+                raise ValueError(f"unsupported archive member type: {member.name}")
+
+        with _path_lock(dst):
+            exists = os.path.lexists(dst)
+            if (
+                exists
+                and not overwrite
+                and not (
+                    dst.is_dir()
+                    and not dst.is_symlink()
+                    and not any(dst.iterdir())
+                )
+            ):
+                raise FileExistsError(f"destination already exists: {dst}")
+            if exists:
+                backup = dst.parent / f".{dst.name}.backup-{uuid.uuid4().hex}"
+                os.replace(dst, backup)
+            try:
+                os.replace(staging, dst)
+                committed = True
+            except Exception:
+                if backup is not None and os.path.lexists(backup):
+                    os.replace(backup, dst)
+                    backup = None
+                raise
+
+        if backup is not None and os.path.lexists(backup):
+            _remove_existing_path(backup)
+        if cleanup_archive:
+            archive.unlink(missing_ok=True)
+        return {
+            "path": relative_display(dst),
+            "archive_path": relative_display(archive),
+            "entries": len(members),
+            "completed": True,
+            "archive_deleted": cleanup_archive,
+        }
+    finally:
+        if not committed and staging.exists():
+            shutil.rmtree(staging, ignore_errors=True)
+        if backup is not None and os.path.lexists(backup):
+            if not os.path.lexists(dst):
+                with contextlib.suppress(OSError):
+                    os.replace(backup, dst)
+            if os.path.lexists(backup):
+                with contextlib.suppress(OSError):
+                    _remove_existing_path(backup)

--- a/src/local_shell_mcp/ui_security.py
+++ b/src/local_shell_mcp/ui_security.py
@@ -39,28 +39,35 @@ def get_or_create_ui_local_token() -> str:
         return inherited
 
     path = _token_path()
-    existing = _read_token(path)
-    if existing:
-        return existing
-
     path.parent.mkdir(parents=True, exist_ok=True)
-    token = secrets.token_urlsafe(48)
-    try:
-        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-    except FileExistsError:
+    for _attempt in range(2):
         existing = _read_token(path)
         if existing:
             return existing
-        with suppress(OSError):
-            path.unlink()
-        return get_or_create_ui_local_token()
 
-    with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
-        handle.write(token)
-        handle.write("\n")
-    with suppress(OSError):
-        path.chmod(0o600)
-    return token
+        token = secrets.token_urlsafe(48)
+        try:
+            descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        except FileExistsError:
+            try:
+                path.unlink()
+            except OSError as exc:
+                raise RuntimeError(
+                    f"Unable to replace invalid UI local token path: {path}"
+                ) from exc
+            continue
+
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(token)
+            handle.write("\n")
+        with suppress(OSError):
+            path.chmod(0o600)
+        return token
+
+    existing = _read_token(path)
+    if existing:
+        return existing
+    raise RuntimeError(f"Unable to initialize UI local token: {path}")
 
 
 def has_valid_ui_local_token(connection: HTTPConnection) -> bool:

--- a/tests/test_audit_tool_calls.py
+++ b/tests/test_audit_tool_calls.py
@@ -32,3 +32,33 @@ def test_audit_tool_arguments_redacts_sensitive_keys():
 
     assert payload["keyword_args"]["token"] == "<redacted>"
     assert payload["keyword_args"]["normal"] == "value"
+
+
+def test_audit_tool_arguments_redacts_opaque_payloads():
+    payload = _audit_tool_arguments(
+        (),
+        {
+            "command": "curl -H 'Authorization: Bearer secret-value' example.test",
+            "content": "API_TOKEN=secret-value",
+            "path": "safe.txt",
+        },
+    )
+
+    assert payload["keyword_args"]["command"] == "<redacted>"
+    assert payload["keyword_args"]["content"] == "<redacted>"
+    assert payload["keyword_args"]["path"] == "safe.txt"
+
+
+@pytest.mark.asyncio
+async def test_mcp_audit_extracts_session_context(tmp_path, monkeypatch):
+    audit_path = tmp_path / "audit.jsonl"
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_AUDIT_LOG_PATH", str(audit_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_REMOTE_ENABLED", "false")
+    get_settings.cache_clear()
+
+    await build_mcp().call_tool("shell_read", {"session_id": "missing-session"})
+
+    records = [json.loads(line) for line in audit_path.read_text(encoding="utf-8").splitlines()]
+    starts = [record for record in records if record["event"] == "mcp_tool_call_start"]
+    assert starts[-1]["session"] == "missing-session"

--- a/tests/test_audit_tool_calls.py
+++ b/tests/test_audit_tool_calls.py
@@ -62,3 +62,31 @@ async def test_mcp_audit_extracts_session_context(tmp_path, monkeypatch):
     records = [json.loads(line) for line in audit_path.read_text(encoding="utf-8").splitlines()]
     starts = [record for record in records if record["event"] == "mcp_tool_call_start"]
     assert starts[-1]["session"] == "missing-session"
+
+
+def test_audit_redacts_lower_level_commands_and_embedded_tokens(tmp_path, monkeypatch):
+    from local_shell_mcp.audit import audit
+
+    audit_path = tmp_path / "audit.jsonl"
+    secret = "configured-secret-value-which-is-long"
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_AUDIT_LOG_PATH", str(audit_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_OAUTH_JWT_SECRET", secret)
+    get_settings.cache_clear()
+
+    audit(
+        "run_shell_start",
+        command="curl -H 'Authorization: Bearer bearer-value' example.test",
+        error=f"failed with ghp_{'A' * 36} and {secret}",
+        token_id="safe-identifier",
+        nested={"access_token": "nested-secret", "path": "safe.txt"},
+    )
+    record = json.loads(audit_path.read_text(encoding="utf-8"))
+
+    assert record["command"] == "<redacted>"
+    assert "bearer-value" not in json.dumps(record)
+    assert "ghp_" not in json.dumps(record)
+    assert secret not in json.dumps(record)
+    assert record["token_id"] == "safe-identifier"
+    assert record["nested"]["access_token"] == "<redacted>"
+    assert record["nested"]["path"] == "safe.txt"

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -1,3 +1,4 @@
+import os
 import time
 
 import pytest
@@ -65,3 +66,73 @@ async def test_file_link_tools_are_registered(tmp_path, monkeypatch):
     names = {tool.name for tool in await build_mcp().list_tools()}
 
     assert {"create_file_link", "list_file_links", "revoke_file_link"} <= names
+
+
+def test_share_link_cannot_be_retargeted_outside_workspace(tmp_path, monkeypatch):
+    _reset(tmp_path, monkeypatch)
+    source = tmp_path / "hello.txt"
+    source.write_text("hello", encoding="utf-8")
+    outside = tmp_path.parent / f"{tmp_path.name}-outside.txt"
+    outside.write_text("outside-secret", encoding="utf-8")
+    link = create_share_link("hello.txt", ttl_s=60)
+
+    source.unlink()
+    try:
+        source.symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks are not available in this environment")
+
+    response = TestClient(Starlette(routes=download_routes())).get(link["url"])
+
+    assert response.status_code == 404
+    assert "outside-secret" not in response.text
+
+
+def test_download_audit_does_not_store_bearer_token(tmp_path, monkeypatch):
+    _reset(tmp_path, monkeypatch)
+    audit_path = tmp_path / "audit.jsonl"
+    monkeypatch.setenv("LOCAL_SHELL_MCP_AUDIT_LOG_PATH", str(audit_path))
+    get_settings.cache_clear()
+    (tmp_path / "hello.txt").write_text("hello", encoding="utf-8")
+
+    link = create_share_link("hello.txt", ttl_s=60)
+    TestClient(Starlette(routes=download_routes())).get(link["url"])
+    raw = audit_path.read_text(encoding="utf-8")
+
+    assert link["token"] not in raw
+    assert "token_id" in raw
+    if os.name != "nt":
+        assert audit_path.stat().st_mode & 0o777 == 0o600
+
+
+def test_share_link_is_bound_to_original_file_identity(tmp_path, monkeypatch):
+    _reset(tmp_path, monkeypatch)
+    source = tmp_path / "hello.txt"
+    source.write_text("original", encoding="utf-8")
+    link = create_share_link("hello.txt", ttl_s=60)
+
+    replacement = tmp_path / "replacement.txt"
+    replacement.write_text("replacement-secret", encoding="utf-8")
+    os.replace(replacement, source)
+
+    response = TestClient(Starlette(routes=download_routes())).get(link["url"])
+
+    assert response.status_code == 410
+    assert response.json()["error"] == "download_changed"
+    assert "replacement-secret" not in response.text
+
+
+def test_download_filename_strips_header_control_characters(tmp_path, monkeypatch):
+    _reset(tmp_path, monkeypatch)
+    (tmp_path / "hello.txt").write_text("hello", encoding="utf-8")
+    link = create_share_link(
+        "hello.txt", ttl_s=60, filename="safe\r\nInjected: value.txt"
+    )
+
+    response = TestClient(Starlette(routes=download_routes())).get(link["url"])
+    disposition = response.headers["content-disposition"]
+
+    assert response.status_code == 200
+    assert "\r" not in disposition
+    assert "\n" not in disposition
+    assert "Injected: value.txt" in disposition

--- a/tests/test_fs_ops.py
+++ b/tests/test_fs_ops.py
@@ -251,3 +251,20 @@ def test_read_text_handles_truncated_utf8_sequence(tmp_path, monkeypatch):
     assert result["truncated"] is True
     assert result["bytes_read"] == 4
     assert result["content"] == "你�"
+
+
+def test_path_lock_state_and_lock_files_are_bounded(tmp_path, monkeypatch):
+    from local_shell_mcp.fs_ops import _PATH_LOCKS, _path_lock
+
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(tmp_path / ".state"))
+    get_settings.cache_clear()
+
+    for index in range(600):
+        with _path_lock(tmp_path / f"file-{index}.txt"):
+            pass
+
+    assert _PATH_LOCKS == {}
+    lock_files = list((tmp_path / ".state" / "locks").glob("*.lock"))
+    assert len(lock_files) <= 256
+    assert all(path.name.startswith("shard-") for path in lock_files)

--- a/tests/test_human_ui.py
+++ b/tests/test_human_ui.py
@@ -575,3 +575,34 @@ def test_websocket_origin_maps_to_http_oauth_resource(tmp_path, monkeypatch):
     websocket = _websocket_for_test(client_host="203.0.113.9")
 
     assert public_base_url(websocket) == "https://control.example.com"
+
+
+def test_http_localhost_bypass_is_not_inherited_by_reverse_proxy(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch, auth_mode="oauth")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MODE", "http")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_AUTH_BYPASS_LOCALHOST", "true")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_OAUTH_JWT_SECRET", "x" * 32)
+    get_settings.cache_clear()
+    client = TestClient(build_http_app(), client=("127.0.0.1", 4242))
+
+    direct = client.get("/tools/version", headers={"Host": "127.0.0.1:8765"})
+    proxied = client.get(
+        "/tools/version",
+        headers={
+            "Host": "public.example.test",
+            "X-Forwarded-For": "203.0.113.9",
+            "X-Forwarded-Proto": "https",
+        },
+    )
+
+    assert direct.status_code == 200
+    assert proxied.status_code == 401
+
+
+def test_invalid_ui_token_path_fails_without_recursion(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    token_path = tmp_path / ".state" / "ui" / "local-token"
+    token_path.mkdir(parents=True)
+
+    with pytest.raises(RuntimeError, match="invalid UI local token path"):
+        get_or_create_ui_local_token()

--- a/tests/test_human_ui.py
+++ b/tests/test_human_ui.py
@@ -18,6 +18,7 @@ from local_shell_mcp.human_ui import (
     UI_FULL_SCOPES,
     _authorize_websocket,
     _bounded_int,
+    _idle_timeout_remaining,
     _split_tui_command,
     _validate_tui_api_base,
     api_files,
@@ -606,3 +607,9 @@ def test_invalid_ui_token_path_fails_without_recursion(tmp_path, monkeypatch):
 
     with pytest.raises(RuntimeError, match="invalid UI local token path"):
         get_or_create_ui_local_token()
+
+
+def test_terminal_idle_timeout_uses_latest_input_or_output_activity():
+    assert _idle_timeout_remaining(100.0, 60.0, 130.0) == 30.0
+    assert _idle_timeout_remaining(100.0, 60.0, 160.0) == 0.0
+    assert _idle_timeout_remaining(150.0, 60.0, 160.0) == 50.0

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,3 +1,7 @@
+import asyncio
+import os
+import shutil
+
 import pytest
 
 import local_shell_mcp.jobs as jobs_module
@@ -45,7 +49,8 @@ async def test_jobs_track_tail_stop_and_retry(tmp_path, monkeypatch):
 
     tail = await tail_job(job["job_id"], lines=20)
     assert tail["job"]["status"] == "running"
-    assert "python -m http.server" in tail["output"]
+    assert "job-runner" in tail["output"]
+    assert tail["job"]["command"] == "python -m http.server"
 
     stopped = await stop_job(job["job_id"])
     assert stopped["killed"] is True
@@ -58,7 +63,7 @@ async def test_jobs_track_tail_stop_and_retry(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_job_list_marks_missing_running_session_exited(tmp_path, monkeypatch):
+async def test_job_list_marks_missing_running_session_lost(tmp_path, monkeypatch):
     monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
     monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(tmp_path / ".local-shell-mcp"))
     get_settings.cache_clear()
@@ -76,5 +81,56 @@ async def test_job_list_marks_missing_running_session_exited(tmp_path, monkeypat
     assert job["status"] == "running"
 
     listed = await list_jobs()
-    assert listed["counts"] == {"exited": 1}
-    assert listed["jobs"][0]["status"] == "exited"
+    assert listed["counts"] == {"lost": 1}
+    assert listed["jobs"][0]["status"] == "lost"
+    assert listed["jobs"][0]["exit_code"] is None
+
+
+@pytest.mark.asyncio
+async def test_completed_job_retains_output_and_exit_code(tmp_path, monkeypatch):
+    if os.name != "nt" and not shutil.which("tmux"):
+        pytest.skip("tmux is required for the Unix persistent shell backend")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv(
+        "LOCAL_SHELL_MCP_STATE_DIR", str(tmp_path / ".local-shell-mcp")
+    )
+    get_settings.cache_clear()
+
+    job = await start_job("printf 'completed-output\n'; exit 3")
+    row = job
+    for _ in range(50):
+        await asyncio.sleep(0.1)
+        row = (await list_jobs())["jobs"][0]
+        if row["status"] != "running":
+            break
+
+    assert row["status"] == "failed"
+    assert row["exit_code"] == 3
+    tail = await tail_job(job["job_id"])
+    assert tail["output"] == "completed-output\n"
+    assert tail["message"] == "job completed with exit code 3"
+
+
+@pytest.mark.asyncio
+async def test_job_log_is_bounded_and_reports_truncation(tmp_path, monkeypatch):
+    if os.name != "nt" and not shutil.which("tmux"):
+        pytest.skip("tmux is required for the Unix persistent shell backend")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv(
+        "LOCAL_SHELL_MCP_STATE_DIR", str(tmp_path / ".local-shell-mcp")
+    )
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_JOB_LOG_BYTES", "32")
+    get_settings.cache_clear()
+
+    job = await start_job('python3 -c "print(\'x\' * 200)"')
+    row = job
+    for _ in range(50):
+        await asyncio.sleep(0.1)
+        row = (await list_jobs())["jobs"][0]
+        if row["status"] != "running":
+            break
+
+    assert row["status"] == "succeeded"
+    assert row["log_truncated"] is True
+    tail = await tail_job(job["job_id"])
+    assert len(tail["output"].encode()) <= 32

--- a/tests/test_mcp_chatgpt_compat.py
+++ b/tests/test_mcp_chatgpt_compat.py
@@ -85,31 +85,38 @@ async def test_mcp_tool_execution_enforces_advertised_scopes(tmp_path, monkeypat
     assert not (tmp_path / "blocked.txt").exists()
 
 @pytest.mark.asyncio
-async def test_full_container_mode_marks_command_tools_for_auto_approval(tmp_path, monkeypatch):
+async def test_tool_annotations_are_conservative_and_mode_independent(
+    tmp_path, monkeypatch
+):
     monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
     monkeypatch.setenv("LOCAL_SHELL_MCP_ALLOW_FULL_CONTAINER", "true")
     get_settings.cache_clear()
 
     tools = {tool.name: tool for tool in await build_mcp().list_tools()}
 
-    annotations = tools["run_shell_tool"].annotations
-    assert annotations.readOnlyHint is False
-    assert annotations.destructiveHint is False
-    assert annotations.idempotentHint is False
-    assert annotations.openWorldHint is False
+    command = tools["run_shell_tool"].annotations
+    assert command.readOnlyHint is False
+    assert command.destructiveHint is True
+    assert command.idempotentHint is False
+    assert command.openWorldHint is True
 
+    assert tools["delete_file_or_dir"].annotations.destructiveHint is True
+    assert tools["git_reset_tool"].annotations.destructiveHint is True
+    assert tools["write_file"].annotations.openWorldHint is False
+    assert tools["create_file_link"].annotations.destructiveHint is False
+    assert tools["create_file_link"].annotations.openWorldHint is True
+    assert tools["browser_get_text_tool"].annotations.readOnlyHint is True
+    assert tools["browser_get_text_tool"].annotations.openWorldHint is True
+    assert tools["remote_read_file"].annotations.readOnlyHint is True
+    assert tools["remote_read_file"].annotations.openWorldHint is True
     assert tools["search"].annotations.readOnlyHint is True
+    assert tools["search"].annotations.openWorldHint is False
+    assert all(tool.annotations is not None for tool in tools.values())
 
-
-@pytest.mark.asyncio
-async def test_default_mode_does_not_mark_command_tools_for_auto_approval(tmp_path, monkeypatch):
-    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
     monkeypatch.setenv("LOCAL_SHELL_MCP_ALLOW_FULL_CONTAINER", "false")
     get_settings.cache_clear()
-
-    tools = {tool.name: tool for tool in await build_mcp().list_tools()}
-
-    assert tools["run_shell_tool"].annotations is None
+    restricted = {tool.name: tool for tool in await build_mcp().list_tools()}
+    assert restricted["run_shell_tool"].annotations == command
 
 
 def test_oauth_access_tokens_do_not_expire_by_default(tmp_path, monkeypatch):

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -268,3 +268,8 @@ async def test_worker_post_json_forever_retries_until_success(monkeypatch, capsy
     assert len(calls) == 3
     assert sleeps == [1.0, 2.0]
     assert "Status: poll failed: temporary failure 1. Retrying in 1s..." in capsys.readouterr().err
+
+
+def test_worker_post_json_rejects_non_http_server_url():
+    with pytest.raises(ValueError, match=r"absolute HTTP\(S\)"):
+        remote._worker_post_json("file:///tmp/worker", {"invite": "abc"})  # noqa: SLF001

--- a/tests/test_search_ops.py
+++ b/tests/test_search_ops.py
@@ -154,3 +154,22 @@ async def test_grep_returns_first_matches_when_output_is_large(tmp_path, monkeyp
     assert result["ok"] is True
     assert result["truncated"] is True
     assert [item["line"] for item in result["matches"]] == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_tree_does_not_follow_directory_symlinks(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    get_settings.cache_clear()
+    outside = tmp_path.parent / f"{tmp_path.name}-outside"
+    outside.mkdir()
+    (outside / "secret-name.txt").write_text("secret", encoding="utf-8")
+    link = tmp_path / "escape"
+    try:
+        link.symlink_to(outside, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlinks are not available in this environment")
+
+    result = await tree(".", depth=3)
+
+    assert "escape" in result["entries"]
+    assert not any("secret-name.txt" in entry for entry in result["entries"])

--- a/tests/test_shell_ops.py
+++ b/tests/test_shell_ops.py
@@ -182,7 +182,8 @@ async def test_run_shell_streams_and_bounds_large_output(tmp_path, monkeypatch):
 
     assert result.ok is True
     assert result.truncated is True
-    assert len(result.stdout.encode()) <= 500
+    assert len(result.stdout.encode()) == 1000
+    assert result.stderr == ""
 
 
 @pytest.mark.asyncio
@@ -221,3 +222,40 @@ async def test_send_shell_invokes_tmux_promptly(monkeypatch):
         (["send-keys", "-t", "session-1", "-l", "echo $HOME && Enter"], 10),
         (["send-keys", "-t", "session-1", "Enter"], 10),
     ]
+
+
+@pytest.mark.asyncio
+async def test_run_shell_uses_unused_stderr_budget_for_stdout(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    get_settings.cache_clear()
+
+    result = await run_shell(
+        python_shell_command('import sys; sys.stdout.write("x" * 1500)'),
+        timeout_s=5,
+        max_output_bytes=2000,
+    )
+
+    assert result.ok is True
+    assert result.truncated is False
+    assert len(result.stdout.encode()) == 1500
+    assert result.stderr == ""
+
+
+@pytest.mark.asyncio
+async def test_run_shell_shares_total_budget_between_streams(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    get_settings.cache_clear()
+
+    result = await run_shell(
+        python_shell_command(
+            'import sys; sys.stdout.write("o" * 900); sys.stderr.write("e" * 900)'
+        ),
+        timeout_s=5,
+        max_output_bytes=1000,
+    )
+
+    assert result.ok is True
+    assert result.truncated is True
+    assert len(result.stdout.encode()) == 500
+    assert len(result.stderr.encode()) == 500
+    assert len(result.stdout.encode()) + len(result.stderr.encode()) == 1000

--- a/tests/test_transfer_ops.py
+++ b/tests/test_transfer_ops.py
@@ -131,3 +131,71 @@ def test_directory_pack_rejects_symlinks_before_archive_creation(tmp_path, monke
 
     with pytest.raises(ValueError, match="does not support symlinks"):
         transfer_pack_dir("src")
+
+
+def test_unpack_failure_preserves_existing_destination(tmp_path, monkeypatch):
+    root = _workspace(tmp_path, monkeypatch)
+    destination = root / "dst"
+    destination.mkdir()
+    important = destination / "important.txt"
+    important.write_text("keep", encoding="utf-8")
+    archive = root / "bad-link.tar"
+    info = tarfile.TarInfo("link")
+    info.type = tarfile.SYMTYPE
+    info.linkname = "target"
+    with tarfile.open(archive, "w") as tar:
+        tar.addfile(info)
+
+    with pytest.raises(ValueError, match="unsupported archive member type"):
+        transfer_unpack_archive(
+            "bad-link.tar", "dst", overwrite=True, cleanup_archive=False
+        )
+
+    assert important.read_text(encoding="utf-8") == "keep"
+    assert not list(root.glob(".dst.unpack-*"))
+
+
+def test_transfer_overwrite_false_rechecks_destination_at_finish(tmp_path, monkeypatch):
+    root = _workspace(tmp_path, monkeypatch)
+    begin = transfer_begin_write("dest.txt", overwrite=False, expected_bytes=3)
+    transfer_write_chunk("dest.txt", begin["transfer_id"], 0, "bmV3")
+    destination = root / "dest.txt"
+    destination.write_text("important", encoding="utf-8")
+
+    with pytest.raises(FileExistsError):
+        transfer_finish_write("dest.txt", begin["transfer_id"], expected_bytes=3)
+
+    assert destination.read_text(encoding="utf-8") == "important"
+    transfer_abort_write("dest.txt", begin["transfer_id"])
+
+
+def test_transfer_chunk_cannot_exceed_declared_size(tmp_path, monkeypatch):
+    _workspace(tmp_path, monkeypatch)
+    begin = transfer_begin_write("dest.txt", expected_bytes=2)
+
+    with pytest.raises(ValueError, match="exceeds expected transfer size"):
+        transfer_write_chunk("dest.txt", begin["transfer_id"], 0, "dG9vLWxvbmc=")
+
+    transfer_abort_write("dest.txt", begin["transfer_id"])
+
+
+def test_unpack_enforces_expanded_size_limit_before_replacement(tmp_path, monkeypatch):
+    root = _workspace(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_TRANSFER_UNPACKED_BYTES", "3")
+    get_settings.cache_clear()
+    destination = root / "dst"
+    destination.mkdir()
+    (destination / "important.txt").write_text("keep", encoding="utf-8")
+    archive = root / "large.tar"
+    info = tarfile.TarInfo("payload.txt")
+    payload = b"four"
+    info.size = len(payload)
+    with tarfile.open(archive, "w") as tar:
+        tar.addfile(info, io.BytesIO(payload))
+
+    with pytest.raises(ValueError, match="expands to more than 3 bytes"):
+        transfer_unpack_archive(
+            "large.tar", "dst", overwrite=True, cleanup_archive=False
+        )
+
+    assert (destination / "important.txt").read_text(encoding="utf-8") == "keep"

--- a/ui/src/files-screen.tsx
+++ b/ui/src/files-screen.tsx
@@ -3,15 +3,23 @@ import { useKeyboard } from "@opentui/react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { api, formatError } from "./api"
 import { EmptyState, KeyHint, MachineSidebar, Modal, Panel, formatBytes, useVisibleRows } from "./components"
-import { clampIndex } from "./state-utils"
+import { clampIndex, payloadMatches } from "./state-utils"
 import { theme } from "./theme"
 import type { FileEntry, FilePreview, FilesPayload, Machine } from "./types"
 
 type Dialog =
   | { type: "none" }
-  | { type: "input"; action: "rename" | "new-file" | "new-dir"; title: string; value: string }
-  | { type: "confirm-delete"; entry: FileEntry }
-  | { type: "editor"; entry: FileEntry; content: string; sha256: string }
+  | {
+      type: "input"
+      action: "rename" | "new-file" | "new-dir"
+      title: string
+      value: string
+      machine: string
+      directory: string
+      entry?: FileEntry
+    }
+  | { type: "confirm-delete"; machine: string; entry: FileEntry }
+  | { type: "editor"; machine: string; entry: FileEntry; content: string; sha256: string }
 
 interface ClipboardState {
   mode: "copy" | "move"
@@ -132,14 +140,17 @@ export function FilesScreen({
   const editorRef = useRef<TextareaRenderable>(null)
   const refreshRequest = useRef(0)
   const refreshController = useRef<AbortController | null>(null)
+  const machineRef = useRef(machine)
+  machineRef.current = machine
+  const activePayload = payloadMatches(payload, machine, path) ? payload : null
 
   const entries = useMemo(
-    () => (payload?.entries || []).filter((entry) => showHidden || !entry.hidden),
-    [payload, showHidden],
+    () => (activePayload?.entries || []).filter((entry) => showHidden || !entry.hidden),
+    [activePayload, showHidden],
   )
   const parentEntries = useMemo(
-    () => (payload?.parent_entries || []).filter((entry) => showHidden || !entry.hidden),
-    [payload, showHidden],
+    () => (activePayload?.parent_entries || []).filter((entry) => showHidden || !entry.hidden),
+    [activePayload, showHidden],
   )
   const current = entries[selected]
   const listHeight = Math.max(4, height - 10)
@@ -172,6 +183,14 @@ export function FilesScreen({
       }
     }
   }, [machine, path, setStatus])
+
+  useEffect(() => {
+    setPayload(null)
+    setPreview(null)
+    setSelected(0)
+    setDialog({ type: "none" })
+    setClipboard(null)
+  }, [machine])
 
   useEffect(() => {
     setSelected(0)
@@ -213,18 +232,28 @@ export function FilesScreen({
   const performInputAction = async (value: string) => {
     const trimmed = value.trim()
     if (!trimmed || dialog.type !== "input") return
+    if (dialog.machine !== machine) {
+      closeDialog()
+      return
+    }
     try {
       if (dialog.action === "rename") {
-        if (!current) return
+        if (!dialog.entry) return
         await api.fileAction("rename", {
-          machine,
-          path: current.path,
-          destination: joinPath(path, trimmed),
+          machine: dialog.machine,
+          path: dialog.entry.path,
+          destination: joinPath(dialog.directory, trimmed),
         })
       } else if (dialog.action === "new-file") {
-        await api.fileAction("touch", { machine, path: joinPath(path, trimmed) })
+        await api.fileAction("touch", {
+          machine: dialog.machine,
+          path: joinPath(dialog.directory, trimmed),
+        })
       } else {
-        await api.fileAction("mkdir", { machine, path: joinPath(path, trimmed) })
+        await api.fileAction("mkdir", {
+          machine: dialog.machine,
+          path: joinPath(dialog.directory, trimmed),
+        })
       }
       closeDialog()
       await refresh()
@@ -235,12 +264,15 @@ export function FilesScreen({
 
   const openEditor = async (entry: FileEntry) => {
     if (entry.type === "dir") return
+    const targetMachine = machine
     setBusy(true)
     try {
-      const content = await api.fileContent(machine, entry.path)
+      const content = await api.fileContent(targetMachine, entry.path)
+      if (machineRef.current !== targetMachine) return
       if (!content.sha256) throw new Error("The editor did not receive a file revision")
       setDialog({
         type: "editor",
+        machine: targetMachine,
         entry,
         content: String(content.content || ""),
         sha256: content.sha256,
@@ -276,20 +308,27 @@ export function FilesScreen({
     if (!machines.length) return
     const index = Math.max(0, machines.findIndex((item) => item.name === machine))
     const next = (index + delta + machines.length) % machines.length
-    onMachine(machines[next]!.name)
-    setPath(".")
+    setPayload(null)
+    setPreview(null)
+    setDialog({ type: "none" })
     setClipboard(null)
+    setPath(".")
+    onMachine(machines[next]!.name)
   }
 
   useKeyboard((key) => {
     if (!keyboardEnabled) return
+    if (dialog.type !== "none" && dialog.machine !== machine) {
+      closeDialog()
+      return
+    }
     if (dialog.type === "editor") {
       if (key.name === "escape") closeDialog()
       if (key.ctrl && key.name === "s") {
         const content = editorRef.current?.plainText ?? dialog.content
         void api
           .fileAction("write", {
-            machine,
+            machine: dialog.machine,
             path: dialog.entry.path,
             content,
             overwrite: true,
@@ -320,7 +359,7 @@ export function FilesScreen({
       if (key.name === "y" || key.name === "return") {
         void api
           .fileAction("delete", {
-            machine,
+            machine: dialog.machine,
             path: dialog.entry.path,
             recursive: dialog.entry.type === "dir",
           })
@@ -339,15 +378,37 @@ export function FilesScreen({
     else if (key.name === "k" || key.name === "up") setSelected((value) => Math.max(0, value - 1))
     else if (key.name === "g" && key.shift) setSelected(Math.max(0, entries.length - 1))
     else if (key.name === "g") setSelected(0)
-    else if (key.name === "h" || key.name === "left" || key.name === "backspace") setPath(payload?.parent || ".")
+    else if (key.name === "h" || key.name === "left" || key.name === "backspace") setPath(activePayload?.parent || ".")
     else if (key.name === "l" || key.name === "right" || key.name === "return") {
       if (current?.type === "dir") setPath(current.path)
       else if (current) void openEditor(current)
     } else if (key.name === "." || key.name === "period") setShowHidden((value) => !value)
-    else if (key.name === "r" && !key.shift) current && setDialog({ type: "input", action: "rename", title: "Rename", value: current.name })
-    else if (key.name === "n" && key.shift) setDialog({ type: "input", action: "new-dir", title: "New directory", value: "" })
-    else if (key.name === "n") setDialog({ type: "input", action: "new-file", title: "New file", value: "" })
-    else if (key.name === "d") current && setDialog({ type: "confirm-delete", entry: current })
+    else if (key.name === "r" && !key.shift) current && setDialog({
+      type: "input",
+      action: "rename",
+      title: "Rename",
+      value: current.name,
+      machine,
+      directory: path,
+      entry: current,
+    })
+    else if (key.name === "n" && key.shift) setDialog({
+      type: "input",
+      action: "new-dir",
+      title: "New directory",
+      value: "",
+      machine,
+      directory: path,
+    })
+    else if (key.name === "n") setDialog({
+      type: "input",
+      action: "new-file",
+      title: "New file",
+      value: "",
+      machine,
+      directory: path,
+    })
+    else if (key.name === "d") current && setDialog({ type: "confirm-delete", machine, entry: current })
     else if (key.name === "e") current && current.type !== "dir" && void openEditor(current)
     else if (key.name === "y") current && setClipboard({ mode: "copy", machine, path: current.path })
     else if (key.name === "x") current && setClipboard({ mode: "move", machine, path: current.path })
@@ -366,9 +427,12 @@ export function FilesScreen({
             selected={machine}
             onSelect={(nextMachine) => {
               if (nextMachine === machine) return
-              onMachine(nextMachine)
-              setPath(".")
+              setPayload(null)
+              setPreview(null)
+              setDialog({ type: "none" })
               setClipboard(null)
+              setPath(".")
+              onMachine(nextMachine)
             }}
           />
         )}

--- a/ui/src/state-utils.test.ts
+++ b/ui/src/state-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { clampIndex, nextValue, updateTodo } from "./state-utils"
+import { clampIndex, nextValue, payloadMatches, scopedItems, updateTodo } from "./state-utils"
 
 describe("clampIndex", () => {
   test("never produces a negative selection for an empty list", () => {
@@ -24,5 +24,20 @@ describe("todo mutations", () => {
   test("applies updates to the latest matching item", () => {
     expect(updateTodo(todos, "a", (todo) => ({ content: `${todo.content}!` }))[0]!.content).toBe("A!")
     expect(updateTodo(todos, "missing", { content: "ignored" })).toEqual(todos)
+  })
+})
+
+
+describe("machine-scoped state", () => {
+  test("hides items from a previous machine immediately", () => {
+    expect(scopedItems("worker-a", "worker-b", ["stale"])).toEqual([])
+    expect(scopedItems("worker-a", "worker-a", ["current"])).toEqual(["current"])
+  })
+
+  test("accepts file payloads only for the current machine and path", () => {
+    const payload = { machine: "worker-a", path: "src" }
+    expect(payloadMatches(payload, "worker-a", "src")).toBe(true)
+    expect(payloadMatches(payload, "worker-b", "src")).toBe(false)
+    expect(payloadMatches(payload, "worker-a", ".")).toBe(false)
   })
 })

--- a/ui/src/state-utils.ts
+++ b/ui/src/state-utils.ts
@@ -5,6 +5,19 @@ export function clampIndex(value: number, length: number): number {
   return Math.max(0, Math.min(value, length - 1))
 }
 
+
+export function scopedItems<T>(owner: string | null, current: string, items: T[]): T[] {
+  return owner === current ? items : []
+}
+
+export function payloadMatches(
+  payload: { machine: string; path?: string } | null,
+  machine: string,
+  path?: string,
+): boolean {
+  return Boolean(payload && payload.machine === machine && (path === undefined || payload.path === path))
+}
+
 export function nextValue<T extends string>(current: string, order: readonly T[]): T {
   const index = order.indexOf(current as T)
   return order[(index + 1 + order.length) % order.length]!

--- a/ui/src/terminals-screen.tsx
+++ b/ui/src/terminals-screen.tsx
@@ -2,14 +2,14 @@ import { useKeyboard } from "@opentui/react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { api, formatError } from "./api"
 import { EmptyState, KeyHint, MachineSidebar, Modal, Panel, formatAge } from "./components"
-import { clampIndex } from "./state-utils"
+import { clampIndex, scopedItems } from "./state-utils"
 import { theme } from "./theme"
 import type { AuditEntry, Machine, TerminalSession } from "./types"
 
 type TerminalDialog =
   | { type: "none" }
-  | { type: "start"; name: string; cwd: string }
-  | { type: "kill"; session: TerminalSession }
+  | { type: "start"; machine: string; name: string; cwd: string }
+  | { type: "kill"; machine: string; session: TerminalSession }
 
 function encodeRawKey(key: {
   name: string
@@ -90,6 +90,7 @@ export function TerminalsScreen({
   onInteractionLockChange: (locked: boolean) => void
 }) {
   const [sessions, setSessions] = useState<TerminalSession[]>([])
+  const [sessionsMachine, setSessionsMachine] = useState<string | null>(null)
   const [selected, setSelected] = useState(0)
   const [output, setOutput] = useState("")
   const [audit, setAudit] = useState<AuditEntry[]>([])
@@ -103,7 +104,8 @@ export function TerminalsScreen({
   const sessionsController = useRef<AbortController | null>(null)
   const outputController = useRef<AbortController | null>(null)
   const machineRef = useRef(machine)
-  const selectedSession = sessions[selected]
+  const activeSessions = scopedItems(sessionsMachine, machine, sessions)
+  const selectedSession = activeSessions[selected]
   const selectedSessionIdRef = useRef<string | null>(selectedSession?.session_id || null)
   machineRef.current = machine
   selectedSessionIdRef.current = selectedSession?.session_id || null
@@ -124,6 +126,7 @@ export function TerminalsScreen({
         controller.signal.aborted
       ) return []
       setSessions(payload.sessions)
+      setSessionsMachine(targetMachine)
       setSelected((value) => clampIndex(value, payload.sessions.length))
       return payload.sessions
     } catch (error) {
@@ -179,9 +182,13 @@ export function TerminalsScreen({
   useEffect(() => {
     sessionsRequest.current += 1
     outputRequest.current += 1
+    setSessions([])
+    setSessionsMachine(machine)
     setSelected(0)
     setOutput("")
     setAudit([])
+    setDialog({ type: "none" })
+    setRawMode(false)
     void refreshSessions()
     const timer = setInterval(() => void refreshSessions(), 4_000)
     return () => {
@@ -190,7 +197,7 @@ export function TerminalsScreen({
       sessionsController.current = null
       clearInterval(timer)
     }
-  }, [refreshSessions])
+  }, [machine, refreshSessions])
 
   useEffect(() => {
     outputRequest.current += 1
@@ -258,10 +265,14 @@ export function TerminalsScreen({
   }
 
   const startSession = async (value: string) => {
+    if (dialog.type !== "start" || dialog.machine !== machine) {
+      setDialog({ type: "none" })
+      return
+    }
     const [namePart, ...cwdParts] = value.trim().split(/\s+/)
     try {
       const created = await api.terminalAction<{ session_id: string }>("start", {
-        machine,
+        machine: dialog.machine,
         name: namePart || undefined,
         cwd: cwdParts.join(" ") || ".",
       })
@@ -278,12 +289,22 @@ export function TerminalsScreen({
     if (!machines.length) return
     const index = Math.max(0, machines.findIndex((item) => item.name === machine))
     const next = (index + delta + machines.length) % machines.length
-    onMachine(machines[next]!.name)
+    setSessions([])
+    setSessionsMachine(null)
     setSelected(0)
+    setOutput("")
+    setAudit([])
+    setDialog({ type: "none" })
+    setRawMode(false)
+    onMachine(machines[next]!.name)
   }
 
   useKeyboard((key) => {
     if (!keyboardEnabled) return
+    if (dialog.type !== "none" && dialog.machine !== machine) {
+      setDialog({ type: "none" })
+      return
+    }
     if (dialog.type === "start") {
       if (key.name === "escape") setDialog({ type: "none" })
       return
@@ -292,7 +313,10 @@ export function TerminalsScreen({
       if (key.name === "escape" || key.name === "n") setDialog({ type: "none" })
       if (key.name === "y" || key.name === "return") {
         void api
-          .terminalAction("kill", { machine, session_id: dialog.session.session_id })
+          .terminalAction("kill", {
+            machine: dialog.machine,
+            session_id: dialog.session.session_id,
+          })
           .then(async () => {
             setDialog({ type: "none" })
             await refreshSessions(true)
@@ -323,10 +347,10 @@ export function TerminalsScreen({
     else if (key.option && key.name === "]") switchMachine(1)
     else if (key.option && key.name === "left") setSelected((value) => Math.max(0, value - 1))
     else if (key.option && key.name === "right") {
-      setSelected((value) => clampIndex(value + 1, sessions.length))
+      setSelected((value) => clampIndex(value + 1, activeSessions.length))
     }
-    else if (key.ctrl && key.name === "n") setDialog({ type: "start", name: "", cwd: "." })
-    else if (key.ctrl && key.name === "w" && selectedSession) setDialog({ type: "kill", session: selectedSession })
+    else if (key.ctrl && key.name === "n") setDialog({ type: "start", machine, name: "", cwd: "." })
+    else if (key.ctrl && key.name === "w" && selectedSession) setDialog({ type: "kill", machine, session: selectedSession })
     else if (key.ctrl && key.name === "a") setShowAudit((value) => !value)
     else if (key.ctrl && key.name === "r") void refreshOutput(true)
   })
@@ -343,8 +367,15 @@ export function TerminalsScreen({
             machines={machines}
             selected={machine}
             onSelect={(nextMachine) => {
-              if (nextMachine !== machine) onMachine(nextMachine)
+              if (nextMachine === machine) return
+              setSessions([])
+              setSessionsMachine(null)
               setSelected(0)
+              setOutput("")
+              setAudit([])
+              setDialog({ type: "none" })
+              setRawMode(false)
+              onMachine(nextMachine)
             }}
           />
         )}
@@ -398,7 +429,7 @@ export function TerminalsScreen({
               paddingRight: 1,
             }}
           >
-            {sessions.map((session, index) => (
+            {activeSessions.map((session, index) => (
               <box
                 key={session.session_id}
                 style={{
@@ -416,7 +447,7 @@ export function TerminalsScreen({
                 />
               </box>
             ))}
-            {sessions.length === 0 && <text fg={theme.faint} content="No sessions" />}
+            {activeSessions.length === 0 && <text fg={theme.faint} content="No sessions" />}
             <box style={{ flexGrow: 1 }} />
             {selectedSession?.created && (
               <text fg={theme.faint} content={formatAge(Number(selectedSession.created))} />


### PR DESCRIPTION
## Summary

- harden localhost authentication bypasses, file-link serving, audit redaction, remote worker URLs, and path traversal boundaries
- make file and directory transfers transactional, race-safe, and bounded by archive entry and expanded-size limits
- isolate Files and Terminals UI state by machine and keep active WebUI terminals alive while output is flowing
- persist long-running job output, exit codes, and terminal states with bounded logs
- correct MCP safety annotations, share shell output limits across stdout/stderr, and bound path-lock resources
- document the new job-log and transfer archive limits

## Validation

- [x] `ruff check .`
- [x] `pytest -q` — 184 passed
- [x] `mkdocs build --strict` if docs changed
- [x] VS Code extension compile if extension files changed — not applicable
- [x] UI TypeScript check, Bun tests, WebUI build, and OpenTUI build
- [x] REST/no-auth and MCP/OAuth endpoint smoke tests
- [x] native PTY/WebSocket bridge and Chromium Human UI smoke tests
- [x] wheel and sdist builds
- [x] Bandit scan — no high-severity findings

## Safety checklist

- [x] No secrets, tunnel tokens, OAuth pins, private keys, or bearer file-link URLs are committed. Secret-scan findings are synthetic test fixtures.
- [x] New or changed MCP tools are documented and tested. No tools were added; job and annotation behavior changed and is covered by regression tests.
- [x] Host-control, remote-worker, file-link, or credential behavior is explicitly described.
- [x] Backwards compatibility impact is noted.

## Backwards compatibility

- existing persisted file links use store version 1 and are intentionally invalidated when the version 2 store is initialized, because version 2 binds links to the original file identity
- completed jobs now resolve to `succeeded`, `failed`, `stopped`, or `lost` instead of the ambiguous `exited` state
- MCP safety annotations are now conservative and may cause clients to request confirmation for destructive or open-world operations that were previously marked otherwise
- three optional settings were added: `max_job_log_bytes`, `max_transfer_archive_entries`, and `max_transfer_unpacked_bytes`
