### PR TITLE
fix: resolve comprehensive bug audit findings

### DIFF
--- a/src/local_shell_mcp/auth.py
+++ b/src/local_shell_mcp/auth.py
@@ -106,7 +106,7 @@ def require_current_scopes(required: list[str] | tuple[str, ...] | set[str]) -> 
         require_scopes(principal, required)
 
 
-def required_scopes_for_http_tool(path: str) -> tuple[str, ...]:
+def required_scopes_for_http_tool(path: str, method: str | None = None) -> tuple[str, ...]:
     """Map the compatibility REST tool surface to the scopes declared by MCP tools."""
 
     read = ("shell:read",)
@@ -120,12 +120,13 @@ def required_scopes_for_http_tool(path: str) -> tuple[str, ...]:
 
     if path.startswith("/tools/download/"):
         return file_share
+    if path == "/tools/todo":
+        return read if str(method or "").upper() == "GET" else write
     if path in {
         "/tools/write_file",
         "/tools/edit_file",
         "/tools/multi_edit_file",
         "/tools/delete",
-        "/tools/todo",
     }:
         return write
     if path in {

--- a/src/local_shell_mcp/fs_ops.py
+++ b/src/local_shell_mcp/fs_ops.py
@@ -200,9 +200,25 @@ def resolve_path(
         except ValueError as exc:
             raise ValueError(f"Path escapes workspace: {path}") from exc
 
-    lower = str(resolved).lower()
+    candidates: list[tuple[str, ...]] = [tuple(part.casefold() for part in resolved.parts)]
+    with contextlib.suppress(ValueError):
+        relative = resolved.relative_to(root)
+        candidates.insert(0, tuple(part.casefold() for part in relative.parts))
     for denied in settings.path_denylist:
-        if denied and denied.lower() in lower:
+        normalized = tuple(
+            part.casefold()
+            for part in str(denied).replace("\\", "/").strip("/").split("/")
+            if part
+        )
+        if not normalized:
+            continue
+        matched = any(
+            len(parts) >= len(normalized) and parts[-len(normalized) :] == normalized
+            for parts in candidates
+        )
+        if len(normalized) == 1:
+            matched = matched or any(normalized[0] in parts for parts in candidates)
+        if matched:
             raise PermissionError(f"Path is denylisted: {path}")
 
     exists = resolved.exists() if follow_final_symlink else os.path.lexists(resolved)
@@ -522,6 +538,8 @@ def perform_file_action(
 
 
 def edit_text(path: str, old: str, new: str, replace_all: bool = False) -> dict:
+    if old == "":
+        raise ValueError("old text must not be empty")
     settings = get_settings()
     p = resolve_path(path, must_exist=True)
     if p.stat().st_size > settings.max_file_write_bytes:
@@ -554,6 +572,8 @@ def multi_edit_text(path: str, edits: list[dict]) -> dict:
     for edit in edits:
         old = str(edit["old"])
         new = str(edit["new"])
+        if old == "":
+            raise ValueError("old text must not be empty")
         replace_all = bool(edit.get("replace_all", False))
         count = text.count(old)
         if count == 0:

--- a/src/local_shell_mcp/http_app.py
+++ b/src/local_shell_mcp/http_app.py
@@ -73,6 +73,17 @@ from .todo_ops import todo_read, todo_write
 from .version import version_info
 
 PUBLIC_TOOL_TIMEOUT_S = PUBLIC_TOOL_WATCHDOG_TIMEOUT_S
+NON_CANCELLABLE_HTTP_MUTATIONS = frozenset(
+    {
+        "/tools/download/create",
+        "/tools/download/revoke",
+        "/tools/write_file",
+        "/tools/edit_file",
+        "/tools/multi_edit_file",
+        "/tools/delete",
+        "/tools/todo",
+    }
+)
 
 
 class SkillLoadRequest(BaseModel):
@@ -87,7 +98,7 @@ class SkillReadFileRequest(SkillLoadRequest):
 
 def principal_dep(request: Request) -> Principal:
     principal = verify_request(request)
-    require_scopes(principal, required_scopes_for_http_tool(str(request.url.path)))
+    require_scopes(principal, required_scopes_for_http_tool(str(request.url.path), request.method))
     return principal
 
 
@@ -96,6 +107,32 @@ PRINCIPAL_DEP = Depends(principal_dep)
 
 async def _blocking(func, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
     return await asyncio.to_thread(func, *args, **kwargs)
+
+
+def _body_bool(body: dict, key: str, default: bool) -> bool:
+    if key not in body:
+        return default
+    value = body[key]
+    if not isinstance(value, bool):
+        raise ValueError(f"{key} must be a boolean")
+    return value
+
+
+def _body_int(
+    body: dict,
+    key: str,
+    default: int | None,
+    *,
+    allow_none: bool = False,
+) -> int | None:
+    if key not in body:
+        return default
+    value = body[key]
+    if value is None and allow_none:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{key} must be an integer")
+    return value
 
 
 def build_http_app() -> FastAPI:
@@ -147,6 +184,10 @@ def build_http_app() -> FastAPI:
     async def tools_timeout_middleware(request: Request, call_next):  # noqa: ANN001
         if not request.url.path.startswith("/tools/"):
             return await call_next(request)
+        if request.url.path in NON_CANCELLABLE_HTTP_MUTATIONS and (
+            request.url.path != "/tools/todo" or request.method.upper() != "GET"
+        ):
+            return await call_next(request)
         try:
             return await asyncio.wait_for(call_next(request), timeout=PUBLIC_TOOL_TIMEOUT_S)
         except TimeoutError:
@@ -165,7 +206,7 @@ def build_http_app() -> FastAPI:
 
     @app.get("/readyz")
     async def readyz():
-        return {"ok": True, "workspace_root": str(settings.workspace_root)}
+        return {"ok": True}
 
     @app.get("/version")
     async def api_version():
@@ -197,7 +238,7 @@ def build_http_app() -> FastAPI:
     @app.post("/tools/run_shell")
     async def api_run_shell(body: dict, _: Principal = PRINCIPAL_DEP):
         try:
-            return (await public_run_shell(body["command"], body.get("cwd", "."), body.get("timeout_s"), body.get("max_output_bytes"))).model_dump()
+            return (await public_run_shell(body["command"], body.get("cwd", "."), _body_int(body, "timeout_s", None, allow_none=True), _body_int(body, "max_output_bytes", None, allow_none=True))).model_dump()
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -207,11 +248,11 @@ def build_http_app() -> FastAPI:
 
     @app.post("/tools/shell_send")
     async def api_shell_send(body: dict, _: Principal = PRINCIPAL_DEP):
-        return await send_shell(body["session_id"], body["input_text"], body.get("enter", True))
+        return await send_shell(body["session_id"], body["input_text"], _body_bool(body, "enter", True))
 
     @app.post("/tools/shell_read")
     async def api_shell_read(body: dict, _: Principal = PRINCIPAL_DEP):
-        return await read_shell(body["session_id"], body.get("lines", 200))
+        return await read_shell(body["session_id"], _body_int(body, "lines", 200))
 
     @app.post("/tools/shell_kill")
     async def api_shell_kill(body: dict, _: Principal = PRINCIPAL_DEP):
@@ -223,19 +264,19 @@ def build_http_app() -> FastAPI:
 
     @app.post("/tools/list_files")
     async def api_list_files(body: dict, _: Principal = PRINCIPAL_DEP):
-        return await _blocking(list_dir, body.get("path", "."), body.get("recursive", False), body.get("max_entries", 500))
+        return await _blocking(list_dir, body.get("path", "."), _body_bool(body, "recursive", False), _body_int(body, "max_entries", 500))
 
     @app.post("/tools/tree")
     async def api_tree(body: dict, _: Principal = PRINCIPAL_DEP):
-        return await tree(body.get("cwd", "."), body.get("depth", 3), body.get("max_entries", 500))
+        return await tree(body.get("cwd", "."), _body_int(body, "depth", 3), _body_int(body, "max_entries", 500))
 
     @app.post("/tools/glob")
     async def api_glob(body: dict, _: Principal = PRINCIPAL_DEP):
-        return {"paths": await _blocking(glob_paths, body["pattern"], body.get("cwd", "."), body.get("max_results", 500))}
+        return {"paths": await _blocking(glob_paths, body["pattern"], body.get("cwd", "."), _body_int(body, "max_results", 500))}
 
     @app.post("/tools/grep")
     async def api_grep(body: dict, _: Principal = PRINCIPAL_DEP):
-        return await grep(body["query"], body.get("cwd", "."), body.get("glob"), body.get("regex", True), body.get("case_sensitive", True), body.get("max_results"))
+        return await grep(body["query"], body.get("cwd", "."), body.get("glob"), _body_bool(body, "regex", True), _body_bool(body, "case_sensitive", True), _body_int(body, "max_results", None, allow_none=True))
 
     @app.api_route("/download/{token}", methods=["GET", "HEAD"])
     async def api_download(request: Request):
@@ -246,9 +287,9 @@ def build_http_app() -> FastAPI:
         return await _blocking(
             create_download_link,
             body["path"],
-            body.get("ttl_s"),
+            _body_int(body, "ttl_s", None, allow_none=True),
             body.get("filename"),
-            body.get("max_downloads"),
+            _body_int(body, "max_downloads", None, allow_none=True),
         )
 
     @app.get("/tools/download/list")
@@ -264,19 +305,19 @@ def build_http_app() -> FastAPI:
         return await _blocking(
             read_text,
             body["path"],
-            body.get("start_line"),
-            body.get("end_line"),
+            _body_int(body, "start_line", None, allow_none=True),
+            _body_int(body, "end_line", None, allow_none=True),
             body.get("binary_preview"),
-            body.get("binary_preview_bytes", 256),
+            _body_int(body, "binary_preview_bytes", 256),
         )
 
     @app.post("/tools/write_file")
     async def api_write_file(body: dict, _: Principal = PRINCIPAL_DEP):
-        return await _blocking(write_text, body["path"], body["content"], body.get("overwrite", True))
+        return await _blocking(write_text, body["path"], body["content"], _body_bool(body, "overwrite", True))
 
     @app.post("/tools/edit_file")
     async def api_edit_file(body: dict, _: Principal = PRINCIPAL_DEP):
-        return await _blocking(edit_text, body["path"], body["old"], body["new"], body.get("replace_all", False))
+        return await _blocking(edit_text, body["path"], body["old"], body["new"], _body_bool(body, "replace_all", False))
 
     @app.post("/tools/multi_edit_file")
     async def api_multi_edit_file(body: dict, _: Principal = PRINCIPAL_DEP):
@@ -284,7 +325,7 @@ def build_http_app() -> FastAPI:
 
     @app.post("/tools/delete")
     async def api_delete(body: dict, _: Principal = PRINCIPAL_DEP):
-        return await _blocking(delete_path, body["path"], body.get("recursive", False))
+        return await _blocking(delete_path, body["path"], _body_bool(body, "recursive", False))
 
     @app.post("/tools/git/status")
     async def api_git_status(body: dict, _: Principal = PRINCIPAL_DEP):
@@ -292,11 +333,11 @@ def build_http_app() -> FastAPI:
 
     @app.post("/tools/git/diff")
     async def api_git_diff(body: dict, _: Principal = PRINCIPAL_DEP):
-        return await git_diff(body.get("cwd", "."), body.get("staged", False), body.get("path"), body.get("stat", False))
+        return await git_diff(body.get("cwd", "."), _body_bool(body, "staged", False), body.get("path"), _body_bool(body, "stat", False))
 
     @app.post("/tools/git/log")
     async def api_git_log(body: dict, _: Principal = PRINCIPAL_DEP):
-        return await git_log(body.get("cwd", "."), body.get("max_count", 20))
+        return await git_log(body.get("cwd", "."), _body_int(body, "max_count", 20))
 
     @app.post("/tools/git/clone")
     async def api_git_clone(body: dict, _: Principal = PRINCIPAL_DEP):
@@ -304,15 +345,15 @@ def build_http_app() -> FastAPI:
 
     @app.post("/tools/git/checkout")
     async def api_git_checkout(body: dict, _: Principal = PRINCIPAL_DEP):
-        return await git_checkout(body["cwd"], body["ref"], body.get("create", False))
+        return await git_checkout(body["cwd"], body["ref"], _body_bool(body, "create", False))
 
     @app.post("/tools/git/fetch")
     async def api_git_fetch(body: dict, _: Principal = PRINCIPAL_DEP):
-        return await git_fetch(body.get("cwd", "."), body.get("remote", "origin"), body.get("prune", True))
+        return await git_fetch(body.get("cwd", "."), body.get("remote", "origin"), _body_bool(body, "prune", True))
 
     @app.post("/tools/git/pull")
     async def api_git_pull(body: dict, _: Principal = PRINCIPAL_DEP):
-        return await git_pull(body.get("cwd", "."), body.get("ff_only", True))
+        return await git_pull(body.get("cwd", "."), _body_bool(body, "ff_only", True))
 
     @app.post("/tools/git/add")
     async def api_git_add(body: dict, _: Principal = PRINCIPAL_DEP):
@@ -320,11 +361,11 @@ def build_http_app() -> FastAPI:
 
     @app.post("/tools/git/commit")
     async def api_git_commit(body: dict, _: Principal = PRINCIPAL_DEP):
-        return await git_commit(body["cwd"], body["message"], body.get("all_changes", False))
+        return await git_commit(body["cwd"], body["message"], _body_bool(body, "all_changes", False))
 
     @app.post("/tools/git/push")
     async def api_git_push(body: dict, _: Principal = PRINCIPAL_DEP):
-        return await git_push(body["cwd"], body.get("remote", "origin"), body.get("branch"), body.get("set_upstream", True))
+        return await git_push(body["cwd"], body.get("remote", "origin"), body.get("branch"), _body_bool(body, "set_upstream", True))
 
     @app.post("/tools/git/show")
     async def api_git_show(body: dict, _: Principal = PRINCIPAL_DEP):
@@ -344,11 +385,11 @@ def build_http_app() -> FastAPI:
 
     @app.post("/tools/playwright/install")
     async def api_playwright_install(body: dict, _: Principal = PRINCIPAL_DEP):
-        return await playwright_install(body.get("browser", "chromium"), body.get("with_deps", False))
+        return await playwright_install(body.get("browser", "chromium"), _body_bool(body, "with_deps", False))
 
     @app.post("/tools/browser/screenshot")
     async def api_browser_screenshot(body: dict, _: Principal = PRINCIPAL_DEP):
-        return await browser_screenshot(body["url"], body.get("output_path", "screenshots/page.png"), body.get("browser", "chromium"), body.get("full_page", True), body.get("width", 1440), body.get("height", 1000), body.get("wait_until", "networkidle"))
+        return await browser_screenshot(body["url"], body.get("output_path", "screenshots/page.png"), body.get("browser", "chromium"), _body_bool(body, "full_page", True), _body_int(body, "width", 1440), _body_int(body, "height", 1000), body.get("wait_until", "networkidle"))
 
     @app.post("/tools/browser/text")
     async def api_browser_text(body: dict, _: Principal = PRINCIPAL_DEP):
@@ -360,11 +401,11 @@ def build_http_app() -> FastAPI:
 
     @app.post("/tools/browser/pdf")
     async def api_browser_pdf(body: dict, _: Principal = PRINCIPAL_DEP):
-        return await browser_pdf(body["url"], body.get("output_path", "screenshots/page.pdf"), body.get("width", 1440), body.get("height", 1000), body.get("wait_until", "networkidle"))
+        return await browser_pdf(body["url"], body.get("output_path", "screenshots/page.pdf"), _body_int(body, "width", 1440), _body_int(body, "height", 1000), body.get("wait_until", "networkidle"))
 
     @app.post("/tools/playwright/run_script")
     async def api_playwright_run_script(body: dict, _: Principal = PRINCIPAL_DEP):
-        return await playwright_run_script(body["script"], body.get("cwd", "."), body.get("timeout_s", 60))
+        return await playwright_run_script(body["script"], body.get("cwd", "."), _body_int(body, "timeout_s", 60))
 
     app.router.routes.extend(ui_routes())
     return app

--- a/src/local_shell_mcp/human_ui.py
+++ b/src/local_shell_mcp/human_ui.py
@@ -177,7 +177,6 @@ async def ui_wallpaper(request: Request) -> Response:  # noqa: ARG001
             )
         return Response(status_code=204)
 
-    stamp_path.write_text(today, encoding="utf-8")
     try:
         import httpx
 
@@ -202,6 +201,7 @@ async def ui_wallpaper(request: Request) -> Response:  # noqa: ARG001
     except Exception:
         if not image_path.is_file():
             return Response(status_code=204)
+        stamp_path.write_text(today, encoding="utf-8")
 
     return FileResponse(image_path, media_type="image/jpeg", headers={"Cache-Control": "public, max-age=3600"})
 

--- a/src/local_shell_mcp/jobs.py
+++ b/src/local_shell_mcp/jobs.py
@@ -17,7 +17,7 @@ from typing import Any, BinaryIO
 from .audit import audit
 from .fs_ops import resolve_path
 from .settings import get_settings
-from .shell_environment import subprocess_env
+from .shell_environment import filtered_subprocess_env
 from .shell_ops import (
     check_command_policy,
     kill_shell,
@@ -253,6 +253,10 @@ def _runner_argv(paths: dict[str, Path], cwd: Path) -> list[str]:
         settings.shell_executable,
         "--max-log-bytes",
         str(max(1, settings.max_job_log_bytes)),
+        "--env-blocklist-json",
+        json.dumps(settings.shell_env_blocklist),
+        "--env-blocked-prefixes-json",
+        json.dumps(settings.shell_env_blocked_prefixes),
     ]
     if getattr(sys, "frozen", False):
         return [sys.executable, *arguments]
@@ -816,6 +820,16 @@ def _compact_log(handle: BinaryIO, max_bytes: int) -> bool:
     return True
 
 
+def _parse_runner_env_policy(raw: str, label: str) -> list[str]:
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{label} must be a JSON string list") from exc
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(f"{label} must be a JSON string list")
+    return value
+
+
 def _write_runner_status(path: Path, payload: dict[str, Any]) -> None:
     temporary = path.with_name(path.name + f".{uuid.uuid4().hex}.tmp")
     try:
@@ -833,6 +847,14 @@ def run_job_runner_cli(argv: list[str] | None = None) -> None:
     parser.add_argument("--cwd", required=True)
     parser.add_argument("--shell", required=True)
     parser.add_argument("--max-log-bytes", type=int, required=True)
+    parser.add_argument(
+        "--env-blocklist-json",
+        default=json.dumps(["CLOUDFLARE_TUNNEL_TOKEN"]),
+    )
+    parser.add_argument(
+        "--env-blocked-prefixes-json",
+        default=json.dumps(["LOCAL_SHELL_MCP_", "DOCKER_"]),
+    )
     args = parser.parse_args(argv)
 
     command_path = Path(args.command_file)
@@ -846,10 +868,16 @@ def run_job_runner_cli(argv: list[str] | None = None) -> None:
     error: str | None = None
     try:
         command = command_path.read_text(encoding="utf-8")
+        blocked_names = _parse_runner_env_policy(
+            args.env_blocklist_json, "env blocklist"
+        )
+        blocked_prefixes = _parse_runner_env_policy(
+            args.env_blocked_prefixes_json, "env blocked prefixes"
+        )
         process = subprocess.Popen(  # noqa: S603
             _runner_shell_args(args.shell, command),
             cwd=args.cwd,
-            env=subprocess_env(),
+            env=filtered_subprocess_env(blocked_names, blocked_prefixes),
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )

--- a/src/local_shell_mcp/jobs.py
+++ b/src/local_shell_mcp/jobs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import contextlib
 import json
 import os
@@ -253,10 +254,10 @@ def _runner_argv(paths: dict[str, Path], cwd: Path) -> list[str]:
         settings.shell_executable,
         "--max-log-bytes",
         str(max(1, settings.max_job_log_bytes)),
-        "--env-blocklist-json",
-        json.dumps(settings.shell_env_blocklist),
-        "--env-blocked-prefixes-json",
-        json.dumps(settings.shell_env_blocked_prefixes),
+        "--env-blocklist-b64",
+        _encode_runner_env_policy(settings.shell_env_blocklist),
+        "--env-blocked-prefixes-b64",
+        _encode_runner_env_policy(settings.shell_env_blocked_prefixes),
     ]
     if getattr(sys, "frozen", False):
         return [sys.executable, *arguments]
@@ -820,13 +821,21 @@ def _compact_log(handle: BinaryIO, max_bytes: int) -> bool:
     return True
 
 
+def _encode_runner_env_policy(values: list[str]) -> str:
+    payload = json.dumps(values, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
+    return base64.urlsafe_b64encode(payload).decode("ascii")
+
+
 def _parse_runner_env_policy(raw: str, label: str) -> list[str]:
     try:
-        value = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        raise ValueError(f"{label} must be a JSON string list") from exc
+        decoded = base64.b64decode(
+            raw.encode("ascii"), altchars=b"-_", validate=True
+        ).decode("utf-8")
+        value = json.loads(decoded)
+    except (ValueError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{label} must be a URL-safe Base64 JSON string list") from exc
     if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
-        raise ValueError(f"{label} must be a JSON string list")
+        raise ValueError(f"{label} must be a URL-safe Base64 JSON string list")
     return value
 
 
@@ -848,12 +857,12 @@ def run_job_runner_cli(argv: list[str] | None = None) -> None:
     parser.add_argument("--shell", required=True)
     parser.add_argument("--max-log-bytes", type=int, required=True)
     parser.add_argument(
-        "--env-blocklist-json",
-        default=json.dumps(["CLOUDFLARE_TUNNEL_TOKEN"]),
+        "--env-blocklist-b64",
+        default=_encode_runner_env_policy(["CLOUDFLARE_TUNNEL_TOKEN"]),
     )
     parser.add_argument(
-        "--env-blocked-prefixes-json",
-        default=json.dumps(["LOCAL_SHELL_MCP_", "DOCKER_"]),
+        "--env-blocked-prefixes-b64",
+        default=_encode_runner_env_policy(["LOCAL_SHELL_MCP_", "DOCKER_"]),
     )
     args = parser.parse_args(argv)
 
@@ -869,10 +878,10 @@ def run_job_runner_cli(argv: list[str] | None = None) -> None:
     try:
         command = command_path.read_text(encoding="utf-8")
         blocked_names = _parse_runner_env_policy(
-            args.env_blocklist_json, "env blocklist"
+            args.env_blocklist_b64, "env blocklist"
         )
         blocked_prefixes = _parse_runner_env_policy(
-            args.env_blocked_prefixes_json, "env blocked prefixes"
+            args.env_blocked_prefixes_b64, "env blocked prefixes"
         )
         process = subprocess.Popen(  # noqa: S603
             _runner_shell_args(args.shell, command),

--- a/src/local_shell_mcp/jobs.py
+++ b/src/local_shell_mcp/jobs.py
@@ -17,6 +17,7 @@ from typing import Any, BinaryIO
 from .audit import audit
 from .fs_ops import resolve_path
 from .settings import get_settings
+from .shell_environment import subprocess_env
 from .shell_ops import (
     check_command_policy,
     kill_shell,
@@ -848,7 +849,7 @@ def run_job_runner_cli(argv: list[str] | None = None) -> None:
         process = subprocess.Popen(  # noqa: S603
             _runner_shell_args(args.shell, command),
             cwd=args.cwd,
-            env=os.environ.copy(),
+            env=subprocess_env(),
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )

--- a/src/local_shell_mcp/playwright_ops.py
+++ b/src/local_shell_mcp/playwright_ops.py
@@ -8,7 +8,7 @@ import uuid
 
 from .fs_ops import prune_temp_dir, relative_display, resolve_path, temp_dir
 from .settings import get_settings
-from .shell_ops import public_run_shell_timeout, run_shell
+from .shell_ops import public_run_shell_timeout, quote_shell_argument, run_shell
 
 
 def _assert_script_size(script: str) -> None:
@@ -21,7 +21,7 @@ def _assert_script_size(script: str) -> None:
 async def playwright_install(browser: str = "chromium", with_deps: bool = False) -> dict:
     if browser not in {"chromium", "firefox", "webkit", "all"}:
         raise ValueError("browser must be chromium, firefox, webkit, or all")
-    cmd = "python3 -m playwright install"
+    cmd = f"{quote_shell_argument(get_settings().python_bin)} -m playwright install"
     if with_deps:
         cmd += " --with-deps"
     if browser != "all":
@@ -45,6 +45,7 @@ async def browser_screenshot(
         raise ValueError("invalid wait_until")
     out = resolve_path(output_path)
     out.parent.mkdir(parents=True, exist_ok=True)
+    out.unlink(missing_ok=True)
     await asyncio.to_thread(prune_temp_dir)
     script_path = temp_dir() / f"playwright-{uuid.uuid4().hex}.py"
     script_path.parent.mkdir(parents=True, exist_ok=True)
@@ -59,8 +60,8 @@ with sync_playwright() as p:
     browser.close()
 '''
     await asyncio.to_thread(script_path.write_text, textwrap.dedent(script), encoding="utf-8")
-    result = await run_shell(f"python3 {shlex.quote(str(script_path))}", timeout_s=60, max_output_bytes=200_000)
-    return {**result.model_dump(), "screenshot_path": relative_display(out)}
+    result = await run_shell(f"{quote_shell_argument(get_settings().python_bin)} {quote_shell_argument(str(script_path))}", timeout_s=60, max_output_bytes=200_000)
+    return {**result.model_dump(), "screenshot_path": relative_display(out) if result.ok and out.is_file() else None}
 
 
 async def browser_get_text(
@@ -87,7 +88,7 @@ with sync_playwright() as p:
     browser.close()
 '''
     await asyncio.to_thread(script_path.write_text, textwrap.dedent(script), encoding="utf-8")
-    result = await run_shell(f"python3 {shlex.quote(str(script_path))}", timeout_s=60, max_output_bytes=500_000)
+    result = await run_shell(f"{quote_shell_argument(get_settings().python_bin)} {quote_shell_argument(str(script_path))}", timeout_s=60, max_output_bytes=500_000)
     return result.model_dump()
 
 
@@ -118,7 +119,7 @@ with sync_playwright() as p:
     browser.close()
 '''
     await asyncio.to_thread(script_path.write_text, textwrap.dedent(script), encoding="utf-8")
-    result = await run_shell(f"python3 {shlex.quote(str(script_path))}", timeout_s=60, max_output_bytes=500_000)
+    result = await run_shell(f"{quote_shell_argument(get_settings().python_bin)} {quote_shell_argument(str(script_path))}", timeout_s=60, max_output_bytes=500_000)
     parsed = None
     if result.ok and result.stdout.strip():
         try:
@@ -137,6 +138,7 @@ async def browser_pdf(
 ) -> dict:
     out = resolve_path(output_path)
     out.parent.mkdir(parents=True, exist_ok=True)
+    out.unlink(missing_ok=True)
     await asyncio.to_thread(prune_temp_dir)
     script_path = temp_dir() / f"playwright-{uuid.uuid4().hex}.py"
     script_path.parent.mkdir(parents=True, exist_ok=True)
@@ -151,14 +153,14 @@ with sync_playwright() as p:
     browser.close()
 '''
     await asyncio.to_thread(script_path.write_text, textwrap.dedent(script), encoding="utf-8")
-    result = await run_shell(f"python3 {shlex.quote(str(script_path))}", timeout_s=60, max_output_bytes=200_000)
-    return {**result.model_dump(), "pdf_path": relative_display(out)}
+    result = await run_shell(f"{quote_shell_argument(get_settings().python_bin)} {quote_shell_argument(str(script_path))}", timeout_s=60, max_output_bytes=200_000)
+    return {**result.model_dump(), "pdf_path": relative_display(out) if result.ok and out.is_file() else None}
 
 
 async def playwright_run_script(script: str, cwd: str = ".", timeout_s: int = 60) -> dict:
     """Run a caller-supplied Python Playwright script inside the workspace.
 
-    The script is written to .local-shell-mcp/tmp and executed with python3. This is powerful;
+    The script is written to .local-shell-mcp/tmp and executed with the configured Python interpreter. This is powerful;
     use it only when the container is disposable and authenticated.
     """
     _assert_script_size(script)
@@ -166,5 +168,10 @@ async def playwright_run_script(script: str, cwd: str = ".", timeout_s: int = 60
     path = temp_dir() / f"playwright-custom-{uuid.uuid4().hex}.py"
     path.parent.mkdir(parents=True, exist_ok=True)
     await asyncio.to_thread(path.write_text, script, encoding="utf-8")
-    result = await run_shell(f"python3 {shlex.quote(str(path))}", cwd=cwd, timeout_s=public_run_shell_timeout(timeout_s), max_output_bytes=1_000_000)
+    result = await run_shell(
+        f"{quote_shell_argument(get_settings().python_bin)} {quote_shell_argument(str(path))}",
+        cwd=cwd,
+        timeout_s=public_run_shell_timeout(timeout_s),
+        max_output_bytes=1_000_000,
+    )
     return {**result.model_dump(), "script_path": relative_display(path)}

--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -70,6 +70,7 @@ from .shell_ops import (
     list_shells,
     public_run_shell,
     public_run_shell_timeout,
+    quote_shell_argument,
     read_shell,
     run_shell,
     send_shell,
@@ -81,6 +82,7 @@ from .transfer_ops import (
     transfer_alloc_temp_path,
     transfer_begin_write,
     transfer_finish_write,
+    transfer_mark_complete_write,
     transfer_pack_dir,
     transfer_read_chunk,
     transfer_stat,
@@ -98,9 +100,31 @@ REMOTE_WORKER_BUNDLE_PATH = "/remote/worker-bundle.tgz"
 # controller's Python ABI.
 REMOTE_WORKER_DISTRIBUTIONS: tuple[str, ...] = ()
 REMOTE_WORKER_REGISTRY_FILE_NAME = "remote-workers.json"
+REMOTE_WORKER_REGISTRY_BACKUP_FILE_NAME = "remote-workers.json.bak"
 REMOTE_WORKER_IDENTITY_FILE_NAME = "identity.json"
 MAX_REMOTE_INVITES = 1_024
 MAX_REMOTE_MACHINE_NAME_LENGTH = 128
+REMOTE_NON_CANCELLABLE_WORKER_TOOLS = frozenset(
+    {
+        "write_file",
+        "edit_file",
+        "multi_edit_file",
+        "delete_file_or_dir",
+        "human_file_action",
+        "transfer_begin_write",
+        "transfer_write_chunk",
+        "transfer_finish_write",
+        "transfer_abort_write",
+        "transfer_pack_dir",
+        "transfer_unpack_archive",
+        "transfer_upload_url",
+        "transfer_download_url",
+    }
+)
+
+
+class RemoteJobCancelled(RuntimeError):
+    pass
 
 
 class WorkerHttpError(RuntimeError):
@@ -210,6 +234,7 @@ class RemoteManager:
         self.pending: dict[str, asyncio.Future[dict[str, Any]]] = {}
         self.pending_machines: dict[str, str] = {}
         self.cancelled_jobs: dict[str, float] = {}
+        self.claimed_jobs: set[str] = set()
         self._lock = asyncio.Lock()
         self._state_lock = threading.RLock()
         self._registry_loaded = False
@@ -217,20 +242,57 @@ class RemoteManager:
     def _registry_path(self) -> Path:
         return get_settings().state_dir / REMOTE_WORKER_REGISTRY_FILE_NAME
 
+    def _registry_backup_path(self) -> Path:
+        return get_settings().state_dir / REMOTE_WORKER_REGISTRY_BACKUP_FILE_NAME
+
+    @staticmethod
+    def _read_registry(path: Path) -> list[dict[str, Any]]:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict) or data.get("version") != 1:
+            raise ValueError(f"unsupported or invalid remote worker registry: {path}")
+        rows = data.get("workers")
+        if not isinstance(rows, list):
+            raise ValueError(f"remote worker registry workers field is invalid: {path}")
+        return [item for item in rows if isinstance(item, dict)]
+
     def _load_registry_unlocked(self) -> None:
         if self._registry_loaded:
             return
-        self._registry_loaded = True
         path = self._registry_path()
-        if not path.exists():
+        backup_path = self._registry_backup_path()
+        if not path.exists() and not backup_path.exists():
+            self._registry_loaded = True
             return
+        rows: list[dict[str, Any]] | None = None
+        main_error: Exception | None = None
+        recovered_from_backup = False
         try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-        except Exception:
-            return
-        rows = data.get("workers") if isinstance(data, dict) else None
-        if not isinstance(rows, list):
-            return
+            if path.exists():
+                rows = self._read_registry(path)
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            main_error = exc
+            audit("remote_worker_registry_unreadable", path=str(path), error=repr(exc))
+        if rows is None and backup_path.exists():
+            try:
+                rows = self._read_registry(backup_path)
+            except (OSError, ValueError, json.JSONDecodeError) as exc:
+                audit(
+                    "remote_worker_registry_backup_unreadable",
+                    path=str(backup_path),
+                    error=repr(exc),
+                )
+            else:
+                recovered_from_backup = True
+                audit(
+                    "remote_worker_registry_recovered",
+                    path=str(path),
+                    backup_path=str(backup_path),
+                )
+        if rows is None:
+            raise RuntimeError(
+                "Remote worker registry is unreadable and no valid backup is available; "
+                "refusing to reset it"
+            ) from main_error
         for item in rows:
             if not isinstance(item, dict):
                 continue
@@ -249,9 +311,13 @@ class RemoteManager:
                 info=dict(item.get("info") or {}),
             )
             self.tokens[access] = name
+        self._registry_loaded = True
+        if recovered_from_backup:
+            self._save_registry_unlocked()
 
     def _save_registry_unlocked(self) -> None:
         path = self._registry_path()
+        backup_path = self._registry_backup_path()
         path.parent.mkdir(parents=True, exist_ok=True)
         data = {
             "version": 1,
@@ -267,11 +333,21 @@ class RemoteManager:
                 for worker in sorted(self.workers.values(), key=lambda item: item.name)
             ],
         }
-        tmp_path = path.with_name(path.name + ".tmp")
-        tmp_path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
-        with contextlib.suppress(OSError):
-            tmp_path.chmod(0o600)
-        tmp_path.replace(path)
+        payload = json.dumps(data, indent=2, sort_keys=True)
+        tmp_path = path.with_name(path.name + f".{uuid.uuid4().hex}.tmp")
+        backup_tmp_path = backup_path.with_name(
+            backup_path.name + f".{uuid.uuid4().hex}.tmp"
+        )
+        try:
+            for temporary in (tmp_path, backup_tmp_path):
+                temporary.write_text(payload, encoding="utf-8")
+                with contextlib.suppress(OSError):
+                    temporary.chmod(0o600)
+            os.replace(tmp_path, path)
+            os.replace(backup_tmp_path, backup_path)
+        finally:
+            tmp_path.unlink(missing_ok=True)
+            backup_tmp_path.unlink(missing_ok=True)
 
     def _join_url(self, base_url: str | None = None) -> str:
         settings = get_settings()
@@ -416,15 +492,26 @@ class RemoteManager:
             oldest = next(iter(self.cancelled_jobs))
             self.cancelled_jobs.pop(oldest, None)
 
+    def _cancel_job_locked(self, job_id: str) -> None:
+        future = self.pending.pop(job_id, None)
+        self.pending_machines.pop(job_id, None)
+        self.claimed_jobs.discard(job_id)
+        now = _utc()
+        self.cancelled_jobs[job_id] = now
+        self._prune_cancelled_jobs_locked(now)
+        if future and not future.done():
+            future.cancel()
+
     def _cancel_job(self, job_id: str) -> None:
         with self._state_lock:
-            future = self.pending.pop(job_id, None)
-            self.pending_machines.pop(job_id, None)
-            now = _utc()
-            self.cancelled_jobs[job_id] = now
-            self._prune_cancelled_jobs_locked(now)
-            if future and not future.done():
-                future.cancel()
+            self._cancel_job_locked(job_id)
+
+    def _cancel_job_if_unclaimed(self, job_id: str) -> bool:
+        with self._state_lock:
+            if job_id in self.claimed_jobs:
+                return False
+            self._cancel_job_locked(job_id)
+            return True
 
     async def poll(self, token: str) -> dict[str, Any]:
         worker = self._worker_by_token(token)
@@ -447,15 +534,24 @@ class RemoteManager:
                 if job_id in self.cancelled_jobs:
                     self.cancelled_jobs.pop(job_id, None)
                     continue
+                self.claimed_jobs.add(job_id)
             return {"job": job}
 
-    async def heartbeat(self, token: str) -> dict[str, Any]:
+    async def heartbeat(
+        self, token: str, payload: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
         worker = self._worker_by_token(token)
+        job_id = str((payload or {}).get("job_id") or "")
         with self._state_lock:
             worker.status = "online"
             worker.last_seen = _utc()
             name = worker.name
-        return {"accepted": True, "name": name}
+            self._prune_cancelled_jobs_locked()
+            cancelled = bool(job_id and job_id in self.cancelled_jobs)
+        result = {"accepted": not cancelled, "name": name}
+        if cancelled:
+            result["cancelled"] = True
+        return result
 
     async def submit_result(self, token: str, payload: dict[str, Any]) -> dict[str, Any]:
         worker = self._worker_by_token(token)
@@ -477,9 +573,11 @@ class RemoteManager:
                 )
             if assigned_machine is None:
                 self.cancelled_jobs.pop(job_id, None)
+                self.claimed_jobs.discard(job_id)
                 return {"accepted": False}
             self.pending_machines.pop(job_id, None)
             self.cancelled_jobs.pop(job_id, None)
+            self.claimed_jobs.discard(job_id)
             future = self.pending.pop(job_id, None)
             if future and not future.done():
                 future.set_result(payload)
@@ -519,18 +617,46 @@ class RemoteManager:
                     "expires_at": _utc() + effective_timeout,
                 }
             )
+        preserve_pending = False
         try:
-            result = await asyncio.wait_for(future, timeout=effective_timeout)
+            result = await asyncio.wait_for(
+                asyncio.shield(future), timeout=effective_timeout
+            )
         except TimeoutError as exc:
-            self._cancel_job(job_id)
-            raise TimeoutError(f"remote job timed out: {tool} on {machine}") from exc
+            if tool in REMOTE_NON_CANCELLABLE_WORKER_TOOLS:
+                cancelled = self._cancel_job_if_unclaimed(job_id)
+                if not cancelled:
+                    result = await future
+                else:
+                    raise TimeoutError(
+                        f"remote job timed out: {tool} on {machine}"
+                    ) from exc
+            else:
+                self._cancel_job(job_id)
+                raise TimeoutError(f"remote job timed out: {tool} on {machine}") from exc
         except asyncio.CancelledError:
-            self._cancel_job(job_id)
+            claimed_mutation = False
+            if tool in REMOTE_NON_CANCELLABLE_WORKER_TOOLS:
+                claimed_mutation = not self._cancel_job_if_unclaimed(job_id)
+            if claimed_mutation:
+                preserve_pending = True
+
+                def cleanup(_future: asyncio.Future[dict[str, Any]]) -> None:
+                    with self._state_lock:
+                        self.pending.pop(job_id, None)
+                        self.pending_machines.pop(job_id, None)
+                        self.claimed_jobs.discard(job_id)
+
+                future.add_done_callback(cleanup)
+            elif tool not in REMOTE_NON_CANCELLABLE_WORKER_TOOLS:
+                self._cancel_job(job_id)
             raise
         finally:
-            with self._state_lock:
-                self.pending.pop(job_id, None)
-                self.pending_machines.pop(job_id, None)
+            if not preserve_pending:
+                with self._state_lock:
+                    self.pending.pop(job_id, None)
+                    self.pending_machines.pop(job_id, None)
+                    self.claimed_jobs.discard(job_id)
         if not result.get("ok", False):
             return _ok(
                 {
@@ -758,7 +884,13 @@ async def heartbeat_endpoint(request: Any):  # noqa: ANN201
     from starlette.responses import JSONResponse
 
     try:
-        return JSONResponse(_ok(await remote_manager().heartbeat(_bearer_token(request))))
+        return JSONResponse(
+            _ok(
+                await remote_manager().heartbeat(
+                    _bearer_token(request), await request.json()
+                )
+            )
+        )
     except Exception as exc:
         return _error(str(exc), type(exc).__name__, 401)
 
@@ -832,7 +964,10 @@ async def _apply_patch_text(patch: str, cwd: str = ".") -> dict[str, Any]:
     patch_path.parent.mkdir(parents=True, exist_ok=True)
     await _to_thread(patch_path.write_text, patch, encoding="utf-8")
     result = await run_shell(
-        f"git apply --check {shlex.quote(str(patch_path))} && git apply {shlex.quote(str(patch_path))}",
+        f"{quote_shell_argument(get_settings().git_bin)} apply --check "
+        f"{quote_shell_argument(str(patch_path))} && "
+        f"{quote_shell_argument(get_settings().git_bin)} apply "
+        f"{quote_shell_argument(str(patch_path))}",
         cwd=cwd,
         timeout_s=60,
         max_output_bytes=500_000,
@@ -847,7 +982,8 @@ async def _run_python(code: str, cwd: str = ".", timeout_s: int = 60) -> dict[st
     script.parent.mkdir(parents=True, exist_ok=True)
     await _to_thread(script.write_text, code, encoding="utf-8")
     result = await run_shell(
-        f"python3 {shlex.quote(str(script))}",
+        f"{quote_shell_argument(get_settings().python_bin)} "
+        f"{quote_shell_argument(str(script))}",
         cwd=cwd,
         timeout_s=public_run_shell_timeout(timeout_s),
         max_output_bytes=1_000_000,
@@ -1024,6 +1160,7 @@ def _worker_download_url(
             raise RuntimeError(
                 f"stream download failed with curl exit {completed.returncode}: {detail}"
             )
+        transfer_mark_complete_write(path, begin["transfer_id"])
         finish = transfer_finish_write(
             path,
             begin["transfer_id"],
@@ -1055,8 +1192,11 @@ async def _execute_worker_tool_inner(tool: str, args: dict[str, Any]) -> Any:
     if tool not in REMOTE_WORKER_TOOL_NAMES:
         raise ValueError(f"unsupported remote worker tool: {tool}")
     if tool == "environment_info":
+        python = quote_shell_argument(get_settings().python_bin)
+        git = quote_shell_argument(get_settings().git_bin)
         result = await run_shell(
-            "uname -a; echo '---'; id; echo '---'; pwd; echo '---'; python3 --version; git --version",
+            f"uname -a; echo '---'; id; echo '---'; pwd; echo '---'; "
+            f"{python} --version; {git} --version",
             cwd=".",
             timeout_s=10,
         )
@@ -1558,21 +1698,28 @@ async def _execute_worker_job_with_heartbeat(
     heartbeat_interval_s: float,
 ) -> Any:
     task = asyncio.create_task(execute_worker_tool(job["tool"], dict(job.get("args") or {})))
+    cancelled_by_controller = False
 
     async def heartbeat_loop() -> None:
+        nonlocal cancelled_by_controller
         interval = max(0.01, heartbeat_interval_s)
         while not task.done():
             await asyncio.sleep(interval)
             if task.done():
                 return
             try:
-                await asyncio.to_thread(
+                response = await asyncio.to_thread(
                     _worker_post_json,
                     f"{server}{REMOTE_API_PREFIX}/heartbeat",
-                    {},
+                    {"job_id": job.get("id")},
                     headers,
                     30,
                 )
+                data = response.get("data", {}) if isinstance(response, dict) else {}
+                if data.get("cancelled"):
+                    cancelled_by_controller = True
+                    task.cancel()
+                    return
             except Exception as exc:  # noqa: BLE001
                 if not _worker_error_is_retryable(exc):
                     return
@@ -1581,6 +1728,10 @@ async def _execute_worker_job_with_heartbeat(
     heartbeat = asyncio.create_task(heartbeat_loop())
     try:
         return await task
+    except asyncio.CancelledError as exc:
+        if cancelled_by_controller:
+            raise RemoteJobCancelled("remote job was cancelled by the controller") from exc
+        raise
     finally:
         heartbeat.cancel()
         await asyncio.gather(heartbeat, return_exceptions=True)

--- a/src/local_shell_mcp/remote_transfer.py
+++ b/src/local_shell_mcp/remote_transfer.py
@@ -44,6 +44,8 @@ class _TransferTicket:
     overwrite: bool
     created_at: float
     expires_at: float
+    display_path: str | None = None
+    cleanup_path: str | None = None
     claimed: bool = False
 
 
@@ -84,11 +86,20 @@ def _validate_expected(expected_bytes: int, expected_sha256: str) -> tuple[int, 
     return size, digest
 
 
+def _cleanup_ticket_file(ticket: _TransferTicket) -> None:
+    if not ticket.cleanup_path:
+        return
+    with contextlib.suppress(OSError):
+        Path(ticket.cleanup_path).unlink(missing_ok=True)
+
+
 def _prune_locked(now: float | None = None) -> None:
     current = _now() if now is None else now
     for token, ticket in list(_TICKETS.items()):
         if ticket.expires_at <= current:
-            _TICKETS.pop(token, None)
+            removed = _TICKETS.pop(token, None)
+            if removed is not None:
+                _cleanup_ticket_file(removed)
 
 
 def _create_ticket(
@@ -97,9 +108,13 @@ def _create_ticket(
     expected_bytes: int,
     expected_sha256: str,
     overwrite: bool,
+    *,
+    token: str | None = None,
+    display_path: Path | None = None,
+    cleanup_path: Path | None = None,
 ) -> dict[str, Any]:
     size, digest = _validate_expected(expected_bytes, expected_sha256)
-    token = secrets.token_urlsafe(32)
+    token = token or secrets.token_urlsafe(32)
     now = _now()
     ticket = _TransferTicket(
         token=token,
@@ -110,6 +125,8 @@ def _create_ticket(
         overwrite=bool(overwrite),
         created_at=now,
         expires_at=now + _ticket_ttl_s(),
+        display_path=str(display_path or path),
+        cleanup_path=str(cleanup_path) if cleanup_path is not None else None,
     )
     with _TICKET_LOCK:
         _prune_locked(now)
@@ -117,14 +134,14 @@ def _create_ticket(
     audit(
         "remote_transfer_ticket_created",
         direction=direction,
-        path=relative_display(path),
+        path=relative_display(Path(ticket.display_path or ticket.path)),
         bytes=size,
         token_id=_token_id(token),
     )
     return {
         "token": token,
         "url": f"{_public_base_url()}{REMOTE_TRANSFER_PREFIX}/{direction}/{token}",
-        "path": relative_display(path),
+        "path": relative_display(Path(ticket.display_path or ticket.path)),
         "bytes": size,
         "sha256": digest,
         "expires_at": ticket.expires_at,
@@ -141,21 +158,91 @@ def create_upload_ticket(
     return _create_ticket("upload", destination, expected_bytes, expected_sha256, overwrite)
 
 
+def _download_snapshot_path(token: str) -> Path:
+    directory = get_settings().state_dir / "remote-transfers"
+    directory.mkdir(parents=True, exist_ok=True)
+    with contextlib.suppress(OSError):
+        directory.chmod(0o700)
+    return directory / f"{hashlib.sha256(token.encode('utf-8')).hexdigest()}.bin"
+
+
+def _create_download_snapshot(
+    source: Path, token: str, expected_bytes: int, expected_sha256: str
+) -> Path:
+    snapshot = _download_snapshot_path(token)
+    temporary = snapshot.with_name(snapshot.name + f".{secrets.token_hex(8)}.tmp")
+    digest = hashlib.sha256()
+    try:
+        with source.open("rb") as source_handle, temporary.open("xb") as output:
+            before = os.fstat(source_handle.fileno())
+            if before.st_size != expected_bytes:
+                raise ValueError(
+                    f"size mismatch: expected {expected_bytes}, got {before.st_size}"
+                )
+            while chunk := source_handle.read(_TRANSFER_CHUNK_BYTES):
+                digest.update(chunk)
+                output.write(chunk)
+            output.flush()
+            os.fsync(output.fileno())
+            after = os.fstat(source_handle.fileno())
+            identity_before = (
+                before.st_dev,
+                before.st_ino,
+                before.st_size,
+                before.st_mtime_ns,
+                before.st_ctime_ns,
+            )
+            identity_after = (
+                after.st_dev,
+                after.st_ino,
+                after.st_size,
+                after.st_mtime_ns,
+                after.st_ctime_ns,
+            )
+            if identity_before != identity_after:
+                raise RuntimeError("source changed while creating remote transfer snapshot")
+        if digest.hexdigest() != expected_sha256:
+            raise ValueError("file sha256 mismatch")
+        with contextlib.suppress(OSError):
+            temporary.chmod(0o600)
+        os.replace(temporary, snapshot)
+        return snapshot
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
 def create_download_ticket(
     source_path: str,
     expected_bytes: int,
     expected_sha256: str,
 ) -> dict[str, Any]:
+    size, digest = _validate_expected(expected_bytes, expected_sha256)
     source = resolve_path(source_path, must_exist=True)
     if not source.is_file():
         raise ValueError(f"source is not a file: {source_path}")
-    return _create_ticket("download", source, expected_bytes, expected_sha256, False)
+    token = secrets.token_urlsafe(32)
+    snapshot = _create_download_snapshot(source, token, size, digest)
+    try:
+        return _create_ticket(
+            "download",
+            snapshot,
+            size,
+            digest,
+            False,
+            token=token,
+            display_path=source,
+            cleanup_path=snapshot,
+        )
+    except Exception:
+        snapshot.unlink(missing_ok=True)
+        raise
 
 
 def revoke_transfer_ticket(token: str) -> dict[str, Any]:
     with _TICKET_LOCK:
         removed = _TICKETS.pop(token, None)
     if removed is not None:
+        _cleanup_ticket_file(removed)
         audit(
             "remote_transfer_ticket_revoked",
             direction=removed.direction,
@@ -189,6 +276,7 @@ def _complete_ticket(token: str) -> None:
     with _TICKET_LOCK:
         ticket = _TICKETS.pop(token, None)
     if ticket is not None:
+        _cleanup_ticket_file(ticket)
         audit(
             "remote_transfer_completed",
             direction=ticket.direction,
@@ -362,7 +450,9 @@ async def download_endpoint(request: Request):  # noqa: ANN201
         headers={
             "Content-Length": str(ticket.expected_bytes),
             "X-Content-SHA256": ticket.expected_sha256,
-            "Content-Disposition": _content_disposition(path.name),
+            "Content-Disposition": _content_disposition(
+                Path(ticket.display_path or path).name
+            ),
             "Cache-Control": "no-store",
         },
     )

--- a/src/local_shell_mcp/settings.py
+++ b/src/local_shell_mcp/settings.py
@@ -39,6 +39,76 @@ _WEAK_OAUTH_SECRET_VALUES = {
 }
 _OAUTH_SECRET_THREAD_LOCK = threading.Lock()
 
+_POSITIVE_INTEGER_SETTINGS = (
+    "port",
+    "default_timeout_s",
+    "max_timeout_s",
+    "max_output_bytes",
+    "max_file_read_bytes",
+    "max_file_write_bytes",
+    "max_grep_results",
+    "max_directory_entries",
+    "max_glob_results",
+    "max_tree_entries",
+    "max_skills",
+    "max_skill_related_files",
+    "max_skill_scan_entries",
+    "max_skill_path_bytes",
+    "max_read_many_files",
+    "max_read_many_total_bytes",
+    "max_todos",
+    "max_todo_bytes",
+    "max_http_request_bytes",
+    "max_job_log_bytes",
+    "max_audit_tail_bytes",
+    "max_audit_log_bytes",
+    "max_tmp_files",
+    "max_tmp_bytes",
+    "max_transfer_archive_entries",
+    "max_transfer_unpacked_bytes",
+    "max_concurrent_commands",
+    "max_tmux_sessions",
+    "ui_terminal_idle_timeout_s",
+    "ui_terminal_max_sessions",
+    "ui_remote_request_timeout_s",
+    "file_download_default_ttl_s",
+    "file_download_max_ttl_s",
+    "remote_invite_ttl_s",
+    "remote_poll_timeout_s",
+    "remote_job_timeout_s",
+    "remote_max_pending_jobs",
+    "remote_cancelled_job_ttl_s",
+    "mcp_session_idle_timeout_s",
+    "mcp_max_sessions",
+    "oauth_code_ttl_s",
+)
+
+_NONNEGATIVE_INTEGER_SETTINGS = (
+    "max_jobs",
+    "file_download_default_max_downloads",
+    "file_download_max_file_bytes",
+    "oauth_access_token_ttl_s",
+)
+
+
+def _validate_numeric_settings(settings: Settings) -> None:
+    for name in _POSITIVE_INTEGER_SETTINGS:
+        value = int(getattr(settings, name))
+        if value <= 0:
+            raise ValueError(f"{name} must be greater than zero")
+    for name in _NONNEGATIVE_INTEGER_SETTINGS:
+        value = int(getattr(settings, name))
+        if value < 0:
+            raise ValueError(f"{name} must be greater than or equal to zero")
+    if int(settings.port) > 65535:
+        raise ValueError("port must be <= 65535")
+    if settings.max_timeout_s < settings.default_timeout_s:
+        raise ValueError("max_timeout_s must be >= default_timeout_s")
+    if settings.file_download_max_ttl_s < settings.file_download_default_ttl_s:
+        raise ValueError(
+            "file_download_max_ttl_s must be >= file_download_default_ttl_s"
+        )
+
 
 def _matches_default_path(value: Path, default: Path) -> bool:
     """Match a default path before or after platform-specific normalization."""
@@ -54,6 +124,10 @@ def default_shell_executable() -> str:
     if os.name == "nt":
         return "power" + "shell.exe"
     return "/bin/bash"
+
+
+def default_python_executable() -> str:
+    return "python.exe" if os.name == "nt" else "python3"
 
 
 def _replace_settings(settings: Settings, **updates: Any) -> Settings:
@@ -309,7 +383,7 @@ if _PYDANTIC_AVAILABLE:
         tmux_bin: str = "tmux"
         rg_bin: str = "rg"
         git_bin: str = "git"
-        python_bin: str = "python3"
+        python_bin: str = Field(default_factory=default_python_executable)
 
         # Authentication. OAuth is the default for ChatGPT custom connectors.
         auth_mode: Literal["none", "oauth"] = "oauth"
@@ -382,6 +456,7 @@ if _PYDANTIC_AVAILABLE:
 
         @model_validator(mode="after")
         def disable_builtin_restrictions_in_full_container_mode(self) -> Settings:
+            _validate_numeric_settings(self)
             if self.allow_full_container:
                 self.command_denylist = []
                 self.path_denylist = []
@@ -505,7 +580,7 @@ else:
         tmux_bin: str = "tmux"
         rg_bin: str = "rg"
         git_bin: str = "git"
-        python_bin: str = "python3"
+        python_bin: str = field(default_factory=default_python_executable)
 
         auth_mode: Literal["none", "oauth"] = "oauth"
         auth_bypass_localhost: bool = True
@@ -566,6 +641,7 @@ else:
                     ).resolve(),
                 )
             self.ui_path = normalize_ui_path(self.ui_path)
+            _validate_numeric_settings(self)
             if self.allow_full_container:
                 self.command_denylist = []
                 self.path_denylist = []

--- a/src/local_shell_mcp/shell_environment.py
+++ b/src/local_shell_mcp/shell_environment.py
@@ -26,10 +26,12 @@ def _restore_or_remove_loader_var(env: dict[str, str], name: str) -> None:
         env.pop(name, None)
 
 
-def subprocess_env() -> dict[str, str]:
-    settings = get_settings()
-    blocked = set(settings.shell_env_blocklist)
-    prefixes = tuple(settings.shell_env_blocked_prefixes)
+def filtered_subprocess_env(
+    blocked_names: list[str] | tuple[str, ...],
+    blocked_prefixes: list[str] | tuple[str, ...],
+) -> dict[str, str]:
+    blocked = set(blocked_names)
+    prefixes = tuple(blocked_prefixes)
     env = {
         key: value
         for key, value in os.environ.items()
@@ -39,3 +41,11 @@ def subprocess_env() -> dict[str, str]:
         for name in FROZEN_LOADER_ENV_VARS:
             _restore_or_remove_loader_var(env, name)
     return env
+
+
+def subprocess_env() -> dict[str, str]:
+    settings = get_settings()
+    return filtered_subprocess_env(
+        settings.shell_env_blocklist,
+        settings.shell_env_blocked_prefixes,
+    )

--- a/src/local_shell_mcp/shell_ops.py
+++ b/src/local_shell_mcp/shell_ops.py
@@ -5,6 +5,7 @@ import os
 import re
 import shlex
 import signal
+import subprocess
 import sys
 import threading
 import time
@@ -72,8 +73,9 @@ class NativeShellSession:
 
 def check_command_policy(command: str) -> None:
     settings = get_settings()
+    normalized = command.casefold()
     for denied in settings.command_denylist:
-        if denied and denied in command:
+        if denied and denied.casefold() in normalized:
             raise PermissionError(f"Command contains denylisted fragment: {denied!r}")
 
 
@@ -156,6 +158,16 @@ def _shell_start_lock() -> asyncio.Lock:
 
 def _shell_program_name(shell: str) -> str:
     return Path(shell).name.lower()
+
+
+def quote_shell_argument(value: str) -> str:
+    name = _shell_program_name(get_settings().shell_executable)
+    powershell = "power" + "shell"
+    if name in {powershell + ".exe", powershell, "pwsh.exe", "pwsh"}:
+        return "'" + value.replace("'", "''") + "'"
+    if name in {"cmd.exe", "cmd"}:
+        return subprocess.list2cmdline([value])
+    return shlex.quote(value)
 
 
 def _shell_command_args(command: str) -> list[str]:
@@ -361,7 +373,8 @@ async def public_run_shell(command: str, cwd: str = ".", timeout_s: int | None =
 
 def _tmux_session_name(name: str | None = None) -> str:
     base = name or f"mcp-{uuid.uuid4().hex[:8]}"
-    return re.sub(r"[^A-Za-z0-9_.-]", "-", base)[:64]
+    cleaned = re.sub(r"[^A-Za-z0-9_.-]", "-", base.strip())[:64].strip(".-")
+    return cleaned or f"mcp-{uuid.uuid4().hex[:8]}"
 
 
 async def tmux(args: list[str], timeout_s: int = 10) -> CommandResult:

--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -2,16 +2,17 @@ from __future__ import annotations
 
 import asyncio
 import json
-import shlex
 import subprocess
 import uuid
 from contextlib import suppress
+from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 from mcp.types import ToolAnnotations
+from pathspec.gitignore import GitIgnoreSpec
 
 from .audit import audit
 from .auth import require_current_scopes
@@ -67,6 +68,7 @@ from .shell_ops import (
     list_shells,
     public_run_shell,
     public_run_shell_timeout,
+    quote_shell_argument,
     read_shell,
     run_shell,
     send_shell,
@@ -80,10 +82,16 @@ from .skill_ops import (
 from .tmux_helper import persistent_shell_backend_info
 from .todo_ops import todo_read, todo_write
 from .transfer_ops import (
+    normalize_chunk_size,
+    transfer_abort_write,
     transfer_alloc_temp_path,
+    transfer_begin_write,
+    transfer_finish_write,
     transfer_pack_dir,
+    transfer_read_chunk,
     transfer_stat,
     transfer_unpack_archive,
+    transfer_write_chunk,
 )
 from .version import version_info as get_version_info
 
@@ -138,8 +146,14 @@ async def _apply_patch_text(patch: str, cwd: str = ".") -> dict:
     patch_path = temp_dir() / f"patch-{uuid.uuid4().hex}.diff"
     patch_path.parent.mkdir(parents=True, exist_ok=True)
     await _to_thread(patch_path.write_text, patch, encoding="utf-8")
-    quoted = shlex.quote(str(patch_path))
-    result = await run_shell(f"git apply --check {quoted} && git apply {quoted}", cwd=cwd, timeout_s=60, max_output_bytes=500_000)
+    quoted = quote_shell_argument(str(patch_path))
+    git = quote_shell_argument(get_settings().git_bin)
+    result = await run_shell(
+        f"{git} apply --check {quoted} && {git} apply {quoted}",
+        cwd=cwd,
+        timeout_s=60,
+        max_output_bytes=500_000,
+    )
     return {**result.model_dump(), "patch_path": relative_display(patch_path)}
 
 
@@ -149,7 +163,13 @@ async def _run_python(code: str, cwd: str = ".", timeout_s: int = 60) -> dict:
     path = temp_dir() / f"script-{uuid.uuid4().hex}.py"
     path.parent.mkdir(parents=True, exist_ok=True)
     await _to_thread(path.write_text, code, encoding="utf-8")
-    result = await run_shell(f"python3 {shlex.quote(str(path))}", cwd=cwd, timeout_s=public_run_shell_timeout(timeout_s), max_output_bytes=1_000_000)
+    python = quote_shell_argument(get_settings().python_bin)
+    result = await run_shell(
+        f"{python} {quote_shell_argument(str(path))}",
+        cwd=cwd,
+        timeout_s=public_run_shell_timeout(timeout_s),
+        max_output_bytes=1_000_000,
+    )
     return {**result.model_dump(), "script_path": relative_display(path)}
 
 
@@ -196,6 +216,31 @@ MCP_INSTRUCTIONS = (
 
 class PublicToolTimeoutError(TimeoutError):
     pass
+
+
+NON_CANCELLABLE_TOOL_NAMES = frozenset(
+    {
+        "create_file_link",
+        "revoke_file_link",
+        "write_file",
+        "edit_file",
+        "multi_edit_file",
+        "delete_file_or_dir",
+        "apply_patch",
+        "todo_write_tool",
+        "remote_write_file",
+        "remote_edit_file",
+        "remote_multi_edit_file",
+        "remote_delete_file_or_dir",
+        "remote_copy_file",
+        "remote_copy_dir",
+        "remote_pull_file",
+        "remote_push_file",
+        "remote_pull_dir",
+        "remote_push_dir",
+        "remote_apply_patch",
+    }
+)
 
 
 def _security_meta(schemes: list[dict[str, Any]]) -> dict[str, Any]:
@@ -350,9 +395,12 @@ def _install_mcp_tool_watchdogs(mcp: FastMCP) -> None:
                 **audit_context,
             )
             try:
-                result = await asyncio.wait_for(
-                    __original(*args, **kwargs), timeout=PUBLIC_TOOL_TIMEOUT_S
-                )
+                if __tool_name in NON_CANCELLABLE_TOOL_NAMES:
+                    result = await __original(*args, **kwargs)
+                else:
+                    result = await asyncio.wait_for(
+                        __original(*args, **kwargs), timeout=PUBLIC_TOOL_TIMEOUT_S
+                    )
                 audit("mcp_tool_call_end", tool=__tool_name, ok=True, **audit_context)
                 return result
             except TimeoutError:
@@ -474,6 +522,41 @@ def _read_many_files_sync(
     return {"files": files, "total_content_bytes": total_content_bytes}
 
 
+def _gitignore_spec(
+    directory: Path, cache: dict[Path, GitIgnoreSpec | None]
+) -> GitIgnoreSpec | None:
+    if directory in cache:
+        return cache[directory]
+    path = directory / ".gitignore"
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        spec = None
+    else:
+        spec = GitIgnoreSpec.from_lines(lines)
+    cache[directory] = spec
+    return spec
+
+
+def _fallback_path_is_ignored(
+    path: Path, base: Path, cache: dict[Path, GitIgnoreSpec | None]
+) -> bool:
+    ignored: bool | None = None
+    directories = [base]
+    current = base
+    for part in path.parent.relative_to(base).parts:
+        current = current / part
+        directories.append(current)
+    for directory in directories:
+        spec = _gitignore_spec(directory, cache)
+        if spec is None:
+            continue
+        include = spec.check_file(path.relative_to(directory).as_posix()).include
+        if include is not None:
+            ignored = bool(include)
+    return bool(ignored)
+
+
 def _secret_scan_candidates(base: Any, glob: str | None = None) -> list[Any]:
     settings = get_settings()
     args = [settings.rg_bin, "--files", "--hidden", "--glob", "!.git/**"]
@@ -490,8 +573,11 @@ def _secret_scan_candidates(base: Any, glob: str | None = None) -> list[Any]:
         return [base / line for line in result.stdout.splitlines() if line.strip()]
 
     candidates = []
+    ignore_cache: dict[Path, GitIgnoreSpec | None] = {}
     for path in base.rglob("*"):
         if ".git" in path.parts or not path.is_file():
+            continue
+        if _fallback_path_is_ignored(path, base, ignore_cache):
             continue
         if glob and not path.match(glob):
             continue
@@ -581,39 +667,92 @@ async def _copy_local_file_to_remote(
     overwrite: bool = True,
     chunk_size: int | None = None,
 ) -> dict:
-    del chunk_size
     stat = await _to_thread(transfer_stat, source_path, True)
     if stat.get("type") != "file":
         raise ValueError(f"source is not a file: {source_path}")
-    ticket = create_download_ticket(
-        source_path,
-        stat["size"],
-        stat["sha256"],
-    )
-    try:
-        finish = await _remote_transfer_data(
+    if chunk_size is None:
+        ticket = create_download_ticket(
+            source_path,
+            stat["size"],
+            stat["sha256"],
+        )
+        try:
+            finish = await _remote_transfer_data(
+                dst_machine,
+                "transfer_download_url",
+                {
+                    "url": ticket["url"],
+                    "path": dst_path,
+                    "overwrite": overwrite,
+                    "expected_bytes": stat["size"],
+                    "expected_sha256": stat["sha256"],
+                    "timeout_s": get_settings().remote_job_timeout_s,
+                },
+                get_settings().remote_job_timeout_s,
+            )
+        finally:
+            revoke_transfer_ticket(ticket["token"])
+        chunks = 1
+        effective_chunk_size = stat["size"]
+        transport = "http-stream"
+    else:
+        effective_chunk_size = normalize_chunk_size(chunk_size)
+        begin = await _remote_transfer_data(
             dst_machine,
-            "transfer_download_url",
+            "transfer_begin_write",
             {
-                "url": ticket["url"],
                 "path": dst_path,
                 "overwrite": overwrite,
                 "expected_bytes": stat["size"],
-                "expected_sha256": stat["sha256"],
-                "timeout_s": get_settings().remote_job_timeout_s,
             },
-            get_settings().remote_job_timeout_s,
         )
-    finally:
-        revoke_transfer_ticket(ticket["token"])
+        offset = 0
+        chunks = 0
+        try:
+            while offset < stat["size"]:
+                chunk = await _to_thread(
+                    transfer_read_chunk, source_path, offset, effective_chunk_size
+                )
+                await _remote_transfer_data(
+                    dst_machine,
+                    "transfer_write_chunk",
+                    {
+                        "path": dst_path,
+                        "transfer_id": begin["transfer_id"],
+                        "offset": offset,
+                        "data_b64": chunk["data_b64"],
+                        "expected_sha256": chunk["sha256"],
+                    },
+                )
+                offset += chunk["bytes"]
+                chunks += 1
+            finish = await _remote_transfer_data(
+                dst_machine,
+                "transfer_finish_write",
+                {
+                    "path": dst_path,
+                    "transfer_id": begin["transfer_id"],
+                    "expected_bytes": stat["size"],
+                    "expected_sha256": stat["sha256"],
+                },
+            )
+        except BaseException:
+            with suppress(Exception):
+                await _remote_transfer_data(
+                    dst_machine,
+                    "transfer_abort_write",
+                    {"path": dst_path, "transfer_id": begin["transfer_id"]},
+                )
+            raise
+        transport = "mcp-chunks"
     return {
         "source": {"machine": "controller", "path": stat["path"]},
         "destination": {"machine": dst_machine, "path": finish["path"]},
         "bytes": stat["size"],
         "sha256": stat.get("sha256"),
-        "chunks": 1,
-        "chunk_size": stat["size"],
-        "transport": "http-stream",
+        "chunks": chunks,
+        "chunk_size": effective_chunk_size,
+        "transport": transport,
     }
 
 
@@ -624,41 +763,86 @@ async def _copy_remote_file_to_local(
     overwrite: bool = True,
     chunk_size: int | None = None,
 ) -> dict:
-    del chunk_size
     stat = await _remote_transfer_data(
         src_machine, "transfer_stat", {"path": src_path, "sha256": True}
     )
     if stat.get("type") != "file":
         raise ValueError(f"source is not a file: {src_path}")
-    ticket = create_upload_ticket(
-        destination_path,
-        stat["size"],
-        stat["sha256"],
-        overwrite,
-    )
-    try:
-        finish = await _remote_transfer_data(
-            src_machine,
-            "transfer_upload_url",
-            {
-                "path": src_path,
-                "url": ticket["url"],
-                "expected_bytes": stat["size"],
-                "expected_sha256": stat["sha256"],
-                "timeout_s": get_settings().remote_job_timeout_s,
-            },
-            get_settings().remote_job_timeout_s,
+    if chunk_size is None:
+        ticket = create_upload_ticket(
+            destination_path,
+            stat["size"],
+            stat["sha256"],
+            overwrite,
         )
-    finally:
-        revoke_transfer_ticket(ticket["token"])
+        try:
+            finish = await _remote_transfer_data(
+                src_machine,
+                "transfer_upload_url",
+                {
+                    "path": src_path,
+                    "url": ticket["url"],
+                    "expected_bytes": stat["size"],
+                    "expected_sha256": stat["sha256"],
+                    "timeout_s": get_settings().remote_job_timeout_s,
+                },
+                get_settings().remote_job_timeout_s,
+            )
+        finally:
+            revoke_transfer_ticket(ticket["token"])
+        chunks = 1
+        effective_chunk_size = stat["size"]
+        transport = "http-stream"
+    else:
+        effective_chunk_size = normalize_chunk_size(chunk_size)
+        begin = await _to_thread(
+            transfer_begin_write, destination_path, overwrite, stat["size"]
+        )
+        offset = 0
+        chunks = 0
+        try:
+            while offset < stat["size"]:
+                chunk = await _remote_transfer_data(
+                    src_machine,
+                    "transfer_read_chunk",
+                    {
+                        "path": src_path,
+                        "offset": offset,
+                        "chunk_size": effective_chunk_size,
+                    },
+                )
+                await _to_thread(
+                    transfer_write_chunk,
+                    destination_path,
+                    begin["transfer_id"],
+                    offset,
+                    chunk["data_b64"],
+                    chunk["sha256"],
+                )
+                offset += chunk["bytes"]
+                chunks += 1
+            finish = await _to_thread(
+                transfer_finish_write,
+                destination_path,
+                begin["transfer_id"],
+                stat["size"],
+                stat["sha256"],
+            )
+        except BaseException:
+            with suppress(Exception):
+                await _to_thread(
+                    transfer_abort_write, destination_path, begin["transfer_id"]
+                )
+            raise
+        transport = "mcp-chunks"
     return {
         "source": {"machine": src_machine, "path": stat["path"]},
         "destination": {"machine": "controller", "path": finish["path"]},
         "bytes": stat["size"],
         "sha256": stat.get("sha256"),
-        "chunks": 1,
-        "chunk_size": stat["size"],
-        "transport": "http-stream",
+        "chunks": chunks,
+        "chunk_size": effective_chunk_size,
+        "transport": transport,
     }
 
 
@@ -696,7 +880,11 @@ async def _copy_remote_file_to_remote(
         "sha256": pull["sha256"],
         "chunks": pull["chunks"] + push["chunks"],
         "chunk_size": pull["chunk_size"],
-        "transport": "http-stream-via-controller",
+        "transport": (
+            "mcp-chunks-via-controller"
+            if pull["transport"] == "mcp-chunks" or push["transport"] == "mcp-chunks"
+            else "http-stream-via-controller"
+        ),
     }
 
 
@@ -752,8 +940,12 @@ async def _copy_remote_dir_to_local(
         copy_result = await _copy_remote_file_to_local(
             src_machine, pack["archive_path"], archive["path"], True, chunk_size
         )
-        unpack = await _to_thread(transfer_unpack_archive, archive["path"], destination_path, overwrite, True)
+        unpack = await _to_thread(
+            transfer_unpack_archive, archive["path"], destination_path, overwrite, True
+        )
     finally:
+        with suppress(Exception):
+            delete_path(archive.get("path", ""), False)
         await _remote_cleanup_file(src_machine, pack.get("archive_path", ""))
     return {
         "source": {"machine": src_machine, "path": pack["path"]},
@@ -874,11 +1066,12 @@ def build_mcp() -> FastMCP:
                 seen.add(path)
                 line = match.get("line")
                 suffix = f":{line}" if line else ""
+                resolved = resolve_path(path, must_exist=True)
                 rows.append(
                     {
                         "id": path,
                         "title": f"{path}{suffix}",
-                        "url": f"file:///workspace/{path}",
+                        "url": resolved.as_uri(),
                     }
                 )
             return json.dumps({"results": rows}, ensure_ascii=False)
@@ -893,16 +1086,20 @@ def build_mcp() -> FastMCP:
             data = await _to_thread(read_text, id)
             path = data.get("path") or id
             binary = bool(data.get("binary"))
+            resolved = resolve_path(id, must_exist=True)
             return json.dumps(
                 {
                     "id": path,
                     "title": path,
                     "text": data.get("content") if not binary else data.get("message", "Binary file omitted"),
-                    "url": f"file:///workspace/{path}",
+                    "url": resolved.as_uri(),
                     "metadata": {
                         "source": "workspace",
                         "binary": binary,
                         "bytes": data.get("bytes"),
+                        "bytes_read": data.get("bytes_read"),
+                        "truncated": bool(data.get("truncated", False)),
+                        "truncated_bytes": data.get("truncated_bytes", 0),
                     },
                 },
                 ensure_ascii=False,
@@ -924,7 +1121,14 @@ def build_mcp() -> FastMCP:
     async def environment_info() -> ToolResult:
         """Return workspace, auth, policy, and basic environment information."""
         try:
-            result = await run_shell("uname -a; echo '---'; id; echo '---'; pwd; echo '---'; python3 --version; git --version", cwd=".", timeout_s=10)
+            python = quote_shell_argument(settings.python_bin)
+            git = quote_shell_argument(settings.git_bin)
+            result = await run_shell(
+                f"uname -a; echo '---'; id; echo '---'; pwd; echo '---'; "
+                f"{python} --version; {git} --version",
+                cwd=".",
+                timeout_s=10,
+            )
             return _ok({"settings": safe_settings_dump(settings), "persistent_shell": persistent_shell_backend_info(), "probe": result.model_dump()})
         except Exception as exc:
             return _handled_error(exc)

--- a/src/local_shell_mcp/transfer_ops.py
+++ b/src/local_shell_mcp/transfer_ops.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import os
 import shutil
+import stat
 import tarfile
 import tempfile
 import uuid
@@ -134,6 +135,44 @@ def _read_transfer_metadata(tmp: Path) -> dict[str, Any]:
     return metadata
 
 
+def _received_ranges(metadata: dict[str, Any]) -> list[list[int]]:
+    raw = metadata.get("received_ranges", [])
+    if not isinstance(raw, list):
+        raise ValueError("transfer metadata received_ranges is invalid")
+    ranges: list[list[int]] = []
+    for item in raw:
+        if (
+            not isinstance(item, list)
+            or len(item) != 2
+            or not all(isinstance(value, int) for value in item)
+            or item[0] < 0
+            or item[1] < item[0]
+        ):
+            raise ValueError("transfer metadata received_ranges is invalid")
+        ranges.append([item[0], item[1]])
+    return ranges
+
+
+def _record_received_range(metadata: dict[str, Any], start: int, end: int) -> None:
+    if end < start:
+        raise ValueError("transfer range is invalid")
+    if end == start:
+        return
+    ranges = _received_ranges(metadata)
+    for existing_start, existing_end in ranges:
+        if start < existing_end and end > existing_start:
+            raise ValueError("transfer chunk overlaps previously received data")
+    ranges.append([start, end])
+    ranges.sort()
+    merged: list[list[int]] = []
+    for range_start, range_end in ranges:
+        if merged and merged[-1][1] == range_start:
+            merged[-1][1] = range_end
+        else:
+            merged.append([range_start, range_end])
+    metadata["received_ranges"] = merged
+
+
 def transfer_begin_write(
     path: str, overwrite: bool = True, expected_bytes: int | None = None
 ) -> dict[str, Any]:
@@ -158,6 +197,7 @@ def transfer_begin_write(
                     "destination": str(dst),
                     "overwrite": bool(overwrite),
                     "expected_bytes": expected,
+                    "received_ranges": [],
                 },
             )
         except Exception:
@@ -198,10 +238,12 @@ def transfer_write_chunk(
         expected = metadata.get("expected_bytes")
         if expected is not None and start + len(data) > int(expected):
             raise ValueError("chunk exceeds expected transfer size")
+        _record_received_range(metadata, start, start + len(data))
         with tmp.open("r+b") as fh:
             fh.seek(start)
             fh.write(data)
             fh.flush()
+        _write_transfer_metadata(tmp, metadata)
     return {
         "path": relative_display(dst),
         "temp_path": relative_display(tmp),
@@ -232,16 +274,40 @@ def transfer_write_bytes(
         expected = metadata.get("expected_bytes")
         if expected is not None and start + len(payload) > int(expected):
             raise ValueError("chunk exceeds expected transfer size")
+        _record_received_range(metadata, start, start + len(payload))
         with tmp.open("r+b") as fh:
             fh.seek(start)
             fh.write(payload)
             fh.flush()
+        _write_transfer_metadata(tmp, metadata)
     return {
         "path": relative_display(dst),
         "temp_path": relative_display(tmp),
         "offset": start,
         "bytes": len(payload),
         "sha256": hashlib.sha256(payload).hexdigest(),
+    }
+
+
+def transfer_mark_complete_write(path: str, transfer_id: str) -> dict[str, Any]:
+    """Record that an external sequential writer populated the whole transfer temp file."""
+
+    dst = resolve_path(path, follow_final_symlink=False)
+    tmp = _transfer_temp_path(dst, transfer_id)
+    with _path_lock(tmp):
+        if not tmp.exists():
+            raise FileNotFoundError(str(tmp))
+        metadata = _read_transfer_metadata(tmp)
+        expected = metadata.get("expected_bytes")
+        size = tmp.stat().st_size
+        if expected is not None and size != int(expected):
+            raise ValueError(f"size mismatch: expected {expected}, got {size}")
+        metadata["received_ranges"] = [] if size == 0 else [[0, size]]
+        _write_transfer_metadata(tmp, metadata)
+    return {
+        "path": relative_display(dst),
+        "temp_path": relative_display(tmp),
+        "bytes": size,
     }
 
 
@@ -266,6 +332,11 @@ def transfer_finish_write(
         size = tmp.stat().st_size
         if expected is not None and size != expected:
             raise ValueError(f"size mismatch: expected {expected}, got {size}")
+        received = _received_ranges(metadata)
+        required_size = size if expected is None else expected
+        complete = received == [] if required_size == 0 else received == [[0, required_size]]
+        if not complete:
+            raise ValueError("transfer has missing or non-contiguous data ranges")
         digest = _sha256_file(tmp) if expected_sha256 else None
         if expected_sha256 and digest != expected_sha256:
             raise ValueError("file sha256 mismatch")
@@ -308,7 +379,7 @@ def transfer_alloc_temp_path(suffix: str = ".bin") -> dict[str, Any]:
     return {"path": relative_display(path)}
 
 
-def _assert_no_symlinks(path: Path) -> None:
+def _assert_transferable_tree(path: Path) -> None:
     if path.is_symlink():
         raise ValueError(f"directory transfer does not support symlinks: {relative_display(path)}")
     for child in path.rglob("*"):
@@ -316,14 +387,21 @@ def _assert_no_symlinks(path: Path) -> None:
             raise ValueError(
                 f"directory transfer does not support symlinks: {relative_display(child)}"
             )
+        mode = child.lstat().st_mode
+        if not (stat.S_ISREG(mode) or stat.S_ISDIR(mode)):
+            raise ValueError(
+                f"directory transfer does not support special files: {relative_display(child)}"
+            )
 
 
 def transfer_pack_dir(path: str, compression: str = "gz") -> dict[str, Any]:
     prune_temp_dir()
+    if compression not in {"gz", "none"}:
+        raise ValueError("compression must be 'gz' or 'none'")
     src = resolve_path(path, must_exist=True)
     if not src.is_dir():
         raise NotADirectoryError(str(src))
-    _assert_no_symlinks(src)
+    _assert_transferable_tree(src)
     suffix = ".tar.gz" if compression == "gz" else ".tar"
     mode = "w:gz" if compression == "gz" else "w"
     archive = temp_dir() / f"transfer-pack-{uuid.uuid4().hex}{suffix}"

--- a/tests/test_audit_regressions.py
+++ b/tests/test_audit_regressions.py
@@ -1,0 +1,537 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import io
+import json
+import os
+import time
+from pathlib import Path
+from urllib.parse import urlsplit
+
+import pytest
+from fastapi.testclient import TestClient
+from starlette.applications import Starlette
+from starlette.requests import Request
+
+import local_shell_mcp.http_app as http_app_module
+import local_shell_mcp.human_ui as human_ui
+import local_shell_mcp.jobs as jobs_module
+import local_shell_mcp.playwright_ops as playwright_module
+import local_shell_mcp.remote as remote_module
+import local_shell_mcp.tools as tools_module
+from local_shell_mcp.auth import required_scopes_for_http_tool
+from local_shell_mcp.fs_ops import edit_text, multi_edit_text, resolve_path
+from local_shell_mcp.http_app import build_http_app
+from local_shell_mcp.models import CommandResult
+from local_shell_mcp.remote import RemoteManager, RemoteWorker
+from local_shell_mcp.remote_transfer import create_download_ticket, remote_transfer_routes
+from local_shell_mcp.settings import Settings, get_settings
+from local_shell_mcp.shell_ops import _tmux_session_name, check_command_policy
+from local_shell_mcp.tools import build_mcp
+from local_shell_mcp.transfer_ops import (
+    transfer_abort_write,
+    transfer_begin_write,
+    transfer_finish_write,
+    transfer_pack_dir,
+    transfer_write_chunk,
+)
+
+
+def _configure_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(tmp_path / ".state"))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_AUTH_MODE", "none")
+    get_settings.cache_clear()
+
+
+@pytest.mark.parametrize(
+    "updates",
+    [
+        {"remote_poll_timeout_s": 0},
+        {"file_download_max_ttl_s": -1},
+        {"port": 70000},
+        {"default_timeout_s": 20, "max_timeout_s": 10},
+        {"file_download_default_ttl_s": 20, "file_download_max_ttl_s": 10},
+    ],
+)
+def test_settings_reject_invalid_numeric_ranges(updates):
+    with pytest.raises(ValueError):
+        Settings(**updates)
+
+
+def test_path_policy_uses_components_and_edit_rejects_empty_search(tmp_path, monkeypatch):
+    workspace = tmp_path / "secrets-project"
+    workspace.mkdir()
+    _configure_workspace(workspace, monkeypatch)
+    (workspace / "README.md").write_text("abc", encoding="utf-8")
+    (workspace / ".environment").write_text("safe", encoding="utf-8")
+
+    assert resolve_path("README.md").name == "README.md"
+    assert resolve_path(".environment").name == ".environment"
+
+    (workspace / "secrets").mkdir()
+    (workspace / "secrets" / "value.txt").write_text("hidden", encoding="utf-8")
+    with pytest.raises(PermissionError):
+        resolve_path("secrets/value.txt")
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        edit_text("README.md", "", "Z", True)
+    with pytest.raises(ValueError, match="must not be empty"):
+        multi_edit_text("README.md", [{"old": "", "new": "Z"}])
+    assert (workspace / "README.md").read_text(encoding="utf-8") == "abc"
+
+
+def test_command_policy_is_case_insensitive_and_session_names_never_empty(
+    tmp_path, monkeypatch
+):
+    _configure_workspace(tmp_path, monkeypatch)
+    with pytest.raises(PermissionError, match="shutdown"):
+        check_command_policy("SHUTDOWN /s /t 0")
+    assert _tmux_session_name("   ").startswith("mcp-")
+    assert _tmux_session_name("💥").startswith("mcp-")
+
+
+def test_job_runner_filters_service_environment(tmp_path, monkeypatch):
+    _configure_workspace(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_PRIVATE_VALUE", "blocked")
+    monkeypatch.setenv("DOCKER_HOST", "blocked")
+    monkeypatch.setenv("CLOUDFLARE_TUNNEL_TOKEN", "blocked")
+    monkeypatch.setenv("SAFE_JOB_VALUE", "visible")
+    command_path = tmp_path / "command.txt"
+    log_path = tmp_path / "job.log"
+    status_path = tmp_path / "status.json"
+    command_path.write_text("true", encoding="utf-8")
+    captured = {}
+
+    class FakeProcess:
+        stdout = io.BytesIO(b"")
+
+        def wait(self):
+            return 0
+
+    def fake_popen(args, **kwargs):
+        captured["args"] = args
+        captured["env"] = kwargs["env"]
+        return FakeProcess()
+
+    monkeypatch.setattr(jobs_module.subprocess, "Popen", fake_popen)
+    with pytest.raises(SystemExit) as raised:
+        jobs_module.run_job_runner_cli(
+            [
+                "--command-file",
+                str(command_path),
+                "--log-file",
+                str(log_path),
+                "--status-file",
+                str(status_path),
+                "--cwd",
+                str(tmp_path),
+                "--shell",
+                "/bin/sh",
+                "--max-log-bytes",
+                "1024",
+            ]
+        )
+
+    assert raised.value.code == 0
+    assert captured["env"]["SAFE_JOB_VALUE"] == "visible"
+    assert "LOCAL_SHELL_MCP_PRIVATE_VALUE" not in captured["env"]
+    assert "DOCKER_HOST" not in captured["env"]
+    assert "CLOUDFLARE_TUNNEL_TOKEN" not in captured["env"]
+
+
+def test_transfer_requires_complete_non_overlapping_ranges(tmp_path, monkeypatch):
+    _configure_workspace(tmp_path, monkeypatch)
+    begin = transfer_begin_write("sparse.bin", expected_bytes=8)
+    transfer_write_chunk("sparse.bin", begin["transfer_id"], 7, "WA==")
+    with pytest.raises(ValueError, match="missing or non-contiguous"):
+        transfer_finish_write("sparse.bin", begin["transfer_id"], expected_bytes=8)
+    transfer_abort_write("sparse.bin", begin["transfer_id"])
+
+    begin = transfer_begin_write("overlap.bin", expected_bytes=4)
+    transfer_write_chunk("overlap.bin", begin["transfer_id"], 0, "YWJj")
+    with pytest.raises(ValueError, match="overlaps"):
+        transfer_write_chunk("overlap.bin", begin["transfer_id"], 2, "eg==")
+    transfer_abort_write("overlap.bin", begin["transfer_id"])
+
+
+def test_directory_pack_rejects_invalid_compression_and_special_files(tmp_path, monkeypatch):
+    _configure_workspace(tmp_path, monkeypatch)
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "regular.txt").write_text("ok", encoding="utf-8")
+    with pytest.raises(ValueError, match="compression"):
+        transfer_pack_dir("source", "zip")
+
+    if hasattr(os, "mkfifo"):
+        os.mkfifo(source / "pipe")
+        with pytest.raises(ValueError, match="special files"):
+            transfer_pack_dir("source", "gz")
+
+
+def test_remote_registry_recovers_backup_and_refuses_total_corruption(tmp_path, monkeypatch):
+    _configure_workspace(tmp_path, monkeypatch)
+    manager = RemoteManager()
+    manager._registry_loaded = True
+    worker = RemoteWorker(name="saved-worker", token="saved-token")
+    manager.workers[worker.name] = worker
+    manager.tokens[worker.token] = worker.name
+    manager._save_registry_unlocked()
+
+    registry = manager._registry_path()
+    backup = manager._registry_backup_path()
+    registry.write_text("{broken", encoding="utf-8")
+    recovered = RemoteManager().list_machines()
+    assert [row["name"] for row in recovered["machines"]] == ["saved-worker"]
+    assert json.loads(registry.read_text(encoding="utf-8"))["version"] == 1
+
+    registry.write_text("{broken again", encoding="utf-8")
+    backup.write_text("{also broken", encoding="utf-8")
+    manager_with_corruption = RemoteManager()
+    with pytest.raises(RuntimeError, match="refusing to reset"):
+        manager_with_corruption.list_machines()
+    with pytest.raises(RuntimeError, match="refusing to reset"):
+        manager_with_corruption.list_machines()
+    assert registry.read_text(encoding="utf-8") == "{broken again"
+    assert backup.read_text(encoding="utf-8") == "{also broken"
+
+
+def test_remote_download_ticket_serves_verified_snapshot(tmp_path, monkeypatch):
+    _configure_workspace(tmp_path, monkeypatch)
+    original = b"abcdefgh"
+    source = tmp_path / "source.bin"
+    source.write_bytes(original)
+    ticket = create_download_ticket(
+        "source.bin", len(original), hashlib.sha256(original).hexdigest()
+    )
+    source.write_bytes(b"12345678")
+
+    client = TestClient(Starlette(routes=remote_transfer_routes()))
+    response = client.get(urlsplit(ticket["url"]).path)
+    assert response.status_code == 200
+    assert response.content == original
+    assert response.headers["x-content-sha256"] == hashlib.sha256(original).hexdigest()
+
+
+@pytest.mark.asyncio
+async def test_controller_timeout_is_visible_to_running_worker(tmp_path, monkeypatch):
+    _configure_workspace(tmp_path, monkeypatch)
+    manager = RemoteManager()
+    manager._registry_loaded = True
+    worker = RemoteWorker(name="worker-a", token="token-a")
+    manager.workers[worker.name] = worker
+    manager.tokens[worker.token] = worker.name
+
+    call = asyncio.create_task(
+        manager.call("worker-a", "list_files", {"path": "."}, timeout_s=0.01)
+    )
+    polled = await manager.poll(worker.token)
+    job_id = polled["job"]["id"]
+    with pytest.raises(TimeoutError, match="remote job timed out"):
+        await call
+
+    heartbeat = await manager.heartbeat(worker.token, {"job_id": job_id})
+    assert heartbeat["accepted"] is False
+    assert heartbeat["cancelled"] is True
+
+
+@pytest.mark.asyncio
+async def test_claimed_remote_mutation_waits_for_definitive_result(tmp_path, monkeypatch):
+    _configure_workspace(tmp_path, monkeypatch)
+    manager = RemoteManager()
+    manager._registry_loaded = True
+    worker = RemoteWorker(name="worker-a", token="token-a")
+    manager.workers[worker.name] = worker
+    manager.tokens[worker.token] = worker.name
+
+    call = asyncio.create_task(
+        manager.call(
+            "worker-a",
+            "write_file",
+            {"path": "target.txt", "content": "done"},
+            timeout_s=0.01,
+        )
+    )
+    polled = await manager.poll(worker.token)
+    await asyncio.sleep(0.03)
+    assert call.done() is False
+
+    accepted = await manager.submit_result(
+        worker.token,
+        {"job_id": polled["job"]["id"], "ok": True, "data": {"path": "target.txt"}},
+    )
+    assert accepted["accepted"] is True
+    result = await call
+    assert result["data"]["path"] == "target.txt"
+
+
+@pytest.mark.asyncio
+async def test_worker_cancels_cooperative_task_when_controller_rejects_heartbeat(monkeypatch):
+    completed = False
+
+    async def fake_execute(tool, args):
+        nonlocal completed
+        del tool, args
+        await asyncio.sleep(1)
+        completed = True
+        return {"done": True}
+
+    def cancelled_heartbeat(url, payload, headers=None, timeout=None):
+        del url, headers, timeout
+        assert payload == {"job_id": "job-cancelled"}
+        return {"ok": True, "data": {"accepted": False, "cancelled": True}}
+
+    monkeypatch.setattr(remote_module, "execute_worker_tool", fake_execute)
+    monkeypatch.setattr(remote_module, "_worker_post_json", cancelled_heartbeat)
+
+    with pytest.raises(remote_module.RemoteJobCancelled):
+        await remote_module._execute_worker_job_with_heartbeat(
+            {"id": "job-cancelled", "tool": "slow", "args": {}},
+            "https://controller.test",
+            {"Authorization": "Bearer token"},
+            0.01,
+        )
+    assert completed is False
+
+
+@pytest.mark.asyncio
+async def test_mcp_mutation_does_not_return_before_thread_finishes(tmp_path, monkeypatch):
+    _configure_workspace(tmp_path, monkeypatch)
+    monkeypatch.setattr(tools_module, "PUBLIC_TOOL_TIMEOUT_S", 0.01)
+    marker = tmp_path / "completed.txt"
+
+    def delayed_write(path, content, overwrite=True, expected_sha256=None):
+        del path, overwrite, expected_sha256
+        time.sleep(0.05)
+        marker.write_text(content, encoding="utf-8")
+        return {"path": "target.txt", "bytes": len(content), "created": True}
+
+    monkeypatch.setattr(tools_module, "write_text", delayed_write)
+    response = await build_mcp().call_tool(
+        "write_file", {"path": "target.txt", "content": "done"}
+    )
+    payload = json.loads(response[0][0].text)
+    assert payload["data"]["path"] == "target.txt"
+    assert marker.read_text(encoding="utf-8") == "done"
+
+
+def test_rest_mutation_does_not_return_before_thread_finishes(tmp_path, monkeypatch):
+    _configure_workspace(tmp_path, monkeypatch)
+    monkeypatch.setattr(http_app_module, "PUBLIC_TOOL_TIMEOUT_S", 0.01)
+    marker = tmp_path / "rest-completed.txt"
+
+    def delayed_write(path, content, overwrite=True):
+        del path, overwrite
+        time.sleep(0.05)
+        marker.write_text(content, encoding="utf-8")
+        return {"path": "target.txt", "bytes": len(content), "created": True}
+
+    monkeypatch.setattr(http_app_module, "write_text", delayed_write)
+    response = TestClient(build_http_app()).post(
+        "/tools/write_file", json={"path": "target.txt", "content": "done"}
+    )
+    assert response.status_code == 200
+    assert marker.read_text(encoding="utf-8") == "done"
+
+
+@pytest.mark.asyncio
+async def test_python_and_playwright_tools_honor_configured_interpreter_and_clear_stale_output(
+    tmp_path, monkeypatch
+):
+    _configure_workspace(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_PYTHON_BIN", "/opt/custom python")
+    get_settings.cache_clear()
+    commands = []
+
+    async def fake_run(command, **kwargs):
+        del kwargs
+        commands.append(command)
+        return CommandResult(
+            ok=False,
+            exit_code=1,
+            timed_out=False,
+            duration_ms=1,
+            cwd=".",
+            command=command,
+            stdout="",
+            stderr="failed",
+            truncated=False,
+        )
+
+    monkeypatch.setattr(tools_module, "run_shell", fake_run)
+    await tools_module._run_python("print('x')")
+    assert commands[-1].startswith("'/opt/custom python' ")
+
+    stale = tmp_path / "screenshots" / "page.png"
+    stale.parent.mkdir()
+    stale.write_bytes(b"old")
+    monkeypatch.setattr(playwright_module, "run_shell", fake_run)
+    result = await playwright_module.browser_screenshot(
+        "https://invalid.test", "screenshots/page.png"
+    )
+    assert commands[-1].startswith("'/opt/custom python' ")
+    assert result["screenshot_path"] is None
+    assert not stale.exists()
+
+
+def test_rest_validation_readiness_and_todo_scope(tmp_path, monkeypatch):
+    _configure_workspace(tmp_path, monkeypatch)
+    client = TestClient(build_http_app())
+
+    ready = client.get("/readyz")
+    assert ready.status_code == 200
+    assert ready.json() == {"ok": True}
+
+    invalid_bool = client.post(
+        "/tools/list_files", json={"path": ".", "recursive": "false"}
+    )
+    assert invalid_bool.status_code == 400
+    assert invalid_bool.json()["error"] == "validation_error"
+
+    invalid_integer = client.post(
+        "/tools/list_files", json={"path": ".", "max_entries": "many"}
+    )
+    assert invalid_integer.status_code == 400
+    assert invalid_integer.json()["error"] == "validation_error"
+
+    assert required_scopes_for_http_tool("/tools/todo", "GET") == ("shell:read",)
+    assert required_scopes_for_http_tool("/tools/todo", "POST") == (
+        "shell:read",
+        "shell:write",
+    )
+
+
+def test_secret_scan_fallback_respects_gitignore(tmp_path, monkeypatch):
+    _configure_workspace(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_RG_BIN", str(tmp_path / "missing-rg"))
+    get_settings.cache_clear()
+    (tmp_path / ".gitignore").write_text("ignored.txt\n", encoding="utf-8")
+    (tmp_path / "ignored.txt").write_text(
+        'api_key="ignored-secret-value"\n', encoding="utf-8"
+    )
+    (tmp_path / "visible.txt").write_text(
+        'api_key="visible-secret-value"\n', encoding="utf-8"
+    )
+
+    findings = tools_module._secret_scan_sync(".", None, 20)["findings"]
+    assert {item["path"] for item in findings} == {"visible.txt"}
+
+
+@pytest.mark.asyncio
+async def test_fetch_reports_truncation_and_encoded_actual_file_uri(tmp_path, monkeypatch):
+    _configure_workspace(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_FILE_READ_BYTES", "5")
+    get_settings.cache_clear()
+    path = tmp_path / "a b#c.txt"
+    path.write_text("0123456789", encoding="utf-8")
+
+    response = await build_mcp().call_tool("fetch", {"id": "a b#c.txt"})
+    payload = json.loads(response[0][0].text)
+    assert payload["text"] == "01234"
+    assert payload["metadata"]["truncated"] is True
+    assert payload["metadata"]["truncated_bytes"] == 5
+    assert "%20" in payload["url"]
+    assert "%23" in payload["url"]
+    assert payload["url"] == path.resolve().as_uri()
+
+
+@pytest.mark.asyncio
+async def test_failed_remote_directory_pull_removes_local_archive(tmp_path, monkeypatch):
+    _configure_workspace(tmp_path, monkeypatch)
+    archive = tmp_path / "temporary.tar.gz"
+
+    async def fake_remote_data(machine, tool, args, timeout_s=None):
+        del machine, args, timeout_s
+        if tool == "transfer_pack_dir":
+            return {
+                "archive_path": "remote.tar.gz",
+                "path": "source",
+                "bytes": 7,
+                "sha256": "digest",
+            }
+        raise AssertionError(tool)
+
+    async def fake_copy(*args, **kwargs):
+        del args, kwargs
+        archive.write_bytes(b"archive")
+        return {
+            "bytes": 7,
+            "sha256": "digest",
+            "chunks": 1,
+            "chunk_size": 7,
+            "source": {},
+            "destination": {},
+        }
+
+    async def fake_cleanup(*args, **kwargs):
+        del args, kwargs
+
+    monkeypatch.setattr(tools_module, "_remote_transfer_data", fake_remote_data)
+    monkeypatch.setattr(
+        tools_module, "transfer_alloc_temp_path", lambda suffix: {"path": archive.name}
+    )
+    monkeypatch.setattr(tools_module, "_copy_remote_file_to_local", fake_copy)
+    monkeypatch.setattr(
+        tools_module,
+        "transfer_unpack_archive",
+        lambda *args, **kwargs: (_ for _ in ()).throw(ValueError("unpack failed")),
+    )
+    monkeypatch.setattr(tools_module, "_remote_cleanup_file", fake_cleanup)
+
+    with pytest.raises(ValueError, match="unpack failed"):
+        await tools_module._copy_remote_dir_to_local("node", "source", "dest")
+    assert not archive.exists()
+
+
+@pytest.mark.asyncio
+async def test_wallpaper_retries_after_transient_failure(tmp_path, monkeypatch):
+    _configure_workspace(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_UI_WALLPAPER", "bing")
+    get_settings.cache_clear()
+    calls = 0
+
+    class FailingClient:
+        def __init__(self, *args, **kwargs):
+            del args, kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            del args
+            return False
+
+        async def get(self, *args, **kwargs):
+            nonlocal calls
+            del args, kwargs
+            calls += 1
+            raise RuntimeError("network unavailable")
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", FailingClient)
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/ui/wallpaper",
+            "headers": [],
+            "query_string": b"",
+            "client": ("127.0.0.1", 1234),
+            "server": ("localhost", 80),
+            "scheme": "http",
+        }
+    )
+    first = await human_ui.ui_wallpaper(request)
+    second = await human_ui.ui_wallpaper(request)
+    assert first.status_code == 204
+    assert second.status_code == 204
+    assert calls == 2
+
+
+def test_vscode_extension_uses_posix_process_group_shutdown():
+    source = Path("vscode-extension/src/extension.ts").read_text(encoding="utf-8")
+    assert "detached: process.platform !== 'win32'" in source
+    assert "process.kill(-proc.pid, signal)" in source
+    assert "await waitForExit(proc, 2000)" in source

--- a/tests/test_audit_regressions.py
+++ b/tests/test_audit_regressions.py
@@ -116,6 +116,11 @@ def test_job_runner_filters_service_environment(tmp_path, monkeypatch):
         return FakeProcess()
 
     monkeypatch.setattr(jobs_module.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(
+        jobs_module,
+        "get_settings",
+        lambda: (_ for _ in ()).throw(AssertionError("runner must not reload settings")),
+    )
     with pytest.raises(SystemExit) as raised:
         jobs_module.run_job_runner_cli(
             [

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -32,6 +32,40 @@ def test_runner_command_invokes_powershell_executable_and_quotes_arguments():
     )
 
 
+def test_runner_environment_policy_is_shell_neutral_and_round_trips(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(tmp_path / ".local-shell-mcp"))
+    monkeypatch.setenv(
+        "LOCAL_SHELL_MCP_SHELL_ENV_BLOCKLIST", "TOKEN_ONE,TOKEN_TWO"
+    )
+    monkeypatch.setenv(
+        "LOCAL_SHELL_MCP_SHELL_ENV_BLOCKED_PREFIXES", "PRIVATE_,SERVICE_"
+    )
+    get_settings.cache_clear()
+
+    paths = jobs_module._attempt_paths("job_test", 1)
+    argv = jobs_module._runner_argv(paths, tmp_path)
+    blocklist_index = argv.index("--env-blocklist-b64") + 1
+    prefixes_index = argv.index("--env-blocked-prefixes-b64") + 1
+    blocklist_payload = argv[blocklist_index]
+    prefixes_payload = argv[prefixes_index]
+
+    assert '"' not in blocklist_payload
+    assert "'" not in blocklist_payload
+    assert '"' not in prefixes_payload
+    assert "'" not in prefixes_payload
+    assert jobs_module._parse_runner_env_policy(
+        blocklist_payload, "env blocklist"
+    ) == ["TOKEN_ONE", "TOKEN_TWO"]
+    assert jobs_module._parse_runner_env_policy(
+        prefixes_payload, "env blocked prefixes"
+    ) == ["PRIVATE_", "SERVICE_"]
+
+    powershell_command = jobs_module._runner_command(argv, "powershell.exe")
+    assert blocklist_payload in powershell_command
+    assert prefixes_payload in powershell_command
+
+
 @pytest.mark.asyncio
 async def test_jobs_track_tail_stop_and_retry(tmp_path, monkeypatch):
     monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))

--- a/tests/test_remote_transfer_tools.py
+++ b/tests/test_remote_transfer_tools.py
@@ -17,9 +17,11 @@ from local_shell_mcp.transfer_ops import (
     transfer_begin_write,
     transfer_finish_write,
     transfer_pack_dir,
+    transfer_read_chunk,
     transfer_stat,
     transfer_unpack_archive,
     transfer_write_bytes,
+    transfer_write_chunk,
 )
 
 
@@ -38,6 +40,33 @@ class FakeRemoteManager:
         try:
             if tool == "transfer_stat":
                 data = transfer_stat(args["path"], args.get("sha256", True))
+            elif tool == "transfer_read_chunk":
+                data = transfer_read_chunk(
+                    args["path"], args.get("offset", 0), args.get("chunk_size")
+                )
+            elif tool == "transfer_begin_write":
+                data = transfer_begin_write(
+                    args["path"],
+                    args.get("overwrite", True),
+                    args.get("expected_bytes"),
+                )
+            elif tool == "transfer_write_chunk":
+                data = transfer_write_chunk(
+                    args["path"],
+                    args["transfer_id"],
+                    args["offset"],
+                    args["data_b64"],
+                    args.get("expected_sha256"),
+                )
+            elif tool == "transfer_finish_write":
+                data = transfer_finish_write(
+                    args["path"],
+                    args["transfer_id"],
+                    args.get("expected_bytes"),
+                    args.get("expected_sha256"),
+                )
+            elif tool == "transfer_abort_write":
+                data = transfer_abort_write(args["path"], args["transfer_id"])
             elif tool == "transfer_upload_url":
                 source = resolve_path(args["path"], must_exist=True)
                 response = self.client.put(
@@ -115,8 +144,8 @@ async def test_remote_copy_file_streams_between_workers(tmp_path, monkeypatch):
         "src", "src-machine/payload.bin", "dst", "dst-machine/payload.bin", True, 128
     )
 
-    assert result["chunks"] == 2
-    assert result["transport"] == "http-stream-via-controller"
+    assert result["chunks"] > 2
+    assert result["transport"] == "mcp-chunks-via-controller"
     assert result["bytes"] == len(data)
     assert (root / "dst-machine" / "payload.bin").read_bytes() == data
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -7,24 +7,57 @@ import * as vscode from 'vscode';
 let output: vscode.OutputChannel;
 let serverProcess: cp.ChildProcessWithoutNullStreams | undefined;
 
-function stopProcessTree(proc: cp.ChildProcessWithoutNullStreams): Promise<void> {
+function waitForExit(proc: cp.ChildProcessWithoutNullStreams, timeoutMs: number): Promise<boolean> {
+  if (proc.exitCode !== null || proc.signalCode !== null) {
+    return Promise.resolve(true);
+  }
   return new Promise((resolve) => {
-    if (proc.exitCode !== null || proc.signalCode !== null) {
-      resolve();
-      return;
-    }
-    if (process.platform === 'win32' && proc.pid) {
+    const finish = (exited: boolean) => {
+      clearTimeout(timer);
+      proc.off('exit', onExit);
+      resolve(exited);
+    };
+    const onExit = () => finish(true);
+    const timer = setTimeout(() => finish(false), timeoutMs);
+    proc.once('exit', onExit);
+  });
+}
+
+function signalPosixProcessTree(proc: cp.ChildProcessWithoutNullStreams, signal: NodeJS.Signals): void {
+  if (!proc.pid) {
+    proc.kill(signal);
+    return;
+  }
+  try {
+    process.kill(-proc.pid, signal);
+  } catch {
+    proc.kill(signal);
+  }
+}
+
+async function stopProcessTree(proc: cp.ChildProcessWithoutNullStreams): Promise<void> {
+  if (proc.exitCode !== null || proc.signalCode !== null) {
+    return;
+  }
+  if (process.platform === 'win32' && proc.pid) {
+    await new Promise<void>((resolve) => {
       cp.execFile('taskkill', ['/PID', String(proc.pid), '/T', '/F'], (error) => {
         if (error) {
           proc.kill();
         }
         resolve();
       });
-      return;
-    }
-    proc.kill();
-    resolve();
-  });
+    });
+    await waitForExit(proc, 2000);
+    return;
+  }
+
+  signalPosixProcessTree(proc, 'SIGTERM');
+  if (await waitForExit(proc, 2000)) {
+    return;
+  }
+  signalPosixProcessTree(proc, 'SIGKILL');
+  await waitForExit(proc, 1000);
 }
 
 interface ExtensionConfig {
@@ -184,6 +217,7 @@ async function startServer(context: vscode.ExtensionContext): Promise<void> {
     cwd: config.workspaceRoot,
     env,
     shell: process.platform === 'win32',
+    detached: process.platform !== 'win32',
   });
 
   serverProcess = child;


### PR DESCRIPTION
## Summary

- harden background jobs, command/path policy, settings validation, REST handling, Playwright output handling, and VS Code process shutdown
- make remote job cancellation and file transfer transactional, verified, resumable, and recoverable
- add regression coverage for all confirmed audit findings, including macOS and Windows runner edge cases

## Validation

- 265 local Python tests passed
- Ruff, compileall, ShellCheck, strict documentation build, UI typecheck/tests/build, VS Code compile/package, wheel/sdist build, schema export, and native TUI PTY smoke passed
- full GitHub Actions matrix passed: 36 matrix jobs plus aggregate gate
