### PR TITLE
Raise branch coverage above 93% and harden CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,9 +113,10 @@ jobs:
         working-directory: ui
         run: bun install --frozen-lockfile
 
-      - name: Type-check and build WebUI/OpenTUI
+      - name: Test, type-check, and build WebUI/OpenTUI
         working-directory: ui
         run: |
+          bun test
           bun run typecheck
           bun run build
 
@@ -158,11 +159,58 @@ jobs:
         working-directory: ui
         run: |
           bun install --frozen-lockfile
+          bun test
           bun run typecheck
           bun run build
 
       - name: Run OAuth, PTY, navigation, and responsive browser smoke test
         run: python scripts/ui-smoke.py
+
+  coverage:
+    name: Coverage / unit and process E2E
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Install test dependencies
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ripgrep tmux
+          python -m pip install --upgrade pip
+          python -m pip install -e '.[dev]'
+          python -m playwright install --with-deps chromium
+
+      - name: Build and test Human UI
+        working-directory: ui
+        run: |
+          bun install --frozen-lockfile
+          bun test
+          bun run typecheck
+          bun run build
+
+      - name: Collect combined branch coverage
+        run: bash scripts/run-coverage.sh
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-coverage
+          path: coverage.xml
+          if-no-files-found: error
+
 
   python-tests:
     name: Python / ${{ matrix.label }}
@@ -453,6 +501,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Reclaim hosted-runner disk space
+        run: bash scripts/free-ci-disk-space.sh
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -553,9 +604,11 @@ jobs:
       - static
       - human-ui
       - human-ui-e2e
+      - coverage
       - python-tests
       - endpoint-smoke
       - package
+      - bundled-tmux
       - docker
       - compose
       - binary-release-matrix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Test, type-check, and build WebUI/OpenTUI
         working-directory: ui
         run: |
-          bun test
+          bun run test
           bun run typecheck
           bun run build
 
@@ -159,7 +159,7 @@ jobs:
         working-directory: ui
         run: |
           bun install --frozen-lockfile
-          bun test
+          bun run test
           bun run typecheck
           bun run build
 
@@ -197,7 +197,7 @@ jobs:
         working-directory: ui
         run: |
           bun install --frozen-lockfile
-          bun test
+          bun run test
           bun run typecheck
           bun run build
 
@@ -208,7 +208,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: python-coverage
-          path: coverage.xml
+          path: |
+            coverage.json
+            coverage.xml
           if-no-files-found: error
 
 
@@ -453,6 +455,86 @@ jobs:
           if-no-files-found: error
 
 
+  standalone-binary:
+    name: Standalone binary / ${{ matrix.label }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: linux-x86_64
+            runner: ubuntu-24.04
+            binary: local-shell-mcp
+            helper_platform: linux/amd64
+            helper_tag: linux-x86_64
+          - label: windows-x86_64
+            runner: windows-latest
+            binary: local-shell-mcp.exe
+            helper_platform: ""
+            helper_tag: ""
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Reclaim hosted-runner disk space
+        if: runner.os == 'Linux'
+        run: bash scripts/free-ci-disk-space.sh
+
+      - name: Build bundled tmux helper
+        if: runner.os == 'Linux'
+        shell: bash
+        run: scripts/build-tmux-helper.sh "src/local_shell_mcp/helpers/${{ matrix.helper_tag }}/tmux" "${{ matrix.helper_platform }}"
+
+      - name: Build and test Human UI assets
+        working-directory: ui
+        run: |
+          bun install --frozen-lockfile
+          bun run test
+          bun run typecheck
+          bun run build
+
+      - name: Build self-contained executable
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install -e . pyinstaller typer
+          EXTRA_PYINSTALLER_ARGS=()
+          if [[ "${RUNNER_OS}" == "Windows" ]]; then
+            EXTRA_PYINSTALLER_ARGS+=(--collect-all winpty)
+          fi
+          pyinstaller \
+            --clean \
+            --onefile \
+            --name local-shell-mcp \
+            --collect-all local_shell_mcp \
+            --collect-all mcp \
+            --collect-all uvicorn \
+            --collect-all fastapi \
+            --collect-all starlette \
+            --exclude-module cryptography \
+            "${EXTRA_PYINSTALLER_ARGS[@]}" \
+            scripts/pyinstaller-entry.py
+
+      - name: Smoke test self-contained executable
+        shell: bash
+        run: |
+          ./dist/${{ matrix.binary }} --version
+          ./dist/${{ matrix.binary }} version
+          ./dist/${{ matrix.binary }} --help
+
+
   bundled-tmux:
     name: Bundled tmux / ${{ matrix.label }}
     runs-on: ${{ matrix.runner }}
@@ -575,9 +657,9 @@ jobs:
         working-directory: vscode-extension
         run: npm ci
 
-      - name: Compile extension
+      - name: Test extension process lifecycle
         working-directory: vscode-extension
-        run: npm run compile
+        run: npm test
 
       - name: Package VSIX
         working-directory: vscode-extension
@@ -608,6 +690,7 @@ jobs:
       - python-tests
       - endpoint-smoke
       - package
+      - standalone-binary
       - bundled-tmux
       - docker
       - compose

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+  "coverage[toml]>=7.8.0",
   "pytest>=8.2.0",
   "pytest-asyncio>=0.23.0",
   "ruff>=0.5.0",
@@ -68,3 +69,23 @@ ignore = ["E501"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+
+[tool.coverage.run]
+branch = true
+parallel = true
+sigterm = true
+source = ["local_shell_mcp"]
+
+[tool.coverage.report]
+fail_under = 90
+precision = 1
+show_missing = true
+skip_covered = true
+exclude_also = [
+  "if TYPE_CHECKING:",
+  "if __name__ == .__main__.:",
+  "raise NotImplementedError",
+]
+
+[tool.coverage.xml]
+output = "coverage.xml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ sigterm = true
 source = ["local_shell_mcp"]
 
 [tool.coverage.report]
-fail_under = 90
+fail_under = 93
 precision = 1
 show_missing = true
 skip_covered = true
@@ -89,3 +89,6 @@ exclude_also = [
 
 [tool.coverage.xml]
 output = "coverage.xml"
+
+[tool.coverage.json]
+output = "coverage.json"

--- a/scripts/check-coverage.py
+++ b/scripts/check-coverage.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Enforce per-module coverage floors after subprocess data is combined."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+GLOBAL_MINIMUM = 93.0
+MODULE_MINIMUM = 90.0
+CRITICAL_MINIMUM = 92.0
+CRITICAL_MODULES = {
+    "src/local_shell_mcp/human_ui.py",
+    "src/local_shell_mcp/remote.py",
+    "src/local_shell_mcp/shell_ops.py",
+    "src/local_shell_mcp/tools.py",
+}
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    report_path = Path(args[0] if args else "coverage.json")
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    failures: list[str] = []
+
+    total = float(report["totals"]["percent_covered"])
+    if total < GLOBAL_MINIMUM:
+        failures.append(
+            f"total coverage {total:.2f}% is below {GLOBAL_MINIMUM:.2f}%"
+        )
+
+    for path, details in sorted(report["files"].items()):
+        covered = float(details["summary"]["percent_covered"])
+        minimum = CRITICAL_MINIMUM if path in CRITICAL_MODULES else MODULE_MINIMUM
+        if covered < minimum:
+            failures.append(
+                f"{path}: {covered:.2f}% is below the {minimum:.2f}% floor"
+            )
+
+    if failures:
+        print("Coverage gate failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+
+    print(
+        f"Coverage gates passed: total={total:.2f}%, "
+        f"all modules>={MODULE_MINIMUM:.2f}%, "
+        f"critical modules>={CRITICAL_MINIMUM:.2f}%"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci-smoke.py
+++ b/scripts/ci-smoke.py
@@ -115,6 +115,12 @@ def start_server(mode: str, auth: str, workspace: Path, port: int) -> subprocess
             "LOCAL_SHELL_MCP_PUBLIC_BASE_URL": base_url if auth == "oauth" else "",
         }
     )
+    if os.getenv("LOCAL_SHELL_MCP_COVERAGE") == "1":
+        env["COVERAGE_PROCESS_START"] = str(ROOT / "pyproject.toml")
+        env["COVERAGE_FILE"] = str(ROOT / ".coverage")
+        env["PYTHONPATH"] = os.pathsep.join(
+            item for item in (str(ROOT), env.get("PYTHONPATH", "")) if item
+        )
     return subprocess.Popen(
         server_command(mode),
         cwd=ROOT,

--- a/scripts/free-ci-disk-space.sh
+++ b/scripts/free-ci-disk-space.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# GitHub's Ubuntu images contain large SDKs that are unrelated to this Docker
+# build. The local-shell-mcp image intentionally includes several development
+# toolchains, so reclaim the hosted-runner copies before BuildKit expands them.
+sudo rm -rf \
+  /usr/local/lib/android \
+  /usr/share/dotnet \
+  /opt/ghc \
+  /usr/local/.ghcup \
+  /opt/hostedtoolcache/CodeQL \
+  /opt/hostedtoolcache/Ruby \
+  /opt/hostedtoolcache/go \
+  /opt/hostedtoolcache/node || true
+sudo apt-get clean
+docker system prune --all --force --volumes || true
+df -h /

--- a/scripts/run-coverage.sh
+++ b/scripts/run-coverage.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+rm -f .coverage .coverage.* coverage.xml
+python -m coverage run --parallel-mode -m pytest -q
+
+export LOCAL_SHELL_MCP_COVERAGE=1
+python -m coverage run --parallel-mode scripts/ci-smoke.py --mode http --auth none
+python -m coverage run --parallel-mode scripts/ci-smoke.py --mode mcp --auth oauth
+python -m coverage run --parallel-mode scripts/ui-pty-smoke.py --tui ui/dist/local-shell-mcp-tui
+python -m coverage run --parallel-mode scripts/ui-smoke.py
+
+python -m coverage combine
+python -m coverage report
+python -m coverage xml

--- a/scripts/run-coverage.sh
+++ b/scripts/run-coverage.sh
@@ -4,15 +4,17 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
-rm -f .coverage .coverage.* coverage.xml
+rm -f .coverage .coverage.* coverage.json coverage.xml
+export LOCAL_SHELL_MCP_COVERAGE=1
 python -m coverage run --parallel-mode -m pytest -q
 
-export LOCAL_SHELL_MCP_COVERAGE=1
-python -m coverage run --parallel-mode scripts/ci-smoke.py --mode http --auth none
-python -m coverage run --parallel-mode scripts/ci-smoke.py --mode mcp --auth oauth
-python -m coverage run --parallel-mode scripts/ui-pty-smoke.py --tui ui/dist/local-shell-mcp-tui
-python -m coverage run --parallel-mode scripts/ui-smoke.py
+python scripts/ci-smoke.py --mode http --auth none
+python scripts/ci-smoke.py --mode mcp --auth oauth
+python scripts/ui-pty-smoke.py --tui ui/dist/local-shell-mcp-tui
+python scripts/ui-smoke.py
 
 python -m coverage combine
 python -m coverage report
+python -m coverage json
 python -m coverage xml
+python scripts/check-coverage.py coverage.json

--- a/scripts/ui-pty-smoke.py
+++ b/scripts/ui-pty-smoke.py
@@ -136,6 +136,14 @@ def main() -> int:
                 "LOCAL_SHELL_MCP_UI_TUI_COMMAND": str(tui_path),
             }
         )
+        if os.getenv("LOCAL_SHELL_MCP_COVERAGE") == "1":
+            env["COVERAGE_PROCESS_START"] = str(ROOT / "pyproject.toml")
+            env["COVERAGE_FILE"] = str(ROOT / ".coverage")
+            env["PYTHONPATH"] = os.pathsep.join(
+                item
+                for item in (str(ROOT), str(ROOT / "src"), env.get("PYTHONPATH", ""))
+                if item
+            )
         process = subprocess.Popen(  # noqa: S603
             [sys.executable, "-m", "local_shell_mcp.main", "--mode", "mcp", "--no-remote"],
             cwd=ROOT,

--- a/scripts/ui-smoke.py
+++ b/scripts/ui-smoke.py
@@ -217,6 +217,14 @@ def main() -> int:
                 "LOCAL_SHELL_MCP_UI_TUI_COMMAND": str(TUI_PATH),
             }
         )
+        if os.getenv("LOCAL_SHELL_MCP_COVERAGE") == "1":
+            env["COVERAGE_PROCESS_START"] = str(ROOT / "pyproject.toml")
+            env["COVERAGE_FILE"] = str(ROOT / ".coverage")
+            env["PYTHONPATH"] = os.pathsep.join(
+                item
+                for item in (str(ROOT), str(ROOT / "src"), env.get("PYTHONPATH", ""))
+                if item
+            )
         process = subprocess.Popen(  # noqa: S603
             [sys.executable, "-m", "local_shell_mcp.main", "--mode", "mcp", "--no-remote"],
             cwd=ROOT,

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,15 @@
+"""Enable opt-in coverage collection in test subprocesses.
+
+The repository root is not packaged, so production installs do not import this
+module. CI smoke tests add the checkout to ``PYTHONPATH`` and set
+``COVERAGE_PROCESS_START`` explicitly.
+"""
+
+from __future__ import annotations
+
+import os
+
+if os.getenv("COVERAGE_PROCESS_START"):
+    import coverage
+
+    coverage.process_startup()

--- a/src/local_shell_mcp/jobs.py
+++ b/src/local_shell_mcp/jobs.py
@@ -211,8 +211,8 @@ def _new_job_id() -> str:
 
 
 def _shell_safe_name(value: str) -> str:
-    cleaned = re.sub(r"[^A-Za-z0-9_.-]", "-", value.strip())
-    return cleaned[:48] or "job"
+    cleaned = re.sub(r"[^A-Za-z0-9_.-]", "-", value.strip())[:48].strip(".-")
+    return cleaned or "job"
 
 
 def _active_session_ids(shells: dict[str, Any]) -> set[str]:

--- a/src/local_shell_mcp/settings.py
+++ b/src/local_shell_mcp/settings.py
@@ -487,7 +487,7 @@ if _PYDANTIC_AVAILABLE:
             return self.model_copy(update=updates)
 
 else:
-    from dataclasses import asdict, dataclass, field, fields, replace
+    from dataclasses import InitVar, asdict, dataclass, field, fields, replace
 
     def _env_bool(value: str) -> bool:
         return value.strip().lower() in {"1", "true", "yes", "on"}
@@ -622,16 +622,20 @@ else:
                 ".git/config",
             ]
         )
+        _load_environment: InitVar[bool] = True
 
-        def __post_init__(self) -> None:
-            for item in fields(self):
-                env_name = "LOCAL_SHELL_MCP_" + item.name.upper()
-                if env_name in os.environ:
-                    setattr(
-                        self,
-                        item.name,
-                        _coerce_env_value(os.environ[env_name], getattr(self, item.name)),
-                    )
+        def __post_init__(self, _load_environment: bool) -> None:
+            if _load_environment:
+                for item in fields(self):
+                    env_name = "LOCAL_SHELL_MCP_" + item.name.upper()
+                    if env_name in os.environ:
+                        setattr(
+                            self,
+                            item.name,
+                            _coerce_env_value(
+                                os.environ[env_name], getattr(self, item.name)
+                            ),
+                        )
             for attr in ("workspace_root", "audit_log_path", "state_dir", "agent_config_dir"):
                 setattr(
                     self,
@@ -655,12 +659,12 @@ else:
             return data
 
         def model_copy(self, update: dict[str, Any] | None = None) -> Settings:
-            return replace(self, **(update or {}))
+            return replace(self, _load_environment=False, **(update or {}))
 
         def apply_yaml(self, path: Path) -> Settings:
             merged = self.model_dump()
             merged.update(_flatten_yaml(path))
-            return Settings(**merged)
+            return Settings(**merged, _load_environment=False)
 
         def with_workspace_relative_defaults(self) -> Settings:
             updates = {}

--- a/tests/test_audit_regressions.py
+++ b/tests/test_audit_regressions.py
@@ -538,5 +538,8 @@ async def test_wallpaper_retries_after_transient_failure(tmp_path, monkeypatch):
 def test_vscode_extension_uses_posix_process_group_shutdown():
     source = Path("vscode-extension/src/extension.ts").read_text(encoding="utf-8")
     assert "detached: process.platform !== 'win32'" in source
-    assert "process.kill(-proc.pid, signal)" in source
-    assert "await waitForExit(proc, 2000)" in source
+    assert "killProcess(-proc.pid, signal)" in source
+    assert "await wait(proc, 2000)" in source
+    assert '"test": "npm run compile && node --test test/*.test.cjs"' in Path(
+        "vscode-extension/package.json"
+    ).read_text(encoding="utf-8")

--- a/tests/test_edge_modules_complete.py
+++ b/tests/test_edge_modules_complete.py
@@ -1,0 +1,784 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import stat
+from pathlib import Path
+from types import SimpleNamespace
+
+import jwt
+import pytest
+from fastapi import HTTPException
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+
+import local_shell_mcp.audit as audit_module
+import local_shell_mcp.auth as auth
+import local_shell_mcp.conpty_ops as conpty_ops
+import local_shell_mcp.http_app as http_app
+import local_shell_mcp.playwright_ops as playwright
+import local_shell_mcp.search_ops as search
+import local_shell_mcp.tmux_helper as tmux_helper
+import local_shell_mcp.ui_security as ui_security
+import local_shell_mcp.version as version
+from local_shell_mcp.models import CommandResult
+from local_shell_mcp.settings import get_settings
+
+
+def _configure(tmp_path, monkeypatch, **extra):
+    values = {
+        "LOCAL_SHELL_MCP_WORKSPACE_ROOT": str(tmp_path),
+        "LOCAL_SHELL_MCP_STATE_DIR": str(tmp_path / ".state"),
+        "LOCAL_SHELL_MCP_AUDIT_LOG_PATH": str(tmp_path / "audit.jsonl"),
+        "LOCAL_SHELL_MCP_AUTH_MODE": "none",
+        "LOCAL_SHELL_MCP_MAX_HTTP_REQUEST_BYTES": "16",
+    }
+    values.update({key: str(value) for key, value in extra.items()})
+    for key, value in values.items():
+        monkeypatch.setenv(key, value)
+    get_settings.cache_clear()
+
+
+def _request(
+    path="/tools/read_file",
+    *,
+    headers=None,
+    client=("127.0.0.1", 1),
+    method="GET",
+):
+    raw_headers = [(name.lower().encode(), value.encode()) for name, value in (headers or {}).items()]
+    return Request(
+        {
+            "type": "http",
+            "asgi": {"version": "3.0"},
+            "http_version": "1.1",
+            "method": method,
+            "scheme": "http",
+            "path": path,
+            "raw_path": path.encode(),
+            "query_string": b"",
+            "headers": raw_headers,
+            "client": client,
+            "server": ("test", 80),
+        }
+    )
+
+
+def test_audit_sanitization_trimming_and_all_filters(tmp_path, monkeypatch):
+    _configure(
+        tmp_path,
+        monkeypatch,
+        LOCAL_SHELL_MCP_AUTH_MODE="oauth",
+        LOCAL_SHELL_MCP_OAUTH_ADMIN_PIN="configured-secret-pin",
+        LOCAL_SHELL_MCP_OAUTH_JWT_SECRET="configured-secret-key-that-is-long-enough",
+        LOCAL_SHELL_MCP_MAX_AUDIT_LOG_BYTES=200,
+        LOCAL_SHELL_MCP_MAX_AUDIT_TAIL_BYTES=40,
+    )
+    settings = get_settings()
+    secrets = audit_module._audit_configured_secrets(settings)
+    assert "configured-secret-pin" in secrets
+    redacted = audit_module._redact_audit_text(
+        "Bearer abc.def configured-secret-pin ghp_" + "x" * 30 + "z" * 3000,
+        secrets,
+    )
+    assert "configured-secret-pin" not in redacted
+    assert "Bearer" not in redacted
+    assert audit_module._redact_audit_text("z" * 3000, ()).endswith("…<truncated>")
+
+    value = audit_module._sanitize_audit_value(
+        {
+            "token": "hidden",
+            "api_token": "hidden",
+            "token_id": "visible",
+            "db_password": "hidden",
+            "items": list(range(110)),
+            "tuple": (1, 2),
+            "object": object(),
+        },
+        secrets,
+    )
+    assert value["token"] == "<redacted>"
+    assert value["api_token"] == "<redacted>"
+    assert value["token_id"] == "visible"
+    assert value["db_password"] == "<redacted>"
+    assert len(value["items"]) == 100
+    assert value["tuple"] == [1, 2]
+    assert "object at" in value["object"]
+
+    path = settings.audit_log_path
+    audit_module._trim_audit_log(path, 100)
+    path.write_text("short\n", encoding="utf-8")
+    audit_module._trim_audit_log(path, 100)
+    path.write_text(("x" * 60 + "\n") * 10, encoding="utf-8")
+    audit_module._trim_audit_log(path, 100)
+    assert path.stat().st_size <= 100
+
+    settings.max_audit_tail_bytes = 10_000
+    settings.max_audit_log_bytes = 10_000
+    rows = [
+        {"ts": 1, "event": "mcp_tool_call_start", "tool": "read_file", "machine": "a", "session": "s", "detail": "needle"},
+        {"ts": 2, "event": "oauth_auth_failed", "node": "b", "session": "x"},
+        ["not", "dict"],
+    ]
+    path.write_text("bad-json\n" + "\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+    matched = audit_module.query_audit(
+        limit=9999,
+        node="a",
+        event="call",
+        operation="read",
+        session="s",
+        search="needle",
+        start_ts=0,
+        end_ts=1,
+        sort="asc",
+    )
+    assert matched["total_matched"] == 1
+    assert matched["entries"][0]["operation"] == "read"
+    assert audit_module._operation_type({}) == "other"
+    assert audit_module._operation_type({"event": "remote_worker_registered"}) == "worker"
+
+
+def test_auth_scopes_hosts_tokens_and_metadata(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    principal = auth.Principal(None, "x", {"scope": ["read", 2, ""]})
+    assert auth.principal_scopes(principal) == {"read", "2"}
+    assert auth.principal_scopes(auth.Principal(None, None, {"scope": 1})) == set()
+    auth.require_scopes(principal, [])
+    auth.require_scopes(auth.Principal(None, None, {"auth": "none"}), ["missing"])
+    with pytest.raises(HTTPException) as exc:
+        auth.require_scopes(principal, ["missing", "read"])
+    assert exc.value.status_code == 403
+    assert "scope=" in exc.value.headers["WWW-Authenticate"]
+
+    token = auth._CURRENT_PRINCIPAL.set(principal)
+    try:
+        with pytest.raises(HTTPException):
+            auth.require_current_scopes(["missing"])
+    finally:
+        auth._CURRENT_PRINCIPAL.reset(token)
+    auth.require_current_scopes(["missing"])
+
+    expected = {
+        "/tools/download/create": ("shell:read", "file:share"),
+        "/tools/todo": ("shell:read",),
+        "/tools/write_file": ("shell:read", "shell:write"),
+        "/tools/run_shell": ("shell:read", "shell:execute"),
+        "/tools/browser/text": ("browser:use",),
+        "/tools/browser/capture": ("browser:use", "shell:write"),
+        "/tools/playwright/run_script": ("browser:use", "shell:execute"),
+        "/tools/other": ("shell:read",),
+        "/other": (),
+    }
+    for path, scopes in expected.items():
+        method = "GET" if path == "/tools/todo" else None
+        assert auth.required_scopes_for_http_tool(path, method) == scopes
+    assert auth.required_scopes_for_http_tool("/tools/todo", "POST") == (
+        "shell:read",
+        "shell:write",
+    )
+
+    for host, result in (
+        ("localhost", True),
+        ("127.0.0.1:123", True),
+        ("[::1]:123", True),
+        ("[::1", True),
+        ("example.com", False),
+        ("", False),
+    ):
+        assert auth._host_header_is_loopback(_request(headers={"host": host})) is result
+    assert auth._is_localhost(_request(client=None)) is False
+    assert auth._extract_token(_request(headers={"authorization": "Bearer abc"})) == "abc"
+    assert auth._extract_token(_request(headers={"authorization": "Basic abc"})) is None
+
+    monkeypatch.setenv("LOCAL_SHELL_MCP_UI_PATH", "/console")
+    get_settings.cache_clear()
+    for path in (
+        "/healthz",
+        "/remote/transfer/x",
+        "/.well-known/x",
+        "/oauth/x",
+        "/download/x",
+        "/console",
+        "/console/",
+        "/console/callback",
+        "/console/wallpaper",
+        "/console/assets/app.js",
+    ):
+        assert auth._is_public_path(path)
+    assert not auth._is_public_path("/private")
+
+
+def test_auth_oauth_body_and_mcp_helpers(tmp_path, monkeypatch):
+    _configure(
+        tmp_path,
+        monkeypatch,
+        LOCAL_SHELL_MCP_AUTH_MODE="oauth",
+        LOCAL_SHELL_MCP_OAUTH_JWT_SECRET="x" * 40,
+        LOCAL_SHELL_MCP_PUBLIC_BASE_URL="http://testserver",
+    )
+    settings = get_settings()
+    with pytest.raises(HTTPException, match="Missing OAuth"):
+        auth._verify_oauth(_request(), settings)
+
+    import local_shell_mcp.oauth as oauth
+
+    monkeypatch.setattr(oauth, "validate_bearer_token", lambda *args: (_ for _ in ()).throw(jwt.InvalidTokenError("bad")))
+    with pytest.raises(HTTPException, match="Invalid OAuth"):
+        auth._verify_oauth(
+            _request(headers={"authorization": "Bearer bad"}), settings
+        )
+    monkeypatch.setattr(oauth, "validate_bearer_token", lambda *args: {"sub": "user", "scope": "shell:read"})
+    verified = auth._verify_oauth(
+        _request(headers={"authorization": "Bearer good"}), settings
+    )
+    assert verified.subject == "user"
+
+    messages = iter(
+        [
+            {"type": "http.request", "body": b"a", "more_body": True},
+            {"type": "http.disconnect"},
+        ]
+    )
+
+    async def receive():
+        return next(messages)
+
+    assert asyncio.run(auth._read_body(receive)) == b"a"
+
+    messages = iter([{"type": "http.request", "body": b"too long", "more_body": False}])
+
+    async def large_receive():
+        return next(messages)
+
+    with pytest.raises(auth.RequestBodyTooLarge):
+        asyncio.run(auth._read_body(large_receive, 2))
+
+    original_calls = []
+
+    async def original_receive():
+        original_calls.append(True)
+        return {"type": "http.disconnect"}
+
+    replay = auth._body_receive(b"body", original_receive)
+    assert asyncio.run(replay())["body"] == b"body"
+    assert asyncio.run(replay())["type"] == "http.disconnect"
+    assert original_calls
+
+    assert auth._mcp_methods_from_body(b"") == set()
+    assert auth._mcp_methods_from_body(b"bad") == set()
+    assert auth._mcp_methods_from_body(b"[1,{\"method\":\"ping\"}]") == {"ping"}
+    assert not auth._is_mcp_discovery_request({"path": "/other", "method": "POST"}, b"{}")
+    assert not auth._is_mcp_discovery_request({"path": "/mcp", "method": "POST"}, b"[]")
+
+
+def test_auth_middlewares_all_fast_paths(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch, LOCAL_SHELL_MCP_MCP_MAX_SESSIONS=1)
+    calls = []
+    sent = []
+
+    async def app(scope, receive, send):
+        calls.append(scope)
+
+    async def receive():
+        return {"type": "http.request", "body": b"{}", "more_body": False}
+
+    async def send(message):
+        sent.append(message)
+
+    manager = SimpleNamespace(
+        _server_instances={
+            "dead": SimpleNamespace(is_terminated=True),
+            "live": SimpleNamespace(is_terminated=False),
+        },
+        _session_owners={"dead": "x", "live": "y"},
+    )
+    limiter = auth.McpSessionLimitMiddleware(app, manager)
+    assert limiter._active_session_count() == 1
+    assert "dead" not in manager._server_instances
+    assert limiter._is_new_session({"type": "websocket"}) is False
+    assert limiter._is_new_session({"type": "http", "path": "/other", "method": "POST"}) is False
+    assert limiter._is_new_session(
+        {
+            "type": "http",
+            "path": "/mcp",
+            "method": "POST",
+            "headers": [(b"mcp-session-id", b"x")],
+        }
+    ) is False
+    asyncio.run(
+        limiter(
+            {"type": "http", "path": "/mcp", "method": "POST", "headers": []},
+            receive,
+            send,
+        )
+    )
+    assert sent[0]["status"] == 429
+
+    manager._server_instances = []
+    assert limiter._active_session_count() == 0
+    calls.clear()
+    asyncio.run(limiter({"type": "http", "path": "/other", "method": "GET"}, receive, send))
+    assert calls
+
+    middleware = auth.AuthMiddleware(app)
+    calls.clear()
+    asyncio.run(middleware({"type": "websocket", "path": "/x"}, receive, send))
+    assert calls
+    calls.clear()
+    asyncio.run(middleware({"type": "http", "path": "/healthz", "method": "GET"}, receive, send))
+    assert calls
+
+    body_limit = auth.RequestBodyLimitMiddleware(app)
+    calls.clear()
+    asyncio.run(body_limit({"type": "http", "path": "/x", "method": "GET"}, receive, send))
+    assert calls
+    calls.clear()
+    asyncio.run(
+        body_limit(
+            {"type": "http", "path": "/remote/transfer/upload/x", "method": "PUT"},
+            receive,
+            send,
+        )
+    )
+    assert calls
+
+    sent.clear()
+    asyncio.run(
+        body_limit(
+            {
+                "type": "http",
+                "path": "/x",
+                "method": "POST",
+                "headers": [(b"content-length", b"999")],
+            },
+            receive,
+            send,
+        )
+    )
+    assert sent[0]["status"] == 413
+    calls.clear()
+    asyncio.run(
+        body_limit(
+            {
+                "type": "http",
+                "path": "/x",
+                "method": "POST",
+                "headers": [(b"content-length", b"invalid")],
+            },
+            receive,
+            send,
+        )
+    )
+    assert calls and calls[-1][auth._REQUEST_BODY_SCOPE_KEY] == b"{}"
+
+
+def test_playwright_helpers_and_generated_scripts(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch, LOCAL_SHELL_MCP_MAX_FILE_WRITE_BYTES=4)
+    with pytest.raises(ValueError, match="Refusing"):
+        playwright._assert_script_size("12345")
+    playwright._assert_script_size("1234")
+    with pytest.raises(ValueError, match="browser"):
+        playwright._validate_browser("edge", "load")
+    with pytest.raises(ValueError, match="wait_until"):
+        playwright._validate_browser("chromium", "later")
+
+    captured = []
+
+    async def generated(script, **kwargs):
+        captured.append((script, kwargs))
+        return {"ok": True}
+
+    monkeypatch.setattr(playwright, "_run_generated_script", generated)
+    result = asyncio.run(
+        playwright.browser_get_text("https://example.test", "firefox", "load", "main")
+    )
+    assert result["ok"] is True
+    assert "locator('main')" in captured[-1][0]
+
+    with pytest.raises(ValueError, match="capture_format"):
+        asyncio.run(playwright.browser_capture("x", capture_format="jpg"))
+    with pytest.raises(ValueError, match="requires chromium"):
+        asyncio.run(playwright.browser_capture("x", capture_format="pdf", browser="firefox"))
+
+    out = tmp_path / "shot.png"
+
+    async def make_capture(script, **kwargs):
+        out.write_bytes(b"png")
+        return {"ok": True}
+
+    monkeypatch.setattr(playwright, "_run_generated_script", make_capture)
+    capture = asyncio.run(
+        playwright.browser_capture("x", str(out), capture_format=" PNG ", width="10", height="20")
+    )
+    assert capture["capture_path"].endswith("shot.png")
+    monkeypatch.setattr(playwright, "_run_generated_script", lambda *args, **kwargs: asyncio.sleep(0, result={"ok": False}))
+    capture = asyncio.run(playwright.browser_capture("x", str(out)))
+    assert capture["capture_path"] is None
+
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_FILE_WRITE_BYTES", "1000")
+    get_settings.cache_clear()
+    commands = []
+
+    async def run_shell(command, **kwargs):
+        commands.append((command, kwargs))
+        return CommandResult(
+            ok=True,
+            exit_code=0,
+            timed_out=False,
+            duration_ms=1,
+            cwd=".",
+            command=command,
+            stdout="",
+            stderr="",
+            truncated=False,
+        )
+
+    monkeypatch.setattr(playwright, "run_shell", run_shell)
+    custom = asyncio.run(playwright.playwright_run_script("print(1)", cwd=".", timeout_s=2))
+    assert custom["script_path"].endswith(".py")
+    assert commands[-1][1]["max_output_bytes"] == 1_000_000
+
+
+def test_tmux_selection_backend_and_version(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setattr(tmux_helper.platform, "system", lambda: "Linux")
+    for machine, tag in (("AMD64", "linux-x86_64"), ("arm64", "linux-aarch64"), ("riscv", None)):
+        monkeypatch.setattr(tmux_helper.platform, "machine", lambda value=machine: value)
+        assert tmux_helper._platform_tag() == tag
+    monkeypatch.setattr(tmux_helper.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(tmux_helper.platform, "machine", lambda: "x86_64")
+    assert tmux_helper._platform_tag() is None
+
+    helper = tmp_path / "tmux"
+    helper.write_text("x", encoding="utf-8")
+    monkeypatch.setattr(tmux_helper, "_platform_tag", lambda: "linux-x86_64")
+    monkeypatch.setattr(tmux_helper.Path, "resolve", lambda self: tmp_path / "module.py")
+    assert tmux_helper.bundled_tmux_path() is None
+
+    monkeypatch.setattr(tmux_helper, "bundled_tmux_path", lambda: helper)
+    monkeypatch.setattr(tmux_helper.shutil, "which", lambda value: "/usr/bin/tmux" if value == "tmux" else None)
+    assert tmux_helper.resolve_tmux().source == "system"
+
+    configured = tmp_path / "configured"
+    configured.write_text("x", encoding="utf-8")
+    configured.chmod(configured.stat().st_mode | stat.S_IXUSR)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_TMUX_BIN", str(configured))
+    get_settings.cache_clear()
+    monkeypatch.setattr(tmux_helper.shutil, "which", lambda value: None)
+    assert tmux_helper.resolve_tmux().source == "configured"
+
+    monkeypatch.setenv("LOCAL_SHELL_MCP_TMUX_BIN", "missing")
+    get_settings.cache_clear()
+    assert tmux_helper.resolve_tmux().source == "bundled"
+    monkeypatch.setattr(tmux_helper, "bundled_tmux_path", lambda: None)
+    assert tmux_helper.resolve_tmux().source == "native"
+    assert tmux_helper.tmux_socket_name().startswith("local-shell-mcp-")
+
+    monkeypatch.setattr(tmux_helper.os, "name", "posix")
+    monkeypatch.setattr(
+        tmux_helper,
+        "resolve_tmux",
+        lambda: tmux_helper.TmuxSelection("/tmux", "bundled"),
+    )
+    info = tmux_helper.persistent_shell_backend_info()
+    assert info["backend"] == "tmux-bundled"
+    assert info["tmux_helper_version"] == tmux_helper.TMUX_HELPER_VERSION
+    monkeypatch.setattr(tmux_helper, "resolve_tmux", lambda: tmux_helper.TmuxSelection(None, "native"))
+    assert tmux_helper.persistent_shell_backend_info()["backend"] == "native"
+
+    monkeypatch.setattr(tmux_helper.os, "name", "nt")
+    monkeypatch.setattr(conpty_ops, "is_available", lambda: True)
+    assert tmux_helper.persistent_shell_backend_info()["backend"] == "conpty"
+    monkeypatch.setattr(conpty_ops, "is_available", lambda: False)
+    assert tmux_helper.persistent_shell_backend_info()["backend"] == "native"
+
+    monkeypatch.setattr(version.importlib_metadata, "version", lambda name: "9.9")
+    assert version.package_version() == "9.9"
+    monkeypatch.setattr(
+        version.importlib_metadata,
+        "version",
+        lambda name: (_ for _ in ()).throw(version.importlib_metadata.PackageNotFoundError()),
+    )
+    assert version.package_version() == version.__version__
+    assert "package 2.0" in version.format_version_info({"version": "1.0", "package_version": "2.0"})
+    assert version.format_version_info({"version": "1.0", "package_version": "1.0"}) == "local-shell-mcp 1.0"
+
+
+def test_ui_security_creation_races_and_loopback(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    inherited = "i" * 32
+    monkeypatch.setenv(ui_security.UI_LOCAL_TOKEN_ENV, inherited)
+    assert ui_security.get_or_create_ui_local_token() == inherited
+    monkeypatch.delenv(ui_security.UI_LOCAL_TOKEN_ENV)
+
+    path = ui_security._token_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("e" * 32, encoding="utf-8")
+    assert ui_security.get_or_create_ui_local_token() == "e" * 32
+    path.write_text("short", encoding="utf-8")
+    assert ui_security._read_token(path) is None
+
+    real_open = os.open
+    attempts = 0
+
+    def race_open(target, flags, mode=0o777):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            path.write_text("r" * 32, encoding="utf-8")
+            raise FileExistsError(target)
+        return real_open(target, flags, mode)
+
+    monkeypatch.setattr(ui_security.os, "open", race_open)
+    assert ui_security.get_or_create_ui_local_token() == "r" * 32
+
+    connection = _request(headers={ui_security.UI_LOCAL_TOKEN_HEADER: "r" * 32})
+    assert ui_security.has_valid_ui_local_token(connection)
+    assert not ui_security.has_valid_ui_local_token(_request())
+    for client, expected in (
+        (("localhost", 1), True),
+        (("127.0.0.1", 1), True),
+        (("[::1]", 1), True),
+        (("fe80::1%eth0", 1), False),
+        (("invalid", 1), False),
+        (None, False),
+    ):
+        assert ui_security.is_loopback_connection(_request(client=client)) is expected
+
+
+def test_search_real_tree_and_fake_grep_branches(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch, LOCAL_SHELL_MCP_MAX_TREE_ENTRIES=2)
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("x", encoding="utf-8")
+    non_dir = search.tree_sync("file.txt")
+    assert non_dir["is_directory"] is False
+    missing = search.tree_sync("missing/child")
+    assert missing["exists"] is False
+
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "dir").mkdir()
+    (tmp_path / "dir" / "nested.txt").write_text("x", encoding="utf-8")
+    (tmp_path / "other.txt").write_text("x", encoding="utf-8")
+    tree = search.tree_sync(".", depth=10, max_entries=2)
+    assert tree["truncated"] is True
+    assert not any(".git" in row for row in tree["entries"])
+    async_tree = asyncio.run(search.tree(".", 1, 10))
+    assert async_tree["exists"] is True
+
+    class Stream:
+        def __init__(self, lines=None, data=b""):
+            self.lines = list(lines or [])
+            self.data = data
+
+        async def readline(self):
+            return self.lines.pop(0) if self.lines else b""
+
+        async def read(self, size):
+            return self.data
+
+    class Process:
+        def __init__(self):
+            match = {
+                "type": "match",
+                "data": {
+                    "path": {"text": "file.txt"},
+                    "line_number": 1,
+                    "submatches": [{"start": 2}],
+                    "lines": {"text": "hello\n"},
+                },
+            }
+            self.stdout = Stream([b"not-json\n", json.dumps({"type": "summary"}).encode() + b"\n", json.dumps(match).encode() + b"\n"])
+            self.stderr = Stream(data=b"e" * 100)
+            self.returncode = 0
+            self.terminated = False
+
+        def terminate(self):
+            self.terminated = True
+            self.returncode = -15
+
+        async def wait(self):
+            return self.returncode
+
+    process = Process()
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", lambda *args, **kwargs: asyncio.sleep(0, result=process))
+    monkeypatch.setattr(search, "_close_process_transport", lambda proc: asyncio.sleep(0))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_OUTPUT_BYTES", "10")
+    get_settings.cache_clear()
+    result = asyncio.run(search.grep("hello", regex=False, case_sensitive=False, glob="*.txt", max_results=1))
+    assert result["count"] == 1
+    assert result["matches"][0]["column"] == 3
+    assert result["truncated"] is True
+    assert process.terminated is True
+
+
+
+def test_http_app_executes_every_route_wrapper(tmp_path, monkeypatch):
+    _configure(
+        tmp_path,
+        monkeypatch,
+        LOCAL_SHELL_MCP_MAX_HTTP_REQUEST_BYTES=10_000,
+    )
+
+    async def async_value(*args, **kwargs):
+        return {"args": list(args), "kwargs": kwargs}
+
+    def sync_value(*args, **kwargs):
+        return {"args": list(args), "kwargs": kwargs}
+
+    monkeypatch.setattr(http_app, "list_installed_skills", sync_value)
+    monkeypatch.setattr(http_app, "load_installed_skill", sync_value)
+    monkeypatch.setattr(http_app, "read_installed_skill_file", sync_value)
+    monkeypatch.setattr(http_app, "public_run_shell", lambda *args, **kwargs: asyncio.sleep(0, result=SimpleNamespace(model_dump=lambda: {"shell": True})))
+    for name in (
+        "start_shell", "send_shell", "read_shell", "kill_shell", "list_shells",
+        "tree", "grep", "browser_capture", "browser_get_text", "playwright_run_script",
+    ):
+        monkeypatch.setattr(http_app, name, async_value)
+    for name in (
+        "list_dir", "glob_paths", "create_download_link", "list_download_links",
+        "revoke_download_link", "read_texts", "write_text", "edit_text", "delete_path",
+        "todo_read", "todo_write",
+    ):
+        monkeypatch.setattr(http_app, name, sync_value)
+    monkeypatch.setattr(
+        http_app,
+        "download_endpoint",
+        lambda request: asyncio.sleep(0, result=JSONResponse({"download": True})),
+    )
+    monkeypatch.setattr(http_app, "ui_routes", lambda: [])
+    client = TestClient(http_app.build_http_app())
+
+    requests = [
+        ("get", "/tools/skills_list", None),
+        ("post", "/tools/skill_load", {"name": "skill"}),
+        ("post", "/tools/skill_read_file", {"name": "skill", "path": "guide.md"}),
+        ("post", "/tools/run_shell", {"command": "true", "timeout_s": None, "max_output_bytes": None}),
+        ("post", "/tools/shell_start", {}),
+        ("post", "/tools/shell_send", {"session_id": "s", "input_text": "x", "enter": False}),
+        ("post", "/tools/shell_read", {"session_id": "s", "lines": 10}),
+        ("post", "/tools/shell_kill", {"session_id": "s"}),
+        ("get", "/tools/shell_list", None),
+        ("post", "/tools/list_files", {"recursive": True, "max_entries": 3}),
+        ("post", "/tools/tree", {"depth": 2, "max_entries": 3}),
+        ("post", "/tools/glob", {"pattern": "*", "max_results": 3}),
+        ("post", "/tools/grep", {"query": "x", "regex": False, "case_sensitive": False, "max_results": None}),
+        ("get", "/download/token", None),
+        ("post", "/tools/download/create", {"path": "x", "ttl_s": None, "max_downloads": None}),
+        ("get", "/tools/download/list?include_expired=true", None),
+        ("post", "/tools/download/revoke", {"token": "x"}),
+        ("post", "/tools/read_file", {"path": "x", "start_line": None, "end_line": None}),
+        ("post", "/tools/write_file", {"path": "x", "content": "y", "overwrite": False}),
+        ("post", "/tools/edit_file", {"path": "x", "edits": []}),
+        ("post", "/tools/delete", {"path": "x", "recursive": True}),
+        ("get", "/tools/todo", None),
+        ("post", "/tools/todo", {"todos": []}),
+        ("post", "/tools/browser/capture", {"url": "x", "full_page": False, "width": 1, "height": 2}),
+        ("post", "/tools/browser/text", {"url": "x"}),
+        ("post", "/tools/playwright/run_script", {"script": "x", "timeout_s": 2}),
+    ]
+    for method, path, body in requests:
+        response = getattr(client, method)(path, json=body) if body is not None else getattr(client, method)(path)
+        assert response.status_code == 200, (method, path, response.text)
+
+    monkeypatch.setattr(
+        http_app,
+        "public_run_shell",
+        lambda *args, **kwargs: (_ for _ in ()).throw(ValueError("bad timeout")),
+    )
+    client = TestClient(http_app.build_http_app())
+    assert client.post("/tools/run_shell", json={"command": "x"}).status_code == 400
+    assert client.post("/tools/skill_load", json={"name": "x", "extra": 1}).status_code == 400
+
+
+def test_search_timeout_no_stream_and_tree_permission_branches(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+
+    class TimeoutStream:
+        async def readline(self):
+            raise TimeoutError
+
+    class Process:
+        stdout = TimeoutStream()
+        stderr = None
+        returncode = None
+        terminated = False
+
+        def terminate(self):
+            self.terminated = True
+
+        async def wait(self):
+            self.returncode = -15
+            return self.returncode
+
+    process = Process()
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", lambda *args, **kwargs: asyncio.sleep(0, result=process))
+    monkeypatch.setattr(search, "_close_process_transport", lambda proc: asyncio.sleep(0))
+    result = asyncio.run(search.grep("x"))
+    assert result["ok"] is False
+    assert process.terminated is True
+    assert result["stderr"] == ""
+
+    directory = tmp_path / "blocked"
+    directory.mkdir()
+    real_iterdir = Path.iterdir
+
+    def iterdir(path):
+        if path == directory:
+            raise OSError("denied")
+        return real_iterdir(path)
+
+    monkeypatch.setattr(Path, "iterdir", iterdir)
+    tree_result = search.tree_sync("blocked")
+    assert tree_result["entries"] == []
+
+
+def test_bundled_tmux_permissions_and_windows_import_failure(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    module_path = tmp_path / "tmux_helper.py"
+    helper = tmp_path / "helpers" / "linux-x86_64" / "tmux"
+    helper.parent.mkdir(parents=True)
+    helper.write_text("binary", encoding="utf-8")
+    monkeypatch.setattr(tmux_helper, "__file__", str(module_path))
+    monkeypatch.setattr(tmux_helper, "_platform_tag", lambda: "linux-x86_64")
+
+    access_calls = iter([False, True])
+    monkeypatch.setattr(tmux_helper.os, "access", lambda *args: next(access_calls))
+    assert tmux_helper.bundled_tmux_path() == helper
+
+    helper.chmod(0o600)
+    monkeypatch.setattr(tmux_helper.os, "access", lambda *args: False)
+    monkeypatch.setattr(Path, "chmod", lambda *args, **kwargs: (_ for _ in ()).throw(OSError("chmod")))
+    assert tmux_helper.bundled_tmux_path() is None
+
+    monkeypatch.setattr(tmux_helper, "_platform_tag", lambda: None)
+    assert tmux_helper.bundled_tmux_path() is None
+    monkeypatch.setattr(tmux_helper.os, "name", "nt")
+    monkeypatch.setattr(conpty_ops, "is_available", lambda: (_ for _ in ()).throw(RuntimeError("import")))
+    assert tmux_helper.persistent_shell_backend_info()["backend"] == "native"
+
+
+def test_ui_token_irrecoverable_paths_and_final_retry(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    path = ui_security._token_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.delenv(ui_security.UI_LOCAL_TOKEN_ENV, raising=False)
+
+    monkeypatch.setattr(ui_security.os, "open", lambda *args, **kwargs: (_ for _ in ()).throw(PermissionError("open")))
+    monkeypatch.setattr(Path, "lstat", lambda self: (_ for _ in ()).throw(FileNotFoundError(self)))
+    with pytest.raises(RuntimeError, match="Unable to create"):
+        ui_security.get_or_create_ui_local_token()
+
+    path.write_text("short", encoding="utf-8")
+    monkeypatch.setattr(Path, "lstat", lambda self: SimpleNamespace())
+    monkeypatch.setattr(Path, "unlink", lambda self: (_ for _ in ()).throw(PermissionError("unlink")))
+    with pytest.raises(RuntimeError, match="replace invalid"):
+        ui_security.get_or_create_ui_local_token()
+
+    unlink_calls = []
+    monkeypatch.setattr(Path, "unlink", lambda self: unlink_calls.append(str(self)))
+    monkeypatch.setattr(ui_security, "_read_token", lambda path: None)
+    with pytest.raises(RuntimeError, match="initialize"):
+        ui_security.get_or_create_ui_local_token()
+    assert len(unlink_calls) == 2

--- a/tests/test_edge_modules_complete.py
+++ b/tests/test_edge_modules_complete.py
@@ -476,7 +476,8 @@ def test_tmux_selection_backend_and_version(tmp_path, monkeypatch):
     assert tmux_helper.resolve_tmux().source == "native"
     assert tmux_helper.tmux_socket_name().startswith("local-shell-mcp-")
 
-    monkeypatch.setattr(tmux_helper.os, "name", "posix")
+    os_proxy = SimpleNamespace(**{**vars(os), "name": "posix"})
+    monkeypatch.setattr(tmux_helper, "os", os_proxy)
     monkeypatch.setattr(
         tmux_helper,
         "resolve_tmux",
@@ -488,7 +489,7 @@ def test_tmux_selection_backend_and_version(tmp_path, monkeypatch):
     monkeypatch.setattr(tmux_helper, "resolve_tmux", lambda: tmux_helper.TmuxSelection(None, "native"))
     assert tmux_helper.persistent_shell_backend_info()["backend"] == "native"
 
-    monkeypatch.setattr(tmux_helper.os, "name", "nt")
+    os_proxy.name = "nt"
     monkeypatch.setattr(conpty_ops, "is_available", lambda: True)
     assert tmux_helper.persistent_shell_backend_info()["backend"] == "conpty"
     monkeypatch.setattr(conpty_ops, "is_available", lambda: False)
@@ -754,7 +755,8 @@ def test_bundled_tmux_permissions_and_windows_import_failure(tmp_path, monkeypat
 
     monkeypatch.setattr(tmux_helper, "_platform_tag", lambda: None)
     assert tmux_helper.bundled_tmux_path() is None
-    monkeypatch.setattr(tmux_helper.os, "name", "nt")
+    os_proxy = SimpleNamespace(**{**vars(os), "name": "nt"})
+    monkeypatch.setattr(tmux_helper, "os", os_proxy)
     monkeypatch.setattr(conpty_ops, "is_available", lambda: (_ for _ in ()).throw(RuntimeError("import")))
     assert tmux_helper.persistent_shell_backend_info()["backend"] == "native"
 

--- a/tests/test_human_ui_complete.py
+++ b/tests/test_human_ui_complete.py
@@ -1,0 +1,653 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import signal
+import subprocess
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+import local_shell_mcp.human_ui as ui
+from local_shell_mcp.auth import Principal
+from local_shell_mcp.settings import get_settings
+
+
+def _configure(tmp_path, monkeypatch, *, remote: bool = False, auth: str = "none"):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(tmp_path / ".state"))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_AUDIT_LOG_PATH", str(tmp_path / "audit.jsonl"))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_AUTH_MODE", auth)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_REMOTE_ENABLED", str(remote).lower())
+    monkeypatch.setenv("LOCAL_SHELL_MCP_UI_WALLPAPER", "none")
+    get_settings.cache_clear()
+
+
+def _request(path: str = "/", *, query: bytes = b"", method: str = "GET") -> Request:
+    return Request(
+        {
+            "type": "http",
+            "asgi": {"version": "3.0"},
+            "http_version": "1.1",
+            "method": method,
+            "scheme": "http",
+            "path": path,
+            "raw_path": path.encode(),
+            "query_string": query,
+            "headers": [],
+            "client": ("127.0.0.1", 1234),
+            "server": ("testserver", 80),
+        }
+    )
+
+
+class FakeRemoteManager:
+    def __init__(self):
+        self.calls: list[tuple[str, str, dict, int | None]] = []
+        self.response: dict = {"ok": True, "data": {}}
+        self.machines = {
+            "machines": [
+                {
+                    "name": "win-node",
+                    "status": "online",
+                    "info": {"platform": "Windows-11"},
+                }
+            ],
+            "counts": {"online": 1, "offline": 0, "total": 1},
+        }
+
+    async def call(self, machine, tool, args, timeout_s=None):
+        self.calls.append((machine, tool, args, timeout_s))
+        return self.response
+
+    def list_machines(self):
+        return self.machines
+
+    async def create_invite(self, name=None, workdir=None, ttl_s=None, base_url=None):
+        return {"name": name, "workdir": workdir, "ttl_s": ttl_s, "base_url": base_url}
+
+    def rename(self, machine, new_name):
+        return {"old_name": machine, "new_name": new_name}
+
+    def revoke(self, machine):
+        return {"machine": machine, "revoked": True}
+
+
+def test_index_assets_principal_and_basic_helpers(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    empty = tmp_path / "assets"
+    empty.mkdir()
+    monkeypatch.setattr(ui, "_assets_dir", lambda: empty)
+    assert "assets are not built" in ui._ui_index_html()
+
+    index = empty / "index.html"
+    index.write_text("__LSM_UI_PATH__ __LSM_UI_CONFIG_JSON__", encoding="utf-8")
+    rendered = ui._ui_index_html()
+    assert "/ui" in rendered
+    assert "apiPrefix" in rendered
+
+    principal = Principal(email=None, subject="s", claims={"scope": "shell:read remote:use"})
+    request = _request()
+    request.state.principal = principal
+    assert ui._request_principal(request) is principal
+    ui._require_ui_scopes(request, "shell:read", machine="node")
+
+    assert ui._bounded_int(None, default=7, minimum=1, maximum=10, label="x") == 7
+    assert ui._bounded_int("", default=8, minimum=1, maximum=10, label="x") == 8
+    assert ui._path_name(".") == "."
+    assert ui._parent_path("") == "."
+
+    assert ui._split_tui_command("echo hello", windows=False) == ["echo", "hello"]
+    with pytest.raises(ValueError, match="empty"):
+        ui._split_tui_command("   ", windows=False)
+
+
+def test_asset_cache_and_wallpaper_branches(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    immutable = assets / "app.123.js"
+    immutable.write_text("js", encoding="utf-8")
+    regular = assets / "app.js"
+    regular.write_text("js", encoding="utf-8")
+    directory = assets / "folder"
+    directory.mkdir()
+    monkeypatch.setattr(ui, "_assets_dir", lambda: assets)
+
+    app = Starlette(routes=[Route("/assets/{path:path}", ui.ui_asset)])
+    client = TestClient(app)
+    assert client.get("/assets//etc/passwd").status_code == 404
+    assert client.get("/assets/../secret").status_code == 404
+    assert client.get("/assets/missing").status_code == 404
+    assert client.get("/assets/folder").status_code == 404
+    assert "31536000" in client.get("/assets/app.123.js").headers["cache-control"]
+    assert "3600" in client.get("/assets/app.js").headers["cache-control"]
+
+    monkeypatch.setenv("LOCAL_SHELL_MCP_UI_WALLPAPER", "bing")
+    get_settings.cache_clear()
+    state_ui = tmp_path / ".state" / "ui"
+    state_ui.mkdir(parents=True)
+    image = state_ui / "wallpaper.jpg"
+    stamp = state_ui / "wallpaper-date.txt"
+    today = ui.time.strftime("%Y-%m-%d", ui.time.gmtime())
+    stamp.write_text(today, encoding="utf-8")
+    assert asyncio.run(ui.ui_wallpaper(_request())).status_code == 204
+    image.write_bytes(b"cached")
+    cached = asyncio.run(ui.ui_wallpaper(_request()))
+    assert cached.status_code == 200
+
+    stamp.unlink()
+
+    class Response:
+        def __init__(self, *, payload=None, content=b""):
+            self._payload = payload
+            self.content = content
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    class Client:
+        def __init__(self, *args, **kwargs):
+            self.calls = 0
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def get(self, url, **kwargs):
+            self.calls += 1
+            if self.calls == 1:
+                return Response(payload={"images": [{"url": "/image.jpg"}]})
+            return Response(content=b"fresh")
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", Client)
+    image.unlink()
+    fetched = asyncio.run(ui.ui_wallpaper(_request()))
+    assert fetched.status_code == 200
+    assert image.read_bytes() == b"fresh"
+
+    class InvalidClient(Client):
+        async def get(self, url, **kwargs):
+            return Response(payload={"images": []})
+
+    monkeypatch.setattr(httpx, "AsyncClient", InvalidClient)
+    stamp.unlink()
+    image.write_bytes(b"stale")
+    stale = asyncio.run(ui.ui_wallpaper(_request()))
+    assert stale.status_code == 200
+    assert stamp.read_text(encoding="utf-8") == today
+
+
+def test_remote_dispatch_machine_rows_and_errors(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch, remote=True)
+    manager = FakeRemoteManager()
+    monkeypatch.setattr(ui, "remote_manager", lambda: manager)
+
+    rows = ui._machine_rows()
+    assert rows["counts"] == {"online": 2, "offline": 0, "total": 2}
+    assert rows["machines"][0]["name"] == "local"
+    assert ui._machine_uses_windows_paths("win-node") is True
+    assert ui._machine_uses_windows_paths("missing") is False
+
+    async def local_coroutine():
+        return {"async": True}
+
+    assert asyncio.run(ui._machine_dispatch("local", lambda: {"sync": True}, "x", {})) == {
+        "sync": True
+    }
+    assert asyncio.run(ui._machine_dispatch("local", local_coroutine, "x", {})) == {
+        "async": True
+    }
+
+    manager.response = {"ok": True, "data": {"value": 1}}
+    assert asyncio.run(ui._remote_call("win-node", "tool", {"a": 1})) == {"value": 1}
+    assert manager.calls[-1][2]["_human"] is True
+    manager.response = {"ok": False, "message": "failed"}
+    with pytest.raises(RuntimeError, match="failed"):
+        asyncio.run(ui._remote_call("win-node", "tool", {}))
+    manager.response = {
+        "ok": True,
+        "data": {"status": "error", "error_type": "Boom", "message": "bad"},
+    }
+    with pytest.raises(RuntimeError, match="bad"):
+        asyncio.run(ui._remote_call("win-node", "tool", {}))
+
+    def broken():
+        raise RuntimeError("registry")
+
+    monkeypatch.setattr(manager, "list_machines", broken)
+    assert ui._machine_uses_windows_paths("win-node") is False
+
+
+def test_remote_file_terminal_todo_audit_and_admin_routes(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch, remote=True)
+    manager = FakeRemoteManager()
+    monkeypatch.setattr(ui, "remote_manager", lambda: manager)
+    app = Starlette(routes=ui.ui_routes())
+    client = TestClient(app)
+
+    manager.response = {
+        "ok": True,
+        "data": [{"path": r"C:\work\folder", "type": "dir"}],
+    }
+    files = client.get("/api/ui/files", params={"machine": "win-node", "path": r"C:\work"})
+    assert files.status_code == 200
+    assert files.json()["data"]["entries"][0]["name"] == "folder"
+
+    preview_dir = client.get(
+        "/api/ui/files/preview", params={"machine": "win-node", "path": r"C:\work\folder"}
+    )
+    assert preview_dir.json()["data"]["kind"] == "directory"
+
+    manager.response = {"ok": True, "data": {"preview": "00 ff", "binary": True}}
+    preview_binary = client.get(
+        "/api/ui/files/preview", params={"machine": "win-node", "path": "x.bin"}
+    )
+    assert preview_binary.json()["data"]["kind"] == "binary"
+
+    manager.response = {"ok": True, "data": "plain"}
+    preview_text = client.get(
+        "/api/ui/files/preview", params={"machine": "win-node", "path": "x.txt"}
+    )
+    assert preview_text.json()["data"]["kind"] == "text"
+
+    manager.response = {"ok": True, "data": {"binary": True}}
+    assert client.get(
+        "/api/ui/files/content", params={"machine": "win-node", "path": "x"}
+    ).status_code == 400
+    manager.response = {"ok": True, "data": "invalid"}
+    assert client.get(
+        "/api/ui/files/content", params={"machine": "win-node", "path": "x"}
+    ).status_code == 400
+    assert client.get(
+        "/api/ui/files/content", params={"machine": "win-node", "path": ""}
+    ).status_code == 400
+
+    manager.response = {"ok": True, "data": {"done": True}}
+    for action, body in (
+        ("delete", {"path": "x"}),
+        ("write", {"path": "x", "content": "data"}),
+        ("mkdir", {"path": "x"}),
+        ("touch", {"path": "x"}),
+        ("rename", {"path": "x", "destination": "y"}),
+        ("copy", {"path": "x", "destination": "y"}),
+        ("move", {"path": "x", "destination": "y"}),
+    ):
+        response = client.post(
+            f"/api/ui/files/{action}", json={"machine": "win-node", **body}
+        )
+        assert response.status_code == 200, action
+    assert client.post(
+        "/api/ui/files/unknown", json={"machine": "win-node", "path": "x"}
+    ).status_code == 400
+    assert client.post(
+        "/api/ui/files/write", json={"machine": "win-node", "path": ""}
+    ).status_code == 400
+
+    manager.response = {"ok": True, "data": None}
+    terminals = client.get("/api/ui/terminals", params={"machine": "win-node"})
+    assert terminals.json()["data"]["sessions"] == []
+    manager.response = {"ok": True, "data": {"output": "ok"}}
+    assert client.get(
+        "/api/ui/terminals/read",
+        params={"machine": "win-node", "session_id": "s", "lines": 10},
+    ).status_code == 200
+    assert client.get(
+        "/api/ui/terminals/read", params={"machine": "win-node", "session_id": ""}
+    ).status_code == 400
+    for action, body in (
+        ("start", {}),
+        ("send", {"session_id": "s", "input_text": "x"}),
+        ("kill", {"session_id": "s"}),
+    ):
+        assert client.post(
+            f"/api/ui/terminals/{action}", json={"machine": "win-node", **body}
+        ).status_code == 200
+    assert client.post(
+        "/api/ui/terminals/send", json={"machine": "win-node"}
+    ).status_code == 400
+    assert client.post(
+        "/api/ui/terminals/kill", json={"machine": "win-node"}
+    ).status_code == 400
+    assert client.post(
+        "/api/ui/terminals/unknown", json={"machine": "win-node"}
+    ).status_code == 400
+
+    monkeypatch.setattr(ui, "todo_read", lambda: (_ for _ in ()).throw(RuntimeError("todo")))
+    assert client.get("/api/ui/todos").status_code == 400
+    assert client.get("/api/ui/audit", params={"limit": "bad"}).status_code == 400
+
+    listing = client.get("/api/ui/remotes")
+    assert listing.status_code == 200
+    invite = client.post(
+        "/api/ui/remotes", json={"name": "node", "workdir": "/w", "ttl_s": 90}
+    )
+    assert invite.status_code == 200
+    assert invite.json()["data"]["base_url"] == "http://testserver"
+    assert client.post(
+        "/api/ui/remotes/rename", json={"machine": "node", "new_name": "new"}
+    ).status_code == 200
+    assert client.post(
+        "/api/ui/remotes/revoke", json={"machine": "node"}
+    ).status_code == 200
+    assert client.post(
+        "/api/ui/remotes/rename", json={"machine": ""}
+    ).status_code == 400
+    assert client.post(
+        "/api/ui/remotes/unknown", json={"machine": "node"}
+    ).status_code == 400
+
+
+def test_local_preview_recovery_and_api_errors(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    folder = tmp_path / "folder"
+    folder.mkdir()
+    (folder / "child.txt").write_text("x", encoding="utf-8")
+    (tmp_path / "text.txt").write_text("hello", encoding="utf-8")
+    client = TestClient(Starlette(routes=ui.ui_routes()))
+
+    directory = client.get("/api/ui/files/preview", params={"path": "folder"})
+    assert directory.json()["data"]["kind"] == "directory"
+    text = client.get("/api/ui/files/preview", params={"path": "text.txt"})
+    assert text.json()["data"]["kind"] == "text"
+    missing = client.get("/api/ui/files/preview", params={"path": "missing"})
+    assert missing.status_code == 400
+
+    monkeypatch.setattr(ui, "read_text", lambda *args, **kwargs: (_ for _ in ()).throw(IsADirectoryError()))
+    monkeypatch.setattr(ui, "list_dir", lambda *args, **kwargs: [{"path": "folder/child", "type": "file"}])
+    recovered = client.get("/api/ui/files/preview", params={"path": "text.txt"})
+    assert recovered.json()["data"]["kind"] == "directory"
+
+    monkeypatch.setattr(ui, "list_shells", lambda: (_ for _ in ()).throw(RuntimeError("shells")))
+    assert client.get("/api/ui/terminals").status_code == 400
+
+
+def test_resolve_spawn_and_tui_cli_branches(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_UI_TUI_COMMAND", '"/tmp/tui binary" --flag')
+    get_settings.cache_clear()
+    assert ui.resolve_tui_command() == ["/tmp/tui binary", "--flag"]
+
+    monkeypatch.delenv("LOCAL_SHELL_MCP_UI_TUI_COMMAND")
+    get_settings.cache_clear()
+    candidate = tmp_path / "local-shell-mcp-tui"
+    candidate.write_text("x", encoding="utf-8")
+    monkeypatch.setattr(ui.sys, "executable", str(tmp_path / "python"))
+    assert ui.resolve_tui_command() == [str(candidate)]
+    candidate.unlink()
+
+    source = tmp_path / "tui.tsx"
+    source.write_text("x", encoding="utf-8")
+    monkeypatch.setattr(ui.Path, "is_file", lambda self: False)
+    monkeypatch.setattr(ui, "_tui_source_path", lambda: source)
+    monkeypatch.setattr(ui.shutil, "which", lambda name: "/usr/bin/bun")
+    assert ui.resolve_tui_command() == ["/usr/bin/bun", str(source)]
+    monkeypatch.setattr(ui.shutil, "which", lambda name: None)
+    with pytest.raises(RuntimeError, match="Bun"):
+        ui.resolve_tui_command()
+    monkeypatch.setattr(ui, "_tui_source_path", lambda: None)
+    with pytest.raises(RuntimeError, match="runtime not found"):
+        ui.resolve_tui_command()
+
+    captured = {}
+
+    class FakeUnix:
+        def __init__(self, command, env, cols, rows):
+            captured.update(command=command, env=env, cols=cols, rows=rows)
+
+    monkeypatch.setenv("LOCAL_SHELL_MCP_UI_TUI_COMMAND", "/tmp/tui")
+    get_settings.cache_clear()
+    monkeypatch.setattr(ui, "_UnixPtyProcess", FakeUnix)
+    monkeypatch.setattr(ui.os, "name", "posix")
+    ui._spawn_tui_process(80, 24)
+    assert captured["env"]["LOCAL_SHELL_MCP_UI_MODE"] == "web"
+
+    monkeypatch.setattr(ui, "resolve_tui_command", lambda: ["tui"])
+    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: SimpleNamespace(returncode=7))
+    with pytest.raises(SystemExit) as raised:
+        ui.run_tui_cli(["--api-base", "http://localhost:8765/api/ui"])
+    assert raised.value.code == 7
+
+    def interrupted(*args, **kwargs):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(subprocess, "run", interrupted)
+    with pytest.raises(SystemExit) as raised:
+        ui.run_tui_cli([])
+    assert raised.value.code == 130
+    with pytest.raises(SystemExit):
+        ui.run_tui_cli(["--api-base", "https://public.test/api/ui"])
+
+
+def test_unix_and_windows_pty_edge_branches(monkeypatch):
+    unix = ui._UnixPtyProcess.__new__(ui._UnixPtyProcess)
+    unix.master_fd = 5
+    reads = iter([BlockingIOError(), b"data"])
+
+    def read(fd, size):
+        value = next(reads)
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    monkeypatch.setattr(ui.os, "read", read)
+    real_sleep = asyncio.sleep
+    monkeypatch.setattr(ui.asyncio, "sleep", lambda delay: real_sleep(0))
+    assert asyncio.run(unix.read()) == b"data"
+    monkeypatch.setattr(ui.os, "read", lambda *args: (_ for _ in ()).throw(OSError()))
+    assert asyncio.run(unix.read()) == b""
+    monkeypatch.setattr(ui.os, "write", lambda *args: 0)
+    with pytest.raises(OSError, match="no progress"):
+        unix._write_all(b"x")
+
+    class FakeStruct:
+        def pack(self, *args):
+            return b"size"
+
+    calls = []
+    unix._struct = FakeStruct()
+    unix._fcntl = SimpleNamespace(ioctl=lambda *args: calls.append(args))
+    unix._termios = SimpleNamespace(TIOCSWINSZ=1)
+    unix.process = SimpleNamespace(pid=12, poll=lambda: None)
+    monkeypatch.setattr(ui.os, "killpg", lambda *args: calls.append(args), raising=False)
+    unix.resize(80, 24)
+    assert calls
+
+    class Process:
+        def __init__(self):
+            self.polls = iter([None, None])
+            self.pid = 12
+
+        def poll(self):
+            return next(self.polls)
+
+        def wait(self):
+            raise RuntimeError("wait")
+
+    unix.process = Process()
+    monkeypatch.setattr(ui.signal, "SIGTERM", signal.SIGTERM, raising=False)
+    monkeypatch.setattr(ui.signal, "SIGKILL", getattr(signal, "SIGKILL", 9), raising=False)
+    monkeypatch.setattr(ui.os, "close", lambda fd: None)
+    kills = []
+    monkeypatch.setattr(ui.os, "killpg", lambda pid, sig: kills.append(sig), raising=False)
+    asyncio.run(unix.close())
+    assert ui.signal.SIGTERM in kills and ui.signal.SIGKILL in kills
+
+    fake_winpty = types.ModuleType("winpty")
+
+    class Spawned:
+        def __init__(self):
+            self.read_calls = 0
+
+        def setwinsize(self, rows, cols):
+            self.size = (rows, cols)
+
+        def read(self, *args):
+            self.read_calls += 1
+            if self.read_calls == 1:
+                raise TypeError
+            return "text"
+
+        def write(self, text):
+            return object()
+
+        def terminate(self, force):
+            self.terminated = force
+
+    spawned = Spawned()
+
+    class PtyProcess:
+        calls = 0
+
+        @classmethod
+        def spawn(cls, command, **kwargs):
+            cls.calls += 1
+            if cls.calls == 1:
+                raise TypeError
+            return spawned
+
+    fake_winpty.PtyProcess = PtyProcess
+    monkeypatch.setitem(sys.modules, "winpty", fake_winpty)
+    windows = ui._WindowsPtyProcess(["cmd", "/c", "echo"], {}, 80, 24)
+    windows.resize(70, 20)
+    assert spawned.size == (20, 70)
+    assert asyncio.run(windows.read()) == b"text"
+    with pytest.raises(OSError, match="Unexpected"):
+        asyncio.run(windows.write(b"x"))
+    asyncio.run(windows.close())
+    assert spawned.terminated is True
+    spawned.read = lambda *args: (_ for _ in ()).throw(RuntimeError("read"))
+    assert asyncio.run(windows.read()) == b""
+
+
+def test_websocket_control_flow_and_limits(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+
+    class Process:
+        def __init__(self, reads=None):
+            self.reads = list(reads or [b""])
+            self.writes = []
+            self.resizes = []
+            self.closed = False
+
+        async def read(self):
+            if self.reads:
+                return self.reads.pop(0)
+            await asyncio.sleep(0.05)
+            return b""
+
+        async def write(self, data):
+            self.writes.append(data)
+
+        def resize(self, cols, rows):
+            self.resizes.append((cols, rows))
+
+        async def close(self):
+            self.closed = True
+
+    class Socket:
+        def __init__(self, messages=None, *, headers=None, query=None, fail_accept=False):
+            self.headers = headers or {"sec-websocket-protocol": "lsm-ui"}
+            self.query_params = query or {}
+            self.messages = list(messages or [])
+            self.closed = []
+            self.sent = []
+            self.accepted = None
+            self.fail_accept = fail_accept
+
+        async def accept(self, subprotocol=None):
+            if self.fail_accept:
+                raise RuntimeError("accept")
+            self.accepted = subprotocol
+
+        async def close(self, code=1000, reason=""):
+            self.closed.append((code, reason))
+
+        async def send_bytes(self, data):
+            self.sent.append(data)
+
+        async def receive(self):
+            await asyncio.sleep(0)
+            if self.messages:
+                return self.messages.pop(0)
+            return {"type": "websocket.disconnect"}
+
+    monkeypatch.setattr(ui, "_authorize_websocket", lambda websocket: False)
+    unauthorized = Socket()
+    asyncio.run(ui.ui_terminal_websocket(unauthorized))
+    assert unauthorized.closed[0][0] == 4401
+
+    monkeypatch.setattr(ui, "_authorize_websocket", lambda websocket: True)
+    ui._ACTIVE_UI_TERMINALS.clear()
+    monkeypatch.setenv("LOCAL_SHELL_MCP_UI_TERMINAL_MAX_SESSIONS", "1")
+    get_settings.cache_clear()
+    ui._ACTIVE_UI_TERMINALS.add(1)
+    limited = Socket()
+    asyncio.run(ui.ui_terminal_websocket(limited))
+    assert limited.closed[0][0] == 4429
+    ui._ACTIVE_UI_TERMINALS.clear()
+
+    failed_accept = Socket(fail_accept=True)
+    with pytest.raises(RuntimeError, match="accept"):
+        asyncio.run(ui.ui_terminal_websocket(failed_accept))
+    assert id(failed_accept) not in ui._ACTIVE_UI_TERMINALS
+
+    monkeypatch.setattr(ui, "_spawn_tui_process", lambda *args: (_ for _ in ()).throw(RuntimeError("spawn")))
+    spawn_failure = Socket()
+    asyncio.run(ui.ui_terminal_websocket(spawn_failure))
+    assert b"Unable to start the TUI" in spawn_failure.sent[0]
+    assert spawn_failure.closed[-1][0] == 1011
+
+    process = Process([b"hello"])
+    monkeypatch.setattr(ui, "_spawn_tui_process", lambda *args: process)
+    messages = [
+        {"type": "websocket.receive", "bytes": b"bytes"},
+        {"type": "websocket.receive", "text": "raw text"},
+        {"type": "websocket.receive", "text": "[]"},
+        {"type": "websocket.receive", "text": ""},
+        {
+            "type": "websocket.receive",
+            "text": json.dumps({"type": "resize", "cols": 90, "rows": 30}),
+        },
+        {"type": "websocket.disconnect"},
+    ]
+    socket = Socket(messages)
+    asyncio.run(ui.ui_terminal_websocket(socket))
+    assert socket.accepted == "lsm-ui"
+    assert b"hello" in socket.sent
+    assert b"bytes" in process.writes
+    assert b"raw text" in process.writes
+    assert process.closed is True
+
+    process = Process([b"keep-running"] * 10)
+    monkeypatch.setattr(ui, "_spawn_tui_process", lambda *args: process)
+    invalid_resize = Socket(
+        [
+            {
+                "type": "websocket.receive",
+                "text": json.dumps({"type": "resize", "cols": "wide", "rows": 30}),
+            }
+        ]
+    )
+    asyncio.run(ui.ui_terminal_websocket(invalid_resize))
+    assert any(code == 4400 for code, _ in invalid_resize.closed)
+
+
+def test_ui_routes_disabled(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_UI_ENABLED", "false")
+    get_settings.cache_clear()
+    assert ui.ui_routes() == []

--- a/tests/test_human_ui_complete.py
+++ b/tests/test_human_ui_complete.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import signal
 import subprocess
 import sys
@@ -391,16 +392,17 @@ def test_resolve_spawn_and_tui_cli_branches(tmp_path, monkeypatch):
 
     source = tmp_path / "tui.tsx"
     source.write_text("x", encoding="utf-8")
-    monkeypatch.setattr(ui.Path, "is_file", lambda self: False)
-    monkeypatch.setattr(ui, "_tui_source_path", lambda: source)
-    monkeypatch.setattr(ui.shutil, "which", lambda name: "/usr/bin/bun")
-    assert ui.resolve_tui_command() == ["/usr/bin/bun", str(source)]
-    monkeypatch.setattr(ui.shutil, "which", lambda name: None)
-    with pytest.raises(RuntimeError, match="Bun"):
-        ui.resolve_tui_command()
-    monkeypatch.setattr(ui, "_tui_source_path", lambda: None)
-    with pytest.raises(RuntimeError, match="runtime not found"):
-        ui.resolve_tui_command()
+    with monkeypatch.context() as scoped:
+        scoped.setattr(ui.Path, "is_file", lambda self: False)
+        scoped.setattr(ui, "_tui_source_path", lambda: source)
+        scoped.setattr(ui.shutil, "which", lambda name: "/usr/bin/bun")
+        assert ui.resolve_tui_command() == ["/usr/bin/bun", str(source)]
+        scoped.setattr(ui.shutil, "which", lambda name: None)
+        with pytest.raises(RuntimeError, match="Bun"):
+            ui.resolve_tui_command()
+        scoped.setattr(ui, "_tui_source_path", lambda: None)
+        with pytest.raises(RuntimeError, match="runtime not found"):
+            ui.resolve_tui_command()
 
     captured = {}
 
@@ -411,7 +413,9 @@ def test_resolve_spawn_and_tui_cli_branches(tmp_path, monkeypatch):
     monkeypatch.setenv("LOCAL_SHELL_MCP_UI_TUI_COMMAND", "/tmp/tui")
     get_settings.cache_clear()
     monkeypatch.setattr(ui, "_UnixPtyProcess", FakeUnix)
-    monkeypatch.setattr(ui.os, "name", "posix")
+    os_proxy = SimpleNamespace(**{**vars(os), "name": "posix"})
+    monkeypatch.setattr(ui, "os", os_proxy)
+    monkeypatch.setattr(ui, "resolve_tui_command", lambda: ["/tmp/tui"])
     ui._spawn_tui_process(80, 24)
     assert captured["env"]["LOCAL_SHELL_MCP_UI_MODE"] == "web"
 
@@ -462,6 +466,7 @@ def test_unix_and_windows_pty_edge_branches(monkeypatch):
     unix._fcntl = SimpleNamespace(ioctl=lambda *args: calls.append(args))
     unix._termios = SimpleNamespace(TIOCSWINSZ=1)
     unix.process = SimpleNamespace(pid=12, poll=lambda: None)
+    monkeypatch.setattr(ui.signal, "SIGWINCH", getattr(signal, "SIGWINCH", 28), raising=False)
     monkeypatch.setattr(ui.os, "killpg", lambda *args: calls.append(args), raising=False)
     unix.resize(80, 24)
     assert calls

--- a/tests/test_human_ui_complete.py
+++ b/tests/test_human_ui_complete.py
@@ -384,7 +384,8 @@ def test_resolve_spawn_and_tui_cli_branches(tmp_path, monkeypatch):
 
     monkeypatch.delenv("LOCAL_SHELL_MCP_UI_TUI_COMMAND")
     get_settings.cache_clear()
-    candidate = tmp_path / "local-shell-mcp-tui"
+    sidecar_name = "local-shell-mcp-tui.exe" if ui.os.name == "nt" else "local-shell-mcp-tui"
+    candidate = tmp_path / sidecar_name
     candidate.write_text("x", encoding="utf-8")
     monkeypatch.setattr(ui.sys, "executable", str(tmp_path / "python"))
     assert ui.resolve_tui_command() == [str(candidate)]

--- a/tests/test_main_complete.py
+++ b/tests/test_main_complete.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import local_shell_mcp.human_ui as human_ui
+import local_shell_mcp.jobs as jobs
+import local_shell_mcp.main as main_module
+import local_shell_mcp.remote as remote
+import local_shell_mcp.settings as settings_module
+import local_shell_mcp.tools as tools
+import local_shell_mcp.version as version
+
+
+class FakeMcp:
+    def __init__(self, *, streamable: bool = False, sse: bool = False, legacy_type_error: bool = False):
+        self.calls: list[tuple[str, object]] = []
+        self._legacy_type_error = legacy_type_error
+        self._session_manager = SimpleNamespace(session_idle_timeout=0)
+        if streamable:
+            self.streamable_http_app = lambda: "streamable-inner"
+        if sse:
+            self.sse_app = lambda: "sse-inner"
+
+    def run(self, *, transport: str) -> None:
+        self.calls.append(("run", transport))
+        if self._legacy_type_error and transport == "streamable-http":
+            self._legacy_type_error = False
+            raise TypeError("old sdk")
+
+
+def _settings(**updates):
+    defaults = {
+        "mode": "mcp",
+        "host": "127.0.0.1",
+        "port": 9876,
+        "auth_mode": "none",
+        "remote_enabled": False,
+        "mcp_session_idle_timeout_s": 9,
+    }
+    defaults.update(updates)
+    return SimpleNamespace(**defaults)
+
+
+def test_run_mcp_stdio_and_legacy_fallback(monkeypatch):
+    validated = []
+    fake = FakeMcp()
+    monkeypatch.setattr(settings_module, "get_settings", lambda: _settings(mode="stdio"))
+    monkeypatch.setattr(settings_module, "validate_public_oauth_configuration", validated.append)
+    monkeypatch.setattr(tools, "build_mcp", lambda: fake)
+
+    main_module.run_mcp()
+
+    assert fake.calls == [("run", "stdio")]
+    assert validated and validated[0].mode == "stdio"
+
+    legacy = FakeMcp(legacy_type_error=True)
+    monkeypatch.setattr(settings_module, "get_settings", lambda: _settings())
+    monkeypatch.setattr(tools, "build_mcp", lambda: legacy)
+    main_module.run_mcp()
+    assert legacy.calls == [("run", "streamable-http"), ("run", "sse")]
+
+
+def test_run_mcp_streamable_and_sse(monkeypatch):
+    import uvicorn
+
+    runs = []
+    monkeypatch.setattr(uvicorn, "run", lambda app, **kwargs: runs.append((app, kwargs)))
+    monkeypatch.setattr(settings_module, "validate_public_oauth_configuration", lambda value: None)
+    monkeypatch.setattr(main_module, "_build_mcp_http_app", lambda mcp: ("wrapped", mcp))
+
+    streamable = FakeMcp(streamable=True)
+    monkeypatch.setattr(settings_module, "get_settings", lambda: _settings())
+    monkeypatch.setattr(tools, "build_mcp", lambda: streamable)
+    main_module.run_mcp()
+    assert runs.pop() == (("wrapped", streamable), {"host": "127.0.0.1", "port": 9876})
+
+    class FakeApp:
+        def __init__(self):
+            self.middleware = []
+
+        def add_middleware(self, middleware, **kwargs):
+            self.middleware.append((middleware, kwargs))
+
+    monkeypatch.setattr(main_module, "_with_oauth_routes", lambda inner: FakeApp())
+    for auth_mode, expected_middleware_count in (("none", 1), ("oauth", 2)):
+        sse = FakeMcp(sse=True)
+        monkeypatch.setattr(settings_module, "get_settings", lambda mode=auth_mode: _settings(auth_mode=mode))
+        monkeypatch.setattr(tools, "build_mcp", lambda item=sse: item)
+        main_module.run_mcp()
+        app, kwargs = runs.pop()
+        assert kwargs == {"host": "127.0.0.1", "port": 9876}
+        assert len(app.middleware) == expected_middleware_count
+
+
+def test_build_mcp_http_app_applies_timeout_and_middleware(monkeypatch):
+    class FakeInnerMcp:
+        def __init__(self):
+            self._session_manager = SimpleNamespace(session_idle_timeout=0)
+
+        def streamable_http_app(self):
+            return object()
+
+    class FakeApp:
+        def __init__(self):
+            self.middleware = []
+
+        def add_middleware(self, middleware, **kwargs):
+            self.middleware.append((middleware, kwargs))
+
+    fake_app = FakeApp()
+    monkeypatch.setattr(main_module, "_with_oauth_routes", lambda inner: fake_app)
+    monkeypatch.setattr(settings_module, "get_settings", lambda: _settings(auth_mode="oauth"))
+    mcp = FakeInnerMcp()
+
+    result = main_module._build_mcp_http_app(mcp)
+
+    assert result is fake_app
+    assert mcp._session_manager.session_idle_timeout == 9
+    assert len(fake_app.middleware) == 3
+
+    no_manager = SimpleNamespace(streamable_http_app=lambda: object())
+    fake_app.middleware.clear()
+    monkeypatch.setattr(settings_module, "get_settings", lambda: _settings(auth_mode="none"))
+    main_module._build_mcp_http_app(no_manager)
+    assert len(fake_app.middleware) == 1
+
+
+def test_run_http(monkeypatch):
+    import uvicorn
+
+    import local_shell_mcp.http_app as http_app
+
+    settings = _settings(mode="http")
+    calls = []
+    monkeypatch.setattr(settings_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(settings_module, "validate_public_oauth_configuration", lambda value: calls.append(("validate", value)))
+    monkeypatch.setattr(http_app, "build_http_app", lambda: "http-app")
+    monkeypatch.setattr(uvicorn, "run", lambda app, **kwargs: calls.append((app, kwargs)))
+
+    main_module.run_http()
+
+    assert calls == [("validate", settings), ("http-app", {"host": "127.0.0.1", "port": 9876})]
+
+
+def test_main_subcommands_and_version(monkeypatch, capsys):
+    calls = []
+    monkeypatch.setattr(jobs, "run_job_runner_cli", lambda argv: calls.append(("job", argv)))
+    monkeypatch.setattr(remote, "run_worker_cli", lambda argv: calls.append(("worker", argv)))
+    monkeypatch.setattr(human_ui, "run_tui_cli", lambda argv: calls.append(("tui", argv)))
+    monkeypatch.setattr(version, "format_version_info", lambda: "version-info")
+
+    main_module.main(["job-runner", "a"])
+    main_module.main(["worker", "b"])
+    main_module.main(["tui", "c"])
+    main_module.main(["version"])
+    main_module.main(["--version"])
+    main_module.main(["-V"])
+
+    assert calls == [("job", ["a"]), ("worker", ["b"]), ("tui", ["c"])]
+    output = capsys.readouterr().out
+    assert "version-info" in output
+    assert output.count("3.0.0") == 2
+
+
+def test_main_modes_config_and_errors(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(main_module, "run_http", lambda: calls.append("http"))
+    monkeypatch.setattr(main_module, "run_mcp", lambda: calls.append("mcp"))
+
+    config = tmp_path / "config.yaml"
+    config.write_text("mode: http\n", encoding="utf-8")
+
+    monkeypatch.setattr(settings_module, "get_settings", lambda: _settings(mode="http"))
+    main_module.main(["--config", str(config), "--mode", "http", "--no-remote"])
+    assert calls == ["http"]
+    assert main_module.os.environ["LOCAL_SHELL_MCP_CONFIG"] == str(config)
+    assert main_module.os.environ["LOCAL_SHELL_MCP_MODE"] == "http"
+    assert main_module.os.environ["LOCAL_SHELL_MCP_REMOTE_ENABLED"] == "false"
+
+    monkeypatch.setattr(settings_module, "get_settings", lambda: _settings(mode="mcp"))
+    main_module.main(["--remote"])
+    monkeypatch.setattr(settings_module, "get_settings", lambda: _settings(mode="stdio"))
+    main_module.main([])
+    assert calls[-2:] == ["mcp", "mcp"]
+    assert main_module.os.environ["LOCAL_SHELL_MCP_REMOTE_ENABLED"] == "true"
+
+    monkeypatch.setattr(settings_module, "get_settings", lambda: _settings(mode="both"))
+    with pytest.raises(SystemExit, match="mode=both"):
+        main_module.main([])
+    monkeypatch.setattr(settings_module, "get_settings", lambda: _settings(mode="invalid"))
+    with pytest.raises(SystemExit, match="Unsupported mode"):
+        main_module.main([])

--- a/tests/test_oauth_complete.py
+++ b/tests/test_oauth_complete.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import time
+from urllib.parse import parse_qs, urlsplit
+
+import jwt
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+import local_shell_mcp.oauth as oauth
+from local_shell_mcp.settings import get_settings
+
+
+def _configure(tmp_path, monkeypatch, **env):
+    values = {
+        "LOCAL_SHELL_MCP_WORKSPACE_ROOT": str(tmp_path),
+        "LOCAL_SHELL_MCP_STATE_DIR": str(tmp_path / ".state"),
+        "LOCAL_SHELL_MCP_AUTH_MODE": "oauth",
+        "LOCAL_SHELL_MCP_OAUTH_JWT_SECRET": "oauth-test-secret-that-is-more-than-32-bytes",
+        "LOCAL_SHELL_MCP_PUBLIC_BASE_URL": "http://testserver",
+        "LOCAL_SHELL_MCP_OAUTH_ADMIN_PIN": "correct-admin-pin",
+    }
+    values.update({key: str(value) for key, value in env.items()})
+    for key, value in values.items():
+        monkeypatch.setenv(key, value)
+    get_settings.cache_clear()
+    oauth._CLIENTS.clear()
+    oauth._CODES.clear()
+
+
+def _app() -> Starlette:
+    return Starlette(
+        routes=[
+            Route("/.well-known/oauth-protected-resource", oauth.oauth_protected_resource),
+            Route("/.well-known/oauth-authorization-server", oauth.oauth_server_metadata),
+            Route("/oauth/register", oauth.oauth_register, methods=["POST"]),
+            Route("/oauth/authorize", oauth.oauth_authorize_get, methods=["GET"]),
+            Route("/oauth/authorize", oauth.oauth_authorize_post, methods=["POST"]),
+            Route("/oauth/token", oauth.oauth_token, methods=["POST"]),
+        ]
+    )
+
+
+def _challenge(verifier: str) -> str:
+    digest = hashlib.sha256(verifier.encode()).digest()
+    return base64.urlsafe_b64encode(digest).decode().rstrip("=")
+
+
+def _register(client: TestClient, redirect: str = "https://client.test/callback") -> str:
+    response = client.post(
+        "/oauth/register",
+        json={"client_name": "test client", "redirect_uris": [redirect]},
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["client_id"]
+
+
+def test_metadata_and_forwarded_base_urls(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    client = TestClient(_app(), base_url="http://internal")
+
+    protected = client.get("/.well-known/oauth-protected-resource")
+    server = client.get("/.well-known/oauth-authorization-server")
+
+    assert protected.headers["cache-control"] == "no-store"
+    assert protected.json()["resource"] == "http://testserver"
+    assert server.json()["issuer"] == "http://testserver"
+    assert server.json()["authorization_endpoint"].endswith("/oauth/authorize")
+    assert "S256" in server.json()["code_challenge_methods_supported"]
+
+    monkeypatch.delenv("LOCAL_SHELL_MCP_PUBLIC_BASE_URL")
+    get_settings.cache_clear()
+    forwarded = TestClient(_app(), base_url="http://internal").get(
+        "/.well-known/oauth-protected-resource",
+        headers={"x-forwarded-proto": "wss", "x-forwarded-host": "public.test"},
+    )
+    assert forwarded.json()["resource"] == "https://public.test"
+
+
+def test_registration_rejects_every_invalid_shape(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    client = TestClient(_app())
+
+    assert client.post("/oauth/register", content=b"not-json").status_code == 400
+    for redirects in (None, [], ["https://x.test"] * (oauth.MAX_REDIRECT_URIS + 1), "bad"):
+        body = {} if redirects is None else {"redirect_uris": redirects}
+        response = client.post("/oauth/register", json=body)
+        assert response.status_code == 400
+    assert client.post("/oauth/register", json={"redirect_uris": [123]}).status_code == 400
+
+    invalid_uris = [
+        "",
+        "relative/path",
+        "https://client.test/cb#fragment",
+        "http:///missing-host",
+        "x" * (oauth.MAX_OAUTH_URI_LENGTH + 1),
+    ]
+    for uri in invalid_uris:
+        response = client.post("/oauth/register", json={"redirect_uris": [uri]})
+        assert response.status_code == 400, uri
+
+    response = client.post(
+        "/oauth/register",
+        json={
+            "client_name": "x" * (oauth.MAX_CLIENT_NAME_LENGTH + 1),
+            "redirect_uris": ["https://client.test/cb"],
+        },
+    )
+    assert response.status_code == 400
+
+    monkeypatch.setattr(oauth, "MAX_OAUTH_CLIENTS", 0)
+    assert client.post(
+        "/oauth/register", json={"redirect_uris": ["https://client.test/cb"]}
+    ).status_code == 503
+
+
+def test_authorize_validation_and_pin_failures(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    client = TestClient(_app())
+    client_id = _register(client)
+    base = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": "https://client.test/callback",
+        "code_challenge": "challenge",
+        "code_challenge_method": "S256",
+    }
+
+    cases = [
+        ({**base, "response_type": "token"}, "Only response_type=code"),
+        ({key: value for key, value in base.items() if key != "client_id"}, "Missing client_id"),
+        ({key: value for key, value in base.items() if key != "redirect_uri"}, "Missing redirect_uri"),
+        ({**base, "client_id": "missing"}, "Unknown client_id"),
+        ({**base, "redirect_uri": "https://other.test/cb"}, "not registered"),
+        ({key: value for key, value in base.items() if key != "code_challenge"}, "Missing code_challenge"),
+        ({**base, "code_challenge_method": "plain"}, "Only code_challenge_method=S256"),
+        ({**base, "scope": "shell:read unsupported"}, "Unsupported OAuth scope"),
+    ]
+    for params, message in cases:
+        response = client.get("/oauth/authorize", params=params)
+        assert response.status_code == 200
+        assert message in response.text
+
+    invalid_post = client.post("/oauth/authorize", data={"client_id": "missing"})
+    assert "Only response_type=code" in invalid_post.text
+
+    wrong_pin = client.post("/oauth/authorize", data={**base, "pin": "wrong"})
+    assert wrong_pin.status_code == 200
+    assert "Invalid admin PIN" in wrong_pin.text
+    assert not oauth._CODES
+
+
+def test_complete_authorization_code_flow_and_token_failures(tmp_path, monkeypatch):
+    _configure(
+        tmp_path,
+        monkeypatch,
+        LOCAL_SHELL_MCP_OAUTH_ACCESS_TOKEN_TTL_S=120,
+        LOCAL_SHELL_MCP_OAUTH_CODE_TTL_S=30,
+    )
+    client = TestClient(_app())
+    redirect = "https://client.test/callback?existing=1"
+    client_id = _register(client, redirect)
+    verifier = "verifier-with-enough-entropy"
+    params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": redirect,
+        "scope": "shell:read shell:execute",
+        "resource": "http://testserver",
+        "state": "opaque-state",
+        "code_challenge": _challenge(verifier),
+        "code_challenge_method": "S256",
+        "pin": "correct-admin-pin",
+    }
+
+    approved = client.post("/oauth/authorize", data=params, follow_redirects=False)
+    assert approved.status_code == 302
+    parsed = urlsplit(approved.headers["location"])
+    query = parse_qs(parsed.query)
+    code = query["code"][0]
+    assert query["state"] == ["opaque-state"]
+    assert query["iss"] == ["http://testserver"]
+    assert "existing=1" in parsed.query
+
+    unsupported = client.post("/oauth/token", data={"grant_type": "password"})
+    assert unsupported.json()["error"] == "unsupported_grant_type"
+    unknown = client.post(
+        "/oauth/token",
+        data={"grant_type": "authorization_code", "code": "missing"},
+    )
+    assert unknown.json()["error"] == "invalid_grant"
+
+    mismatch = client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": "wrong",
+            "redirect_uri": redirect,
+            "code_verifier": verifier,
+        },
+    )
+    assert "mismatch" in mismatch.json()["error_description"]
+
+    bad_pkce = client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": client_id,
+            "redirect_uri": redirect,
+            "code_verifier": "wrong",
+        },
+    )
+    assert "PKCE" in bad_pkce.json()["error_description"]
+
+    token_response = client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": client_id,
+            "redirect_uri": redirect,
+            "code_verifier": verifier,
+        },
+    )
+    assert token_response.status_code == 200
+    body = token_response.json()
+    assert body["expires_in"] == 120
+    claims = jwt.decode(
+        body["access_token"],
+        "oauth-test-secret-that-is-more-than-32-bytes",
+        algorithms=["HS256"],
+        audience="http://testserver",
+        issuer="http://testserver",
+    )
+    assert claims["client_id"] == client_id
+    assert claims["scope"] == "shell:read shell:execute"
+    assert claims["exp"] > claims["iat"]
+
+    reused = client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": client_id,
+            "redirect_uri": redirect,
+            "code_verifier": verifier,
+        },
+    )
+    assert reused.json()["error"] == "invalid_grant"
+
+
+def test_expired_code_capacity_pruning_and_pkce_variants(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch, LOCAL_SHELL_MCP_OAUTH_CODE_TTL_S=1)
+    client = TestClient(_app())
+    client_id = _register(client)
+
+    expired = oauth.AuthCode(
+        code="expired",
+        client_id=client_id,
+        redirect_uri="https://client.test/callback",
+        scope="shell:read",
+        resource="http://testserver",
+        code_challenge=None,
+        code_challenge_method=None,
+        created_at=int(time.time()) - 100,
+    )
+    oauth._CODES[expired.code] = expired
+    response = client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": expired.code,
+            "client_id": client_id,
+            "redirect_uri": expired.redirect_uri,
+        },
+    )
+    assert response.json()["error"] == "invalid_grant"
+
+    oauth._CODES.clear()
+    oauth._CODES["used"] = oauth.AuthCode(
+        code="used",
+        client_id=client_id,
+        redirect_uri="https://client.test/callback",
+        scope="shell:read",
+        resource="http://testserver",
+        code_challenge=None,
+        code_challenge_method=None,
+        used=True,
+    )
+    oauth._CLIENTS["old"] = oauth.OAuthClient(
+        client_id="old",
+        redirect_uris=["https://old.test/cb"],
+        created_at=0,
+    )
+    monkeypatch.setattr(oauth, "MAX_OAUTH_CODES", 2)
+    for index in range(4):
+        oauth._CODES[str(index)] = oauth.AuthCode(
+            code=str(index),
+            client_id=client_id,
+            redirect_uri="https://client.test/callback",
+            scope="shell:read",
+            resource="http://testserver",
+            code_challenge=None,
+            code_challenge_method=None,
+            created_at=100 + index,
+        )
+    oauth._prune_oauth_state(now=100_000)
+    assert "used" not in oauth._CODES
+    assert "old" not in oauth._CLIENTS
+
+    for index in range(4):
+        oauth._CODES[str(index)] = oauth.AuthCode(
+            code=str(index),
+            client_id=client_id,
+            redirect_uri="https://client.test/callback",
+            scope="shell:read",
+            resource="http://testserver",
+            code_challenge=None,
+            code_challenge_method=None,
+            created_at=100_000,
+        )
+    oauth._prune_oauth_state(now=100_000)
+    assert len(oauth._CODES) <= 2
+
+    assert oauth._verify_pkce(expired, None) is True
+    plain = oauth.AuthCode(
+        code="plain",
+        client_id="c",
+        redirect_uri="https://x.test",
+        scope="",
+        resource="",
+        code_challenge="secret",
+        code_challenge_method="plain",
+    )
+    assert oauth._verify_pkce(plain, None) is False
+    assert oauth._verify_pkce(plain, "secret") is True
+    assert oauth._verify_pkce(plain, "other") is False
+
+
+def test_authorization_capacity_error_and_no_pin_hint(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_OAUTH_ADMIN_PIN", "")
+    get_settings.cache_clear()
+    client = TestClient(_app())
+    client_id = _register(client)
+    params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": "https://client.test/callback",
+        "code_challenge": "challenge",
+        "code_challenge_method": "S256",
+    }
+    form = client.get("/oauth/authorize", params=params)
+    assert "No admin PIN is configured" in form.text
+
+    monkeypatch.setattr(oauth, "MAX_OAUTH_CODES", 0)
+    response = client.post("/oauth/authorize", data=params)
+    assert "Too many pending authorization requests" in response.text

--- a/tests/test_remote_complete.py
+++ b/tests/test_remote_complete.py
@@ -1,0 +1,693 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import io
+import subprocess
+import tarfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+import local_shell_mcp.remote as remote
+from local_shell_mcp.models import CommandResult
+from local_shell_mcp.settings import get_settings
+
+
+def _configure(tmp_path, monkeypatch, **extra):
+    values = {
+        "LOCAL_SHELL_MCP_WORKSPACE_ROOT": str(tmp_path),
+        "LOCAL_SHELL_MCP_STATE_DIR": str(tmp_path / ".state"),
+        "LOCAL_SHELL_MCP_AUTH_MODE": "none",
+        "LOCAL_SHELL_MCP_PUBLIC_BASE_URL": "http://testserver",
+        "LOCAL_SHELL_MCP_REMOTE_POLL_TIMEOUT_S": "1",
+        "LOCAL_SHELL_MCP_REMOTE_JOB_TIMEOUT_S": "30",
+    }
+    values.update({key: str(value) for key, value in extra.items()})
+    for key, value in values.items():
+        monkeypatch.setenv(key, value)
+    get_settings.cache_clear()
+
+
+def _result() -> CommandResult:
+    return CommandResult(
+        ok=True,
+        exit_code=0,
+        timed_out=False,
+        duration_ms=1,
+        cwd=".",
+        command="cmd",
+        stdout="ok",
+        stderr="",
+        truncated=False,
+    )
+
+
+def test_distribution_helpers_and_worker_bundle(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    assert remote._canonical_dist_name("My_Pkg.Name") == "my-pkg-name"
+    assert remote._dist_name_from_requirement("pkg-name>=1") == "pkg-name"
+    assert remote._dist_name_from_requirement("extra; extra == 'x'") is None
+    assert remote._dist_name_from_requirement(" !!!") is None
+
+    package_file = tmp_path / "module.py"
+    package_file.write_text("x = 1\n", encoding="utf-8")
+    bytecode = tmp_path / "module.pyc"
+    bytecode.write_bytes(b"ignored")
+    unsafe = Path("../unsafe.py")
+
+    class FakeDist:
+        requires = ["dependency>=1", "optional; extra == 'feature'"]
+        files = [Path("module.py"), Path("module.pyc"), unsafe]
+
+        def locate_file(self, entry):
+            return tmp_path / entry
+
+    calls = []
+
+    def distribution(name):
+        calls.append(name)
+        if name == "missing":
+            raise remote.importlib_metadata.PackageNotFoundError(name)
+        return FakeDist()
+
+    monkeypatch.setattr(remote.importlib_metadata, "distribution", distribution)
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+        remote._add_distribution_to_tar(tar, "root", set())
+        remote._add_distribution_to_tar(tar, "missing", set())
+    with tarfile.open(fileobj=io.BytesIO(buffer.getvalue()), mode="r:gz") as tar:
+        names = tar.getnames()
+    assert "vendor/module.py" in names
+    assert all(not name.endswith(".pyc") for name in names)
+    assert "dependency" in calls
+
+    response = asyncio.run(remote.worker_bundle(None))
+    assert response.media_type == "application/gzip"
+    with tarfile.open(fileobj=io.BytesIO(response.body), mode="r:gz") as tar:
+        bundled = tar.getnames()
+    assert "local_shell_mcp/remote.py" in bundled
+    assert not any(name.endswith(".pyc") for name in bundled)
+
+
+def test_controller_registration_resume_rename_revoke_and_defaults(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    manager = remote.RemoteManager()
+    monkeypatch.setattr(remote, "_utc", lambda: 100.0)
+
+    invite = asyncio.run(manager.create_invite(ttl_s=1, base_url="http://control.test"))
+    assert invite["ttl_s"] == 60
+    registration = asyncio.run(
+        manager.register_worker(
+            {
+                "invite": invite["code"],
+                "workdir": "/work",
+                "capabilities": ["files"],
+                "info": {"user": "alice", "hostname": "host"},
+            }
+        )
+    )
+    assert registration["name"] == "alice@host"
+    token = registration["token"]
+
+    with pytest.raises(ValueError, match="invalid invite"):
+        asyncio.run(manager.register_worker({"invite": "missing"}))
+
+    resumed = asyncio.run(
+        manager.resume_worker(
+            token,
+            {"name": "alice@host", "workdir": "/new", "capabilities": ["shell"]},
+        )
+    )
+    assert resumed["name"] == "alice@host"
+    assert manager.workers["alice@host"].workdir == "/new"
+    with pytest.raises(ValueError, match="belongs"):
+        asyncio.run(manager.resume_worker(token, {"name": "other"}))
+    with pytest.raises(PermissionError):
+        asyncio.run(manager.resume_worker("invalid", {}))
+
+    second_invite = asyncio.run(manager.create_invite(base_url="http://control.test"))
+    second = asyncio.run(
+        manager.register_worker(
+            {
+                "invite": second_invite["code"],
+                "info": {"user": "alice", "hostname": "host"},
+            }
+        )
+    )
+    assert second["name"] == "alice@host-2"
+
+    renamed = manager.rename("alice@host", "renamed")
+    assert renamed == {"old_name": "alice@host", "new_name": "renamed"}
+    assert manager.tokens[token] == "renamed"
+    with pytest.raises(ValueError, match="already exists"):
+        manager.rename("renamed", "alice@host-2")
+    with pytest.raises(ValueError, match="unknown"):
+        manager.rename("missing", "new")
+
+    revoked = manager.revoke("renamed")
+    assert revoked["revoked"] is True
+    with pytest.raises(ValueError, match="unknown"):
+        manager.revoke("renamed")
+    with pytest.raises(PermissionError):
+        manager._worker_by_token(token)
+
+
+def test_controller_poll_result_errors_and_cancellation(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    manager = remote.RemoteManager()
+    manager._registry_loaded = True
+    worker = remote.RemoteWorker(name="node", token="token", last_seen=100)
+    manager.workers[worker.name] = worker
+    manager.tokens[worker.token] = worker.name
+    monkeypatch.setattr(remote, "_utc", lambda: 100.0)
+
+    assert asyncio.run(manager.heartbeat("token", {"job_id": "none"}))["accepted"] is True
+    assert asyncio.run(manager.submit_result("token", {"job_id": "unknown"})) == {"accepted": False}
+
+    async def failed_call():
+        task = asyncio.create_task(manager.call("node", "list_files", {}, timeout_s=2))
+        polled = await manager.poll("token")
+        await manager.submit_result(
+            "token",
+            {"job_id": polled["job"]["id"], "ok": False, "error": "Boom", "message": "bad"},
+        )
+        return await task
+
+    failed = asyncio.run(failed_call())
+    assert failed["data"]["status"] == "error"
+    assert failed["data"]["error_type"] == "Boom"
+
+    async def cancelled_call():
+        task = asyncio.create_task(manager.call("node", "list_files", {}, timeout_s=10))
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(cancelled_call())
+    with pytest.raises(ValueError, match="unknown remote"):
+        asyncio.run(manager.call("missing", "x", {}))
+    worker.last_seen = 0
+    with pytest.raises(RuntimeError, match="offline"):
+        asyncio.run(manager.call("node", "x", {}))
+
+
+def test_remote_http_routes_success_and_errors(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    manager = remote.RemoteManager()
+    monkeypatch.setattr(remote, "REMOTE_MANAGER", manager)
+    app = Starlette(routes=remote.remote_routes())
+    client = TestClient(app)
+
+    invite = asyncio.run(manager.create_invite("route-node", base_url="http://testserver"))
+    registered = client.post(
+        "/remote/register",
+        json={"invite": invite["code"], "name": "route-node", "info": {}},
+    )
+    assert registered.status_code == 200
+    token = registered.json()["data"]["token"]
+    headers = {"authorization": f"Bearer {token}"}
+
+    resumed = client.post("/remote/resume", json={"name": "route-node"}, headers=headers)
+    assert resumed.status_code == 200
+    heartbeat = client.post("/remote/heartbeat", json={}, headers=headers)
+    assert heartbeat.json()["data"]["accepted"] is True
+    result = client.post("/remote/result", json={"job_id": "missing"}, headers=headers)
+    assert result.json()["data"]["accepted"] is False
+
+    assert client.post("/remote/register", json={"invite": "bad"}).status_code == 400
+    assert client.post("/remote/resume", json={}, headers={}).status_code == 401
+    assert client.post("/remote/poll", json={}, headers={}).status_code == 401
+    assert client.post("/remote/heartbeat", json={}, headers={}).status_code == 401
+    assert client.post("/remote/result", json={}, headers={}).status_code == 401
+    assert remote._bearer_token(SimpleNamespace(headers={"authorization": "Basic x"})) == ""
+
+    join = client.get("/join")
+    assert join.status_code == 200
+    assert "--invite is required" in join.text
+    bundle = client.get(remote.REMOTE_WORKER_BUNDLE_PATH)
+    assert bundle.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_every_worker_tool_dispatch_branch(monkeypatch, tmp_path):
+    _configure(tmp_path, monkeypatch)
+    command_result = _result()
+
+    async def async_value(*args, **kwargs):
+        return {"args": list(args), "kwargs": kwargs}
+
+    def sync_value(*args, **kwargs):
+        return {"args": list(args), "kwargs": kwargs}
+
+    monkeypatch.setattr(remote, "run_shell", lambda *args, **kwargs: asyncio.sleep(0, result=command_result))
+    monkeypatch.setattr(remote, "public_run_shell", lambda *args, **kwargs: asyncio.sleep(0, result=command_result))
+    monkeypatch.setattr(remote, "_run_python", async_value)
+    for name in (
+        "start_shell",
+        "send_shell",
+        "read_shell",
+        "kill_shell",
+        "list_shells",
+        "start_job",
+        "list_jobs",
+        "tail_job",
+        "stop_job",
+        "retry_job",
+        "tree",
+        "grep",
+        "browser_capture",
+        "browser_get_text",
+        "playwright_run_script",
+        "_apply_patch_text",
+    ):
+        monkeypatch.setattr(remote, name, async_value)
+    for name in (
+        "list_dir",
+        "glob_paths",
+        "read_texts",
+        "write_text",
+        "edit_text",
+        "delete_path",
+        "perform_file_action",
+        "transfer_stat",
+        "transfer_read_chunk",
+        "transfer_begin_write",
+        "transfer_write_chunk",
+        "transfer_finish_write",
+        "transfer_abort_write",
+        "transfer_alloc_temp_path",
+        "transfer_pack_dir",
+        "transfer_unpack_archive",
+        "_worker_upload_url",
+        "_worker_download_url",
+    ):
+        monkeypatch.setattr(remote, name, sync_value)
+
+    cases = {
+        "environment_info": {},
+        "run_shell_tool": {"command": "echo ok"},
+        "run_python_tool": {"code": "print(1)"},
+        "shell_start": {},
+        "shell_send": {"session_id": "s", "input_text": "x"},
+        "shell_read": {"session_id": "s"},
+        "shell_kill": {"session_id": "s"},
+        "shell_list": {},
+        "job_start": {"command": "true"},
+        "job_list": {},
+        "job_tail": {"job_id": "j"},
+        "job_stop": {"job_id": "j"},
+        "job_retry": {"job_id": "j"},
+        "list_files": {},
+        "tree_view": {},
+        "glob_search": {"pattern": "*.py"},
+        "grep_search": {"query": "x"},
+        "read_file": {"path": "x"},
+        "write_file": {"path": "x", "content": "y"},
+        "edit_file": {"path": "x", "edits": []},
+        "delete_file_or_dir": {"path": "x"},
+        "human_file_action": {"action": "touch", "path": "x"},
+        "transfer_stat": {"path": "x"},
+        "transfer_read_chunk": {"path": "x"},
+        "transfer_begin_write": {"path": "x"},
+        "transfer_write_chunk": {"path": "x", "transfer_id": "t", "offset": 0, "data_b64": ""},
+        "transfer_finish_write": {"path": "x", "transfer_id": "t"},
+        "transfer_abort_write": {"path": "x", "transfer_id": "t"},
+        "transfer_alloc_temp_path": {},
+        "transfer_pack_dir": {"path": "x"},
+        "transfer_unpack_archive": {"archive_path": "a", "dst_path": "d"},
+        "transfer_upload_url": {"path": "x", "url": "http://x", "expected_bytes": 0, "expected_sha256": "d"},
+        "transfer_download_url": {"url": "http://x", "path": "x", "expected_bytes": 0, "expected_sha256": "d"},
+        "apply_patch": {"patch": "diff"},
+        "browser_capture_tool": {"url": "https://x"},
+        "browser_get_text_tool": {"url": "https://x"},
+        "playwright_run_script_tool": {"script": "print(1)"},
+    }
+    for tool, args in cases.items():
+        result = await remote.execute_worker_tool(tool, {**args, "_human": True})
+        assert result is not None, tool
+
+    with pytest.raises(ValueError, match="unsupported"):
+        await remote.execute_worker_tool("unknown", {})
+
+
+def test_worker_transfer_validation_and_curl_failures(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch, LOCAL_SHELL_MCP_WORKER_STATE_DIR=tmp_path / "worker-state")
+    remote._write_worker_identity(
+        {"server": "https://control.test", "name": "node", "access": "token"}
+    )
+    valid = "https://control.test/remote/transfer/token"
+    remote._worker_validate_transfer_url(valid)
+    for url in (
+        "file:///tmp/x",
+        "https://other.test/remote/transfer/x",
+        "https://control.test/not-transfer/x",
+    ):
+        with pytest.raises(ValueError):
+            remote._worker_validate_transfer_url(url)
+
+    assert remote._worker_curl_timeout(None) == 30
+    assert remote._worker_curl_timeout(1) == 30
+    assert remote._worker_curl_timeout(999) == 30
+
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"payload")
+    digest = hashlib.sha256(b"payload").hexdigest()
+    monkeypatch.setattr(remote.shutil, "which", lambda name: None)
+    with pytest.raises(FileNotFoundError, match="curl"):
+        remote._worker_upload_url("source.bin", valid, 7, digest)
+    with pytest.raises(FileNotFoundError, match="curl"):
+        remote._worker_download_url(valid, "dest.bin", True, 7, digest)
+    assert not (tmp_path / "dest.bin").exists()
+
+    monkeypatch.setattr(remote.shutil, "which", lambda name: "/usr/bin/curl")
+    monkeypatch.setattr(
+        remote.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 22, stdout="", stderr="network"),
+    )
+    with pytest.raises(RuntimeError, match="curl exit 22"):
+        remote._worker_upload_url("source.bin", valid, 7, digest)
+    with pytest.raises(RuntimeError, match="curl exit 22"):
+        remote._worker_download_url(valid, "dest.bin", True, 7, digest)
+
+
+def test_worker_identity_storage_retryability_and_http_parsing(tmp_path, monkeypatch, capsys):
+    _configure(tmp_path, monkeypatch, LOCAL_SHELL_MCP_WORKER_STATE_DIR=tmp_path / "worker-state")
+    assert remote._worker_state_dir() == tmp_path / "worker-state"
+    monkeypatch.delenv("LOCAL_SHELL_MCP_WORKER_STATE_DIR")
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "xdg"))
+    assert remote._worker_state_dir() == tmp_path / "xdg" / "local-shell-mcp-worker"
+    monkeypatch.delenv("XDG_STATE_HOME")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "home"))
+    assert remote._worker_state_dir() == tmp_path / "home" / ".local/state/local-shell-mcp-worker"
+
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKER_STATE_DIR", str(tmp_path / "state"))
+    identity = {"server": "https://control.test", "name": "node", "access": "token"}
+    remote._write_worker_identity(identity)
+    assert remote._read_worker_identity("https://control.test") == identity
+    assert remote._read_worker_identity("https://other.test") is None
+    assert remote._read_worker_identity("https://control.test", "other") is None
+    remote._worker_identity_path().write_text("bad", encoding="utf-8")
+    assert remote._read_worker_identity("https://control.test") is None
+    remote._delete_worker_identity()
+    remote._delete_worker_identity()
+
+    assert remote._worker_error_is_retryable(remote.WorkerHttpError("u", 429, "busy"))
+    assert remote._worker_error_is_retryable(remote.WorkerHttpError("u", 503, "down"))
+    assert not remote._worker_error_is_retryable(remote.WorkerHttpError("u", 400, "bad"))
+    assert not remote._worker_error_is_retryable(ValueError("bad"))
+    assert remote._worker_error_is_retryable(RuntimeError("temporary"))
+    remote._worker_log_retry("poll", RuntimeError("down"), 2)
+    assert "Retrying in 2s" in capsys.readouterr().err
+
+    assert remote._parse_worker_http_json("u", 200, '{"ok":true}') == {"ok": True}
+    with pytest.raises(remote.WorkerHttpError):
+        remote._parse_worker_http_json("u", 500, "down")
+    with pytest.raises(RuntimeError, match="invalid JSON"):
+        remote._parse_worker_http_json("u", 200, "bad")
+    with pytest.raises(RuntimeError, match="expected object"):
+        remote._parse_worker_http_json("u", 200, "[]")
+
+
+def test_worker_cli_error_path(monkeypatch, capsys):
+    async def fail(*args, **kwargs):
+        raise RuntimeError("connect failed")
+
+    monkeypatch.setattr(remote, "run_worker", fail)
+    with pytest.raises(SystemExit) as raised:
+        remote.run_worker_cli(["--server", "https://x", "--invite", "i"])
+    assert raised.value.code == 1
+    assert "connection failed" in capsys.readouterr().err
+
+
+
+def test_remote_registry_invite_and_registration_edge_cases(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    invalid = tmp_path / "invalid-registry.json"
+    for payload in (
+        "[]",
+        '{"version":2,"workers":[]}',
+        '{"version":1,"workers":{}}',
+    ):
+        invalid.write_text(payload, encoding="utf-8")
+        with pytest.raises(ValueError, match="registry"):
+            remote.RemoteManager._read_registry(invalid)
+
+    manager = remote.RemoteManager()
+    manager._registry_loaded = True
+    with pytest.raises(ValueError, match="required"):
+        remote._validate_machine_name("   ")
+
+    monkeypatch.setattr(remote, "MAX_REMOTE_INVITES", 0)
+    with pytest.raises(RuntimeError, match="Too many"):
+        asyncio.run(manager.create_invite())
+    monkeypatch.setattr(remote, "MAX_REMOTE_INVITES", 128)
+
+    now = 100.0
+    monkeypatch.setattr(remote, "_utc", lambda: now)
+    manager.invites["used"] = remote.RemoteInvite("used", None, None, now + 10, used=True)
+    with pytest.raises(ValueError, match="already"):
+        asyncio.run(manager.register_worker({"invite": "used"}))
+    manager.invites["expired"] = remote.RemoteInvite("expired", None, None, now - 1)
+    with pytest.raises(ValueError, match="expired"):
+        asyncio.run(manager.register_worker({"invite": "expired"}))
+    manager.invites["bound"] = remote.RemoteInvite("bound", "bound-name", None, now + 10)
+    with pytest.raises(ValueError, match="bound"):
+        asyncio.run(
+            manager.register_worker({"invite": "bound", "name": "different"})
+        )
+    manager.workers["duplicate"] = remote.RemoteWorker("duplicate", "existing")
+    manager.invites["duplicate"] = remote.RemoteInvite(
+        "duplicate", "duplicate", None, now + 10
+    )
+    with pytest.raises(ValueError, match="already exists"):
+        asyncio.run(manager.register_worker({"invite": "duplicate"}))
+
+    manager.tokens["orphan"] = "missing"
+    with pytest.raises(PermissionError, match="no longer valid"):
+        asyncio.run(manager.resume_worker("orphan", {}))
+
+    manager.workers["user@host"] = remote.RemoteWorker("user@host", "one")
+    manager.workers["user@host-2"] = remote.RemoteWorker("user@host-2", "two")
+    assert manager._default_machine_name(
+        {"info": {"user": "user", "hostname": "host"}}
+    ) == "user@host-3"
+
+
+def test_remote_cancel_prune_revoke_and_rename_pending_jobs(tmp_path, monkeypatch):
+    _configure(
+        tmp_path,
+        monkeypatch,
+        LOCAL_SHELL_MCP_REMOTE_MAX_PENDING_JOBS=1,
+        LOCAL_SHELL_MCP_REMOTE_CANCELLED_JOB_TTL_S=1000,
+    )
+    manager = remote.RemoteManager()
+    manager._registry_loaded = True
+    worker = remote.RemoteWorker("node", "token", last_seen=100)
+    manager.workers["node"] = worker
+    manager.tokens["token"] = "node"
+    monkeypatch.setattr(remote, "_utc", lambda: 100.0)
+
+    for index in range(70):
+        manager.cancelled_jobs[f"job-{index}"] = 100.0
+    manager._prune_cancelled_jobs_locked(100.0)
+    assert len(manager.cancelled_jobs) == 64
+
+    loop = asyncio.new_event_loop()
+    try:
+        future = loop.create_future()
+        manager.pending["cancel-me"] = future
+        manager.pending_machines["cancel-me"] = "node"
+        assert manager._cancel_job_if_unclaimed("cancel-me") is True
+        assert future.cancelled()
+    finally:
+        loop.close()
+
+    manager.pending_machines["pending"] = "node"
+    worker.queue.put_nowait({"id": "queued"})
+    renamed = manager.rename("node", "renamed")
+    assert renamed["new_name"] == "renamed"
+    assert manager.pending_machines["pending"] == "renamed"
+
+    manager.pending_machines["pending"] = "renamed"
+    manager.pending["pending"] = None  # type: ignore[assignment]
+    revoked = manager.revoke("renamed")
+    assert revoked["revoked"] is True
+    assert worker.queue.empty()
+    assert "queued" not in manager.cancelled_jobs
+
+
+@pytest.mark.asyncio
+async def test_remote_mutation_timeout_and_claimed_cancellation_cleanup(
+    tmp_path, monkeypatch
+):
+    _configure(tmp_path, monkeypatch)
+    manager = remote.RemoteManager()
+    manager._registry_loaded = True
+    worker = remote.RemoteWorker("node", "token", last_seen=100)
+    manager.workers["node"] = worker
+    manager.tokens["token"] = "node"
+    monkeypatch.setattr(remote, "_utc", lambda: 100.0)
+
+    with pytest.raises(TimeoutError, match="write_file"):
+        await manager.call("node", "write_file", {}, timeout_s=0.01)
+
+    task = asyncio.create_task(
+        manager.call("node", "write_file", {"path": "x"}, timeout_s=10)
+    )
+    polled = await manager.poll("token")
+    job_id = polled["job"]["id"]
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert job_id in manager.pending
+    accepted = await manager.submit_result(
+        "token", {"job_id": job_id, "ok": True, "data": {"done": True}}
+    )
+    assert accepted == {"accepted": True}
+    await asyncio.sleep(0)
+    assert job_id not in manager.pending
+    assert job_id not in manager.pending_machines
+    assert job_id not in manager.claimed_jobs
+
+
+def test_worker_upload_protocol_and_generated_execution_edges(tmp_path, monkeypatch):
+    _configure(
+        tmp_path,
+        monkeypatch,
+        LOCAL_SHELL_MCP_WORKER_STATE_DIR=tmp_path / "worker-state",
+    )
+    remote._write_worker_identity(
+        {"server": "https://control.test", "name": "node", "access": "token"}
+    )
+    url = "https://control.test/remote/transfer/token"
+    directory = tmp_path / "directory"
+    directory.mkdir()
+    with pytest.raises(ValueError, match="not a file"):
+        remote._worker_upload_url("directory", url, 0, hashlib.sha256(b"").hexdigest())
+
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"payload")
+    digest = hashlib.sha256(b"payload").hexdigest()
+    with pytest.raises(ValueError, match="size mismatch"):
+        remote._worker_upload_url("source.bin", url, 8, digest)
+    with pytest.raises(ValueError, match="sha256"):
+        remote._worker_upload_url("source.bin", url, 7, "0" * 64)
+
+    monkeypatch.setattr(remote.shutil, "which", lambda name: "/usr/bin/curl")
+    monkeypatch.setattr(
+        remote.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args[0], 0, stdout="not-json", stderr=""
+        ),
+    )
+    with pytest.raises(RuntimeError, match="invalid JSON"):
+        remote._worker_upload_url("source.bin", url, 7, digest)
+    monkeypatch.setattr(
+        remote.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args[0], 0, stdout='{"ok":false,"message":"bad"}', stderr=""
+        ),
+    )
+    with pytest.raises(RuntimeError, match="stream upload failed"):
+        remote._worker_upload_url("source.bin", url, 7, digest)
+
+    async def fake_run_shell(command, **kwargs):
+        return _result()
+
+    monkeypatch.setattr(remote, "run_shell", fake_run_shell)
+    patch = asyncio.run(remote._apply_patch_text("diff --git a/a b/a\n", "."))
+    assert patch["patch_path"].endswith(".diff")
+    script = asyncio.run(remote._run_python("print('ok')", ".", 5))
+    assert script["script_path"].endswith(".py")
+    assert remote._handled_remote_exception(ValueError("bad"))["error"] == "ValueError"
+
+
+def test_worker_resume_identity_and_curl_post_failures(tmp_path, monkeypatch, capsys):
+    _configure(
+        tmp_path,
+        monkeypatch,
+        LOCAL_SHELL_MCP_WORKER_STATE_DIR=tmp_path / "worker-state",
+    )
+    remote._write_worker_identity(
+        {"server": "https://control.test", "name": "node", "access": "token"}
+    )
+    assert remote._worker_identity_rejected(RuntimeError("failed with 401"))
+    assert remote._worker_identity_rejected(RuntimeError("invalid worker identity"))
+    assert remote._worker_identity_rejected(RuntimeError("identity is no longer valid"))
+    assert not remote._worker_identity_rejected(RuntimeError("temporary"))
+
+    monkeypatch.setattr(
+        remote,
+        "_worker_post_json",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            remote.WorkerHttpError("u", 401, "invalid")
+        ),
+    )
+    assert asyncio.run(remote._worker_resume_or_none("u", {}, {})) is None
+    assert not remote._worker_identity_path().exists()
+    assert "identity rejected" in capsys.readouterr().err
+
+    attempts = iter([RuntimeError("temporary"), {"ok": True}])
+
+    def retry(*args, **kwargs):
+        value = next(attempts)
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    monkeypatch.setattr(remote, "_worker_post_json", retry)
+    monkeypatch.setattr(remote, "_worker_retry_delay", lambda attempt: 0)
+    assert asyncio.run(remote._worker_resume_or_none("u", {}, {})) == {"ok": True}
+    with pytest.raises(ValueError, match="permanent"):
+        monkeypatch.setattr(
+            remote,
+            "_worker_post_json",
+            lambda *args, **kwargs: (_ for _ in ()).throw(ValueError("permanent")),
+        )
+        asyncio.run(remote._worker_resume_or_none("u", {}, {}))
+
+    monkeypatch.setattr(remote.shutil, "which", lambda name: None)
+    with pytest.raises(FileNotFoundError, match="curl"):
+        remote._worker_post_json_with_curl("u", b"{}", {})
+    monkeypatch.setattr(remote.shutil, "which", lambda name: "/usr/bin/curl")
+    monkeypatch.setattr(
+        remote.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args[0], 7, stdout=b"body\nLOCAL_SHELL_MCP_HTTP_STATUS:503", stderr=b"network"
+        ),
+    )
+    with pytest.raises(RuntimeError, match="curl exit 7"):
+        remote._worker_post_json_with_curl("u", b"{}", {"X-Test": "1"}, 2)
+
+
+def test_worker_identity_incomplete_and_cli_interrupt(tmp_path, monkeypatch, capsys):
+    _configure(
+        tmp_path,
+        monkeypatch,
+        LOCAL_SHELL_MCP_WORKER_STATE_DIR=tmp_path / "worker-state",
+    )
+    path = remote._worker_identity_path()
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        '{"server":"https://control.test","name":"","access":""}',
+        encoding="utf-8",
+    )
+    assert remote._read_worker_identity("https://control.test") is None
+
+    async def interrupted(*args, **kwargs):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(remote, "run_worker", interrupted)
+    with pytest.raises(SystemExit) as raised:
+        remote.run_worker_cli(["--server", "https://x", "--invite", "i"])
+    assert raised.value.code == 130
+    assert "disconnected by user" in capsys.readouterr().err

--- a/tests/test_remote_process_e2e.py
+++ b/tests/test_remote_process_e2e.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import platform
+import runpy
+import socket
+import subprocess
+import sys
+import threading
+import time
+from contextlib import suppress
+from pathlib import Path
+
+import pytest
+import uvicorn
+from starlette.applications import Starlette
+
+import local_shell_mcp.remote as remote
+import local_shell_mcp.tools as tools
+from local_shell_mcp.settings import get_settings
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_until(predicate, timeout: float = 15.0) -> None:
+    deadline = time.monotonic() + timeout
+    last_error: BaseException | None = None
+    while time.monotonic() < deadline:
+        try:
+            if predicate():
+                return
+        except BaseException as exc:  # noqa: BLE001
+            last_error = exc
+        time.sleep(0.05)
+    raise TimeoutError(f"condition was not met within {timeout}s: {last_error!r}")
+
+
+def _stop_process(process: subprocess.Popen[str]) -> tuple[str, str]:
+    if process.poll() is None:
+        process.terminate()
+        try:
+            return process.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+    return process.communicate(timeout=5)
+
+
+def _worker_environment(worker_root: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "PYTHONUNBUFFERED": "1",
+            "PYTHONPATH": os.pathsep.join(
+                item for item in (str(ROOT), str(ROOT / "src"), env.get("PYTHONPATH", "")) if item
+            ),
+            "LOCAL_SHELL_MCP_WORKER_STATE_DIR": str(worker_root / "identity"),
+            "LOCAL_SHELL_MCP_WORKSPACE_ROOT": str(worker_root / "workspace"),
+            "LOCAL_SHELL_MCP_STATE_DIR": str(worker_root / "service-state"),
+            "LOCAL_SHELL_MCP_AUTH_MODE": "none",
+            "LOCAL_SHELL_MCP_REMOTE_POLL_TIMEOUT_S": "1",
+            "LOCAL_SHELL_MCP_REMOTE_JOB_TIMEOUT_S": "20",
+            "LOCAL_SHELL_MCP_COMMAND_DENYLIST": "",
+            "LOCAL_SHELL_MCP_PATH_DENYLIST": "",
+        }
+    )
+    if env.get("LOCAL_SHELL_MCP_COVERAGE") == "1":
+        env["COVERAGE_PROCESS_START"] = str(ROOT / "pyproject.toml")
+        env["COVERAGE_FILE"] = str(ROOT / ".coverage")
+    return env
+
+
+def _start_worker(base_url: str, invite: str, worker_root: Path) -> subprocess.Popen[str]:
+    workspace = worker_root / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    return subprocess.Popen(  # noqa: S603
+        [
+            sys.executable,
+            "-m",
+            "local_shell_mcp.remote_worker",
+            "--server",
+            base_url,
+            "--invite",
+            invite,
+            "--name",
+            "process-node",
+            "--workdir",
+            str(workspace),
+        ],
+        cwd=ROOT,
+        env=_worker_environment(worker_root),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=(os.name != "nt"),
+    )
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux" or platform.machine().lower() not in {"x86_64", "amd64"},
+    reason="one Linux x86_64 real process integration run is sufficient",
+)
+def test_real_controller_worker_tools_transfers_and_reconnect(tmp_path, monkeypatch):
+    controller_root = tmp_path / "controller"
+    worker_root = tmp_path / "worker"
+    controller_root.mkdir()
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(controller_root))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(controller_root / ".state"))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_AUTH_MODE", "none")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_REMOTE_POLL_TIMEOUT_S", "1")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_REMOTE_JOB_TIMEOUT_S", "20")
+    get_settings.cache_clear()
+
+    manager = remote.RemoteManager()
+    monkeypatch.setattr(remote, "REMOTE_MANAGER", manager)
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    monkeypatch.setenv("LOCAL_SHELL_MCP_PUBLIC_BASE_URL", base_url)
+    get_settings.cache_clear()
+
+    app = Starlette(routes=remote.remote_routes())
+    server = uvicorn.Server(
+        uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error", access_log=False)
+    )
+    loop_holder: dict[str, asyncio.AbstractEventLoop] = {}
+
+    def serve() -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop_holder["loop"] = loop
+        try:
+            loop.run_until_complete(server.serve())
+        finally:
+            loop.close()
+
+    thread = threading.Thread(target=serve, name="remote-e2e-controller", daemon=True)
+    thread.start()
+    _wait_until(lambda: server.started and "loop" in loop_holder)
+
+    def controller(coroutine, timeout: float = 30):
+        return asyncio.run_coroutine_threadsafe(coroutine, loop_holder["loop"]).result(timeout)
+
+    invite = controller(
+        manager.create_invite("process-node", str(worker_root / "workspace"), base_url=base_url)
+    )
+    first = _start_worker(base_url, invite["code"], worker_root)
+    second: subprocess.Popen[str] | None = None
+    try:
+        _wait_until(
+            lambda: any(
+                row["name"] == "process-node" and row["status"] == "online"
+                for row in manager.list_machines()["machines"]
+            )
+        )
+        assert first.poll() is None
+
+        written = controller(
+            manager.call(
+                "process-node",
+                "write_file",
+                {"path": "remote.txt", "content": "worker-data\n", "overwrite": True},
+                timeout_s=10,
+            )
+        )
+        assert written["ok"] is True
+        read = controller(
+            manager.call("process-node", "read_file", {"path": "remote.txt"}, timeout_s=10)
+        )
+        assert read["data"]["content"] == "worker-data\n"
+        shell_result = controller(
+            manager.call(
+                "process-node",
+                "run_shell_tool",
+                {"command": "printf worker-shell-ok", "cwd": ".", "timeout_s": 5},
+                timeout_s=10,
+            )
+        )
+        assert "worker-shell-ok" in shell_result["data"]["stdout"]
+
+        local_file = controller_root / "controller.bin"
+        local_file.write_bytes(b"controller-to-worker" * 1024)
+        pushed = controller(
+            tools._copy_local_file_to_remote(
+                "controller.bin", "process-node", "pushed.bin", True, None
+            )
+        )
+        assert pushed["transport"] == "http-stream"
+        pulled = controller(
+            tools._copy_remote_file_to_local(
+                "process-node", "pushed.bin", "roundtrip.bin", True, None
+            )
+        )
+        assert pulled["transport"] == "http-stream"
+        assert (controller_root / "roundtrip.bin").read_bytes() == local_file.read_bytes()
+
+        local_dir = controller_root / "tree"
+        (local_dir / "nested").mkdir(parents=True)
+        (local_dir / "nested" / "value.txt").write_text("directory-data", encoding="utf-8")
+        directory_push = controller(
+            tools._copy_local_dir_to_remote(
+                "tree", "process-node", "remote-tree", True, 4096
+            )
+        )
+        assert directory_push["entries"] >= 1
+        directory_pull = controller(
+            tools._copy_remote_dir_to_local(
+                "process-node", "remote-tree", "tree-roundtrip", True, 4096
+            )
+        )
+        assert directory_pull["entries"] >= 1
+        assert (
+            controller_root / "tree-roundtrip" / "nested" / "value.txt"
+        ).read_text(encoding="utf-8") == "directory-data"
+
+        identity_path = worker_root / "identity" / remote.REMOTE_WORKER_IDENTITY_FILE_NAME
+        _wait_until(identity_path.is_file)
+        identity_before = identity_path.read_text(encoding="utf-8")
+        first_stdout, first_stderr = _stop_process(first)
+        assert first.returncode in {0, -15}
+        assert "Status: connected" in first_stdout
+        assert "connection failed" not in first_stderr
+
+        second = _start_worker(base_url, invite["code"], worker_root)
+        _wait_until(lambda: second.poll() is None and "process-node" in manager.workers)
+        time.sleep(1.2)
+        assert second.poll() is None, second.stderr.read() if second.stderr else ""
+        assert identity_path.read_text(encoding="utf-8") == identity_before
+
+        resumed = controller(
+            manager.call(
+                "process-node",
+                "read_file",
+                {"path": "remote.txt"},
+                timeout_s=10,
+            )
+        )
+        assert resumed["data"]["content"] == "worker-data\n"
+    finally:
+        with suppress(Exception):
+            if first.poll() is None:
+                _stop_process(first)
+        if second is not None:
+            with suppress(Exception):
+                _stop_process(second)
+        server.should_exit = True
+        thread.join(timeout=10)
+        assert not thread.is_alive()
+
+
+def test_remote_worker_module_delegates_to_cli(monkeypatch):
+    calls = []
+    monkeypatch.setattr(remote, "run_worker_cli", calls.append)
+    monkeypatch.setattr(sys, "argv", ["remote_worker", "--server", "x"])
+    runpy.run_module("local_shell_mcp.remote_worker", run_name="__main__")
+    assert calls == [["--server", "x"]]

--- a/tests/test_runtime_edge_complete.py
+++ b/tests/test_runtime_edge_complete.py
@@ -395,6 +395,7 @@ def test_shell_process_termination_native_sessions_and_dispatch(tmp_path, monkey
     assert (asyncio.run(shell.read_shell("x")))["native"]
     assert (asyncio.run(shell.kill_shell("x")))["native"]
 
+    monkeypatch.setattr(shell, "_use_windows_persistent_shell_backend", lambda: False)
     monkeypatch.setattr(shell, "resolve_tmux", lambda: TmuxSelection("/tmux", "system"))
     responses = iter([_command_result(), _command_result(), _command_result(stdout="pane"), _command_result()])
     monkeypatch.setattr(shell, "tmux", lambda *args, **kwargs: asyncio.sleep(0, result=next(responses)))

--- a/tests/test_runtime_edge_complete.py
+++ b/tests/test_runtime_edge_complete.py
@@ -1,0 +1,508 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import io
+import json
+import os
+from types import SimpleNamespace
+
+import pytest
+
+import local_shell_mcp.conpty_ops as conpty
+import local_shell_mcp.jobs as jobs
+import local_shell_mcp.shell_ops as shell
+from local_shell_mcp.models import CommandResult
+from local_shell_mcp.settings import get_settings
+from local_shell_mcp.tmux_helper import TmuxSelection
+
+
+def _configure(tmp_path, monkeypatch, **extra):
+    values = {
+        "LOCAL_SHELL_MCP_WORKSPACE_ROOT": str(tmp_path),
+        "LOCAL_SHELL_MCP_STATE_DIR": str(tmp_path / ".state"),
+        "LOCAL_SHELL_MCP_AUDIT_LOG_PATH": str(tmp_path / "audit.jsonl"),
+        "LOCAL_SHELL_MCP_AUTH_MODE": "none",
+        "LOCAL_SHELL_MCP_COMMAND_DENYLIST": "",
+        "LOCAL_SHELL_MCP_PATH_DENYLIST": "",
+    }
+    values.update({key: str(value) for key, value in extra.items()})
+    for key, value in values.items():
+        monkeypatch.setenv(key, value)
+    get_settings.cache_clear()
+    jobs._ACTIVE_JOB_OPERATIONS.clear()
+    shell._NATIVE_SHELL_SESSIONS.clear()
+    conpty._CONPTY_SHELL_SESSIONS.clear()
+
+
+def _command_result(*, ok=True, stdout="", stderr=""):
+    return CommandResult(
+        ok=ok,
+        exit_code=0 if ok else 1,
+        timed_out=False,
+        duration_ms=1,
+        cwd=".",
+        command="cmd",
+        stdout=stdout,
+        stderr=stderr,
+        truncated=False,
+    )
+
+
+def test_job_store_helpers_recovery_pruning_and_attempt_files(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch, LOCAL_SHELL_MCP_MAX_JOBS=1)
+    assert jobs._load_store() == jobs._empty_store()
+
+    invalid = tmp_path / "invalid.json"
+    for payload in ({"version": 1, "jobs": []}, {"version": 2, "jobs": {}}, []):
+        invalid.write_text(json.dumps(payload), encoding="utf-8")
+        with pytest.raises(ValueError):
+            jobs._load_store_file(invalid)
+
+    main = jobs._job_store_path()
+    backup = jobs._job_store_backup_path()
+    main.parent.mkdir(parents=True, exist_ok=True)
+    main.write_text("bad", encoding="utf-8")
+    backup.write_text(json.dumps({"version": 2, "jobs": [{"job_id": "a"}, 1]}), encoding="utf-8")
+    recovered = jobs._load_store()
+    assert recovered["jobs"] == [{"job_id": "a"}]
+    backup.write_text("bad", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="refusing"):
+        jobs._load_store()
+
+    jobs._remove_attempt_paths(None)
+    paths = {"a": tmp_path / "a", "b": tmp_path / "b"}
+    for path in paths.values():
+        path.write_text("x", encoding="utf-8")
+    jobs._remove_attempt_paths(paths)
+    assert not any(path.exists() for path in paths.values())
+
+    runtime = jobs._job_runtime_dir()
+    for name in ("job_x-attempt-1.log", "job_x-attempt-2.log"):
+        (runtime / name).write_text("x", encoding="utf-8")
+    jobs._remove_attempt_files("")
+    jobs._remove_attempt_files("job_x", keep_attempt=2)
+    assert not (runtime / "job_x-attempt-1.log").exists()
+    assert (runtime / "job_x-attempt-2.log").exists()
+
+    store = {
+        "jobs": [
+            {"job_id": "active", "status": "running", "created_at": 1},
+            {"job_id": "old", "status": "failed", "created_at": 1},
+            {"job_id": "new", "status": "failed", "created_at": 2},
+        ]
+    }
+    jobs._prune_store(store)
+    assert [job["job_id"] for job in store["jobs"]] == ["active"]
+
+
+def test_job_runner_arguments_status_and_operations(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    paths = jobs._attempt_paths("job", 2)
+    argv = jobs._runner_argv(paths, tmp_path)
+    assert argv[1:4] == ["-m", "local_shell_mcp.main", "job-runner"]
+    monkeypatch.setattr(jobs.sys, "frozen", True, raising=False)
+    assert jobs._runner_argv(paths, tmp_path)[1] == "job-runner"
+
+    assert jobs._runner_command(["a", "b c"], "bash") == "a 'b c'"
+    assert jobs._runner_command(["a", "b'c"], "powershell.exe").startswith("& ")
+    assert "\"b c\"" in jobs._runner_command(["a", "b c"], "cmd.exe")
+    assert jobs._runner_shell_args("pwsh", "x")[-1] == "x"
+    assert jobs._runner_shell_args("cmd", "x")[1:3] == ["/S", "/C"]
+    assert jobs._runner_shell_args("bash", "x")[-2:] == ["-lc", "x"]
+
+    assert jobs._shell_safe_name("  💥  ") == "job"
+    assert jobs._active_session_ids({"sessions": [{"session_id": "a"}, {}]}) == {"a"}
+    assert jobs._read_status_path(None) is None
+    bad = tmp_path / "bad-status"
+    bad.write_text("bad", encoding="utf-8")
+    assert jobs._read_status_path(bad) is None
+    bad.write_text("[]", encoding="utf-8")
+    assert jobs._read_status_path(bad) is None
+
+    job = {}
+    jobs._apply_status_payload(job, {"exit_code": 0, "completed_at": 5, "output_bytes": 3}, 9)
+    assert job["status"] == "succeeded" and job["completed_at"] == 5
+    jobs._apply_status_payload(job, {"exit_code": 2, "error": "bad"}, 9)
+    assert job["status"] == "failed" and job["error"] == "bad"
+
+    job = {
+        "pending_attempt": 2,
+        "pending_session_name": "s",
+        "pending_command_path": "c",
+        "pending_log_path": "l",
+        "pending_status_path": "p",
+    }
+    jobs._adopt_pending_retry(job)
+    assert job["attempts"] == 2 and job["session_id"] == "s"
+    jobs._clear_pending_retry(job)
+    assert "pending_attempt" not in job
+
+    op = jobs._begin_job_operation(job, "retry")
+    assert jobs._job_operation_matches(job, op)
+    assert jobs._job_operation_is_active(job, "retry")
+    jobs._ACTIVE_JOB_OPERATIONS.discard(op)
+    assert not jobs._job_operation_is_active(job, "retry")
+    jobs._clear_job_operation(job)
+    assert "operation_id" not in job
+    with pytest.raises(KeyError, match="not found"):
+        jobs._find_job({"jobs": []}, "missing")
+
+    encoded = jobs._encode_runner_env_policy(["A", "B"])
+    assert jobs._parse_runner_env_policy(encoded, "value") == ["A", "B"]
+    for raw in ("bad", base64.urlsafe_b64encode(b"{}").decode()):
+        with pytest.raises(ValueError):
+            jobs._parse_runner_env_policy(raw, "value")
+
+
+def test_job_refresh_every_recovery_state(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    assert jobs._refresh_job_status({"status": "done"}, set()) == {"status": "done"}
+
+    active_retry = {"status": "retrying"}
+    operation = jobs._begin_job_operation(active_retry, "retry")
+    assert jobs._refresh_job_status(active_retry, set()) is active_retry
+    jobs._ACTIVE_JOB_OPERATIONS.discard(operation)
+
+    status_path = tmp_path / "status.json"
+    status_path.write_text(json.dumps({"exit_code": 0, "completed_at": 3}), encoding="utf-8")
+    retry = {
+        "status": "retrying",
+        "pending_attempt": 2,
+        "pending_session_name": "new",
+        "pending_status_path": str(status_path),
+    }
+    jobs._refresh_job_status(retry, set(), 5)
+    assert retry["status"] == "succeeded" and retry["attempts"] == 2
+
+    retry = {"status": "retrying", "pending_attempt": 2, "pending_session_name": "new"}
+    jobs._refresh_job_status(retry, {"new"}, 5)
+    assert retry["status"] == "running" and "recovered retry" in retry["error"]
+    retry = {"status": "retrying", "pending_attempt": 2}
+    jobs._refresh_job_status(retry, set(), 5)
+    assert retry["status"] == "failed"
+
+    stopping = {"status": "stopping", "session_id": "s"}
+    jobs._refresh_job_status(stopping, {"s"}, 5)
+    assert stopping["status"] == "running"
+    stopping = {"status": "stopping", "session_id": "s"}
+    jobs._refresh_job_status(stopping, set(), 5)
+    assert stopping["status"] == "stopped"
+
+    running = {"status": "running", "session_id": "s"}
+    assert jobs._refresh_job_status(running, {"s"}, 5)["status"] == "running"
+    jobs._refresh_job_status(running, set(), 5)
+    assert running["status"] == "lost"
+
+
+def test_job_log_compaction_and_runner_error_status(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch, LOCAL_SHELL_MCP_MAX_JOB_LOG_BYTES=5)
+    log = tmp_path / "log"
+    assert jobs._read_log_tail(None, 2) == ""
+    assert jobs._read_log_tail(str(log), 2) == ""
+    log.write_bytes(b"a\nb\nc\n")
+    assert jobs._read_log_tail(str(log), 2) == "b\nc\n"
+
+    handle = io.BytesIO(b"123")
+    handle.seek(0, os.SEEK_END)
+    assert jobs._compact_log(handle, 5) is False
+    handle = io.BytesIO(b"123456789")
+    handle.seek(0, os.SEEK_END)
+    assert jobs._compact_log(handle, 4) is True
+    assert handle.getvalue() == b"6789"
+
+    command = tmp_path / "command"
+    log = tmp_path / "runner.log"
+    status = tmp_path / "runner.status"
+    command.write_text("echo x", encoding="utf-8")
+
+    class NoStdout:
+        stdout = None
+
+    monkeypatch.setattr(jobs.subprocess, "Popen", lambda *args, **kwargs: NoStdout())
+    with pytest.raises(SystemExit) as raised:
+        jobs.run_job_runner_cli(
+            [
+                "--command-file", str(command),
+                "--log-file", str(log),
+                "--status-file", str(status),
+                "--cwd", str(tmp_path),
+                "--shell", "bash",
+                "--max-log-bytes", "4",
+            ]
+        )
+    assert raised.value.code == 127
+    payload = json.loads(status.read_text(encoding="utf-8"))
+    assert "did not expose stdout" in payload["error"]
+
+
+def test_job_start_tail_stop_and_retry_failures(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+
+    async def start_shell(cwd, name, command):
+        return {"session_id": "session", "backend": "native"}
+
+    monkeypatch.setattr(jobs, "start_shell", start_shell)
+    started = asyncio.run(jobs.start_job("echo x", name="name"))
+    assert started["status"] == "running"
+    job_id = started["job_id"]
+
+    monkeypatch.setattr(jobs, "list_shells", lambda: asyncio.sleep(0, result={"sessions": [{"session_id": "session"}]}))
+    monkeypatch.setattr(jobs, "read_shell", lambda *args: asyncio.sleep(0, result={"output": "live"}))
+    tailed = asyncio.run(jobs.tail_job(job_id))
+    assert tailed["output"] == "live"
+
+    monkeypatch.setattr(jobs, "read_shell", lambda *args: (_ for _ in ()).throw(RuntimeError("read failed")))
+    tailed = asyncio.run(jobs.tail_job(job_id))
+    assert tailed["job"]["status"] == "lost"
+
+    terminal = asyncio.run(jobs.stop_job(job_id))
+    assert terminal["killed"] is False
+
+    with jobs._store_transaction() as store:
+        current = jobs._find_job(store, job_id)
+        current["status"] = "failed"
+    monkeypatch.setattr(jobs, "_prepare_attempt", lambda *args: (_ for _ in ()).throw(RuntimeError("prepare")))
+    with pytest.raises(RuntimeError, match="prepare"):
+        asyncio.run(jobs.retry_job(job_id))
+    with jobs._store_transaction() as store:
+        assert "retry failed" in jobs._find_job(store, job_id)["error"]
+
+
+def test_shell_buffers_arguments_timeouts_and_reader_helpers(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch, LOCAL_SHELL_MCP_MAX_OUTPUT_BYTES=5)
+    tail = shell.TailBuffer(3, bytearray())
+    tail.append(b"")
+    tail.append(b"abcdef")
+    assert bytes(tail.data) == b"def" and tail.truncated
+
+    assert shell._shared_tail_bytes(b"a", b"b", 5) == (b"a", b"b", False)
+    out, err, truncated = shell._shared_tail_bytes(b"abcdef", b"xy", 5)
+    assert len(out) + len(err) == 5 and truncated
+    assert shell.clamp_output("abcdef", "xy")[-1] is True
+    assert shell._effective_output_limit(None) == 5
+    assert shell._effective_output_limit(100) == 5
+
+    for executable, expected in (
+        ("powershell.exe", ["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", "x"]),
+        ("cmd.exe", ["cmd.exe", "/S", "/C", "x"]),
+        ("/bin/bash", ["/bin/bash", "-lc", "x"]),
+    ):
+        monkeypatch.setenv("LOCAL_SHELL_MCP_SHELL_EXECUTABLE", executable)
+        get_settings.cache_clear()
+        assert shell._shell_command_args("x") == expected
+    monkeypatch.setenv("LOCAL_SHELL_MCP_SHELL_EXECUTABLE", "powershell.exe")
+    get_settings.cache_clear()
+    assert shell.quote_shell_argument("a'b") == "'a''b'"
+    monkeypatch.setenv("LOCAL_SHELL_MCP_SHELL_EXECUTABLE", "cmd.exe")
+    get_settings.cache_clear()
+    assert "a b" in shell.quote_shell_argument("a b")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_SHELL_EXECUTABLE", "/bin/bash")
+    get_settings.cache_clear()
+    assert shell._persistent_shell_args() == ["/bin/bash"]
+    assert shell._persistent_shell_args("x")[-1] == "x"
+
+    assert shell.public_run_shell_timeout(None) == 10
+    assert shell.public_run_shell_timeout(0) == 10
+    with pytest.raises(ValueError):
+        shell.public_run_shell_timeout(121)
+
+    class Stream:
+        def __init__(self, values):
+            self.values = list(values)
+
+        async def read(self, size):
+            return self.values.pop(0)
+
+    tail = shell.TailBuffer(10, bytearray())
+    asyncio.run(shell._read_stream_tail(None, tail))
+    asyncio.run(shell._read_stream_tail(Stream([b"x", b""]), tail))
+    assert bytes(tail.data) == b"x"
+
+    class Proc:
+        async def wait(self):
+            await asyncio.sleep(1)
+
+    assert asyncio.run(shell._wait_for_process_exit(Proc(), 0)) is False
+
+    async def slow():
+        await asyncio.sleep(1)
+
+    task = None
+
+    async def finish():
+        nonlocal task
+        task = asyncio.create_task(slow())
+        await shell._finish_reader_tasks([task], timeout_s=0)
+
+    asyncio.run(finish())
+    assert task is not None and task.cancelled()
+
+
+def test_shell_process_termination_native_sessions_and_dispatch(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+
+    class Proc:
+        pid = 12
+        returncode = None
+
+        def __init__(self):
+            self.terminated = False
+            self.killed = False
+            self.stdin = None
+            self._transport = SimpleNamespace(close=lambda: None)
+
+        def terminate(self):
+            self.terminated = True
+
+        def kill(self):
+            self.killed = True
+
+    proc = Proc()
+    waits = iter([False, True])
+    monkeypatch.setattr(shell, "_wait_for_process_exit", lambda *args: asyncio.sleep(0, result=next(waits)))
+    monkeypatch.setattr(
+        shell.os,
+        "killpg",
+        lambda *args: (_ for _ in ()).throw(OSError()),
+        raising=False,
+    )
+    assert asyncio.run(shell._terminate_process_group(proc)) == ""
+    assert proc.terminated and proc.killed
+
+    proc = Proc()
+    monkeypatch.setattr(shell, "_wait_for_process_exit", lambda *args: asyncio.sleep(0, result=False))
+    assert "did not exit" in asyncio.run(shell._native_stop_process(proc))
+
+    output = shell.TailBuffer(100, bytearray(b"one\ntwo\n"))
+    alive = SimpleNamespace(returncode=None)
+    session = shell.NativeShellSession("s", alive, tmp_path, "cmd", 1, output, [], asyncio.Lock())
+    shell._NATIVE_SHELL_SESSIONS["s"] = session
+    assert asyncio.run(shell._native_read_shell("s", 1))["output"] == "two\n"
+    assert asyncio.run(shell._native_list_shells())["sessions"][0]["session_id"] == "s"
+    alive.returncode = 2
+    with pytest.raises(RuntimeError, match="exited"):
+        shell._get_native_session("s")
+    with pytest.raises(RuntimeError, match="not found"):
+        shell._get_native_session("missing")
+    assert asyncio.run(shell._native_kill_shell("missing"))["killed"] is False
+
+    monkeypatch.setattr(shell, "resolve_tmux", lambda: TmuxSelection(None, "native"))
+    monkeypatch.setattr(shell, "_native_send_shell", lambda *args: asyncio.sleep(0, result={"native": True}))
+    monkeypatch.setattr(shell, "_native_read_shell", lambda *args: asyncio.sleep(0, result={"native": True}))
+    monkeypatch.setattr(shell, "_native_kill_shell", lambda *args: asyncio.sleep(0, result={"native": True}))
+    assert (asyncio.run(shell.send_shell("x", "y")))["native"]
+    assert (asyncio.run(shell.read_shell("x")))["native"]
+    assert (asyncio.run(shell.kill_shell("x")))["native"]
+
+    monkeypatch.setattr(shell, "resolve_tmux", lambda: TmuxSelection("/tmux", "system"))
+    responses = iter([_command_result(), _command_result(), _command_result(stdout="pane"), _command_result()])
+    monkeypatch.setattr(shell, "tmux", lambda *args, **kwargs: asyncio.sleep(0, result=next(responses)))
+    sent = asyncio.run(shell.send_shell("tmux", "text", True))
+    assert sent["enter"] is True
+    assert asyncio.run(shell.read_shell("tmux"))["output"] == "pane"
+    assert asyncio.run(shell.kill_shell("tmux"))["killed"] is True
+
+
+def test_conpty_helpers_cleanup_start_send_read_kill_and_list(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch, LOCAL_SHELL_MCP_MAX_TMUX_SESSIONS=1)
+    assert conpty.is_available() is (conpty.winpty is not None and hasattr(conpty.winpty, "PtyProcess"))
+    assert conpty._session_name("bad name") == "bad-name"
+    for executable, suffix in (
+        ("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", "x"]),
+        ("cmd.exe", ["/S", "/C", "x"]),
+        ("bash", ["-lc", "x"]),
+    ):
+        monkeypatch.setenv("LOCAL_SHELL_MCP_SHELL_EXECUTABLE", executable)
+        get_settings.cache_clear()
+        assert conpty._shell_command_args("x")[1:] == suffix
+    assert isinstance(conpty._spawn_command(["a", "b c"]), str)
+
+    monkeypatch.setattr(conpty, "winpty", None)
+    with pytest.raises(RuntimeError, match="not available"):
+        conpty._spawn_pty(["x"], tmp_path)
+
+    class Process:
+        def __init__(self, alive=True):
+            self.alive = alive
+            self.exitstatus = None if alive else 1
+            self.writes = []
+            self.closed = False
+
+        def isalive(self):
+            return self.alive
+
+        def read(self, *args):
+            if args:
+                raise TypeError
+            return "data"
+
+        def write(self, data):
+            self.writes.append(data)
+
+        def close(self, force=False):
+            self.closed = True
+
+    process = Process()
+    assert conpty._pty_is_alive(process)
+    assert conpty._read_pty(process) == "data"
+    conpty._close_pty_process(process, True)
+    assert process.closed
+
+    terminate = SimpleNamespace(terminate=lambda: None)
+    conpty._close_pty_process(terminate, True)
+
+    dead = Process(False)
+    stale = conpty.ConPtyShellSession("stale", dead, tmp_path, "x", 1, conpty.TailBuffer(10, bytearray()), None, asyncio.Lock())
+    conpty._CONPTY_SHELL_SESSIONS["stale"] = stale
+
+    spawned = Process(True)
+    monkeypatch.setattr(conpty, "_spawn_pty", lambda *args: spawned)
+    checked = []
+    started = asyncio.run(conpty.start_shell(".", "new", "cmd", checked.append))
+    assert started["backend"] == "conpty" and checked == ["cmd"]
+    assert "stale" not in conpty._CONPTY_SHELL_SESSIONS
+    with pytest.raises(RuntimeError, match="more than"):
+        asyncio.run(conpty.start_shell(".", "other"))
+
+    assert asyncio.run(conpty.send_shell("new", "input"))["enter"] is True
+    assert spawned.writes[-1] == "input\r"
+    session = conpty._CONPTY_SHELL_SESSIONS["new"]
+    session.output.append(b"one\ntwo\n")
+    assert asyncio.run(conpty.read_shell("new", 1))["output"] == "two\n"
+    assert asyncio.run(conpty.list_shells())["sessions"][0]["backend"] == "conpty"
+    killed = asyncio.run(conpty.kill_shell("new"))
+    assert killed["killed"] is True
+    assert asyncio.run(conpty.kill_shell("missing"))["killed"] is False
+    with pytest.raises(RuntimeError, match="not found"):
+        asyncio.run(conpty._get_session("missing"))
+
+
+def test_conpty_reader_exception_and_cleanup_variants(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+
+    class Process:
+        exitstatus = None
+
+        def isalive(self):
+            return True
+
+    process = Process()
+    session = conpty.ConPtyShellSession("s", process, tmp_path, "x", 1, conpty.TailBuffer(100, bytearray()), None, asyncio.Lock())
+    monkeypatch.setattr(conpty, "_read_pty", lambda value: (_ for _ in ()).throw(RuntimeError("read")))
+    asyncio.run(conpty._read_conpty_shell(session))
+    assert b"reader stopped" in session.output.data
+
+    class BadClose:
+        def close(self, force=False):
+            raise RuntimeError("close")
+
+    session.process = BadClose()
+    error = asyncio.run(conpty._cleanup_session(session, force=True))
+    assert "close" in error
+
+    class FakeReader:
+        def get_loop(self):
+            raise RuntimeError("loop")
+
+    asyncio.run(conpty._cleanup_reader(FakeReader()))

--- a/tests/test_settings_complete.py
+++ b/tests/test_settings_complete.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+import local_shell_mcp.settings as settings
+
+
+def test_ui_path_csv_shell_and_default_helpers(tmp_path, monkeypatch):
+    assert settings.normalize_ui_path(" /console//nested ") == "/console/nested"
+    for value in ("ui", "/", "/a/../b", "/api", "/api/x", "/x?y", "/x#y", r"/x\y"):
+        with pytest.raises(ValueError):
+            settings.normalize_ui_path(value)
+
+    assert settings._split_csv(None) == []
+    assert settings._split_csv(["a", "b"]) == ["a", "b"]
+    assert settings._split_csv(" a, ,b ") == ["a", "b"]
+
+    monkeypatch.setattr(settings.os, "name", "nt")
+    assert settings.default_shell_executable() == "powershell.exe"
+    assert settings.default_python_executable() == "python.exe"
+    monkeypatch.setattr(settings.os, "name", "posix")
+    assert settings.default_shell_executable() == "/bin/bash"
+    assert settings.default_python_executable() == "python3"
+
+    value = tmp_path / "value"
+    assert settings._matches_default_path(value, value)
+
+    class BrokenPath:
+        def __eq__(self, other):
+            return False
+
+        def resolve(self):
+            raise OSError("broken")
+
+    assert settings._matches_default_path(BrokenPath(), Path("other")) is False
+
+
+def test_yaml_flatten_apply_get_settings_and_redaction(tmp_path, monkeypatch):
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        """
+mode: http
+ui:
+  wallpaper: none
+remote:
+  enabled: false
+port: 9001
+""".strip(),
+        encoding="utf-8",
+    )
+    flat = settings._flatten_yaml(config)
+    assert flat == {
+        "mode": "http",
+        "ui_wallpaper": "none",
+        "remote_enabled": False,
+        "port": 9001,
+    }
+    with pytest.raises(FileNotFoundError):
+        settings._flatten_yaml(tmp_path / "missing.yaml")
+    monkeypatch.setattr(settings, "yaml", None)
+    with pytest.raises(RuntimeError, match="PyYAML"):
+        settings._flatten_yaml(config)
+
+    import yaml
+
+    monkeypatch.setattr(settings, "yaml", yaml)
+    workspace = tmp_path / "workspace"
+    monkeypatch.setenv("LOCAL_SHELL_MCP_CONFIG", str(config))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(workspace))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_OAUTH_JWT_SECRET", "x" * 40)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_OAUTH_ADMIN_PIN", "secret-pin-value")
+    settings.get_settings.cache_clear()
+    loaded = settings.get_settings()
+    assert loaded.mode == "http"
+    assert loaded.port == 9001
+    assert loaded.ui_wallpaper == "none"
+    assert loaded.remote_enabled is False
+    assert loaded.workspace_root == workspace.resolve()
+    assert workspace.is_dir()
+
+    dumped = settings.safe_settings_dump(loaded)
+    assert dumped["oauth_jwt_secret"] == "<redacted>"
+    assert dumped["oauth_admin_pin"] == "<redacted>"
+    loaded.oauth_admin_pin = None
+    assert settings.safe_settings_dump(loaded)["oauth_admin_pin"] is None
+
+
+def test_pydantic_settings_validation_and_copy_paths(tmp_path):
+    model = settings.Settings(
+        workspace_root=tmp_path,
+        state_dir=tmp_path / "state",
+        audit_log_path=tmp_path / "audit.jsonl",
+        agent_config_dir=tmp_path / "agents",
+        allow_full_container=True,
+        command_denylist=["blocked"],
+        path_denylist=["hidden"],
+    )
+    assert model.command_denylist == []
+    assert model.path_denylist == []
+    assert model.with_workspace_relative_defaults() is model
+
+    copied = settings._replace_settings(model, port=9999)
+    assert copied.port == 9999
+    assert model.port != 9999
+
+    config = tmp_path / "settings.yaml"
+    config.write_text("port: 7654\nshell:\n  executable: /bin/sh\n", encoding="utf-8")
+    applied = model.apply_yaml(config)
+    assert applied.port == 7654
+    assert applied.shell_executable == "/bin/sh"
+
+    assert settings.Settings(command_denylist="a,b").command_denylist == ["a", "b"]
+    assert settings.Settings(path_denylist=["a"]).path_denylist == ["a"]
+
+
+@pytest.mark.parametrize(
+    "updates, message",
+    [
+        ({"max_jobs": -1}, "greater than or equal"),
+        ({"oauth_access_token_ttl_s": -1}, "greater than or equal"),
+        ({"port": 0}, "greater than zero"),
+        ({"file_download_default_max_downloads": -1}, "greater than or equal"),
+    ],
+)
+def test_additional_numeric_validation(updates, message):
+    with pytest.raises(ValueError, match=message):
+        settings.Settings(**updates)
+
+
+def test_oauth_validation_early_returns_and_secret_read(tmp_path):
+    settings.validate_public_oauth_configuration(
+        settings.Settings(auth_mode="none", oauth_jwt_secret="short")
+    )
+    settings.validate_public_oauth_configuration(
+        settings.Settings(
+            auth_mode="oauth",
+            oauth_jwt_secret="s" * 32,
+            public_base_url=None,
+        )
+    )
+
+    missing = tmp_path / "missing"
+    assert settings._read_oauth_secret(missing) is None
+    short = tmp_path / "short"
+    short.write_text("tiny", encoding="utf-8")
+    assert settings._read_oauth_secret(short) is None
+    valid = tmp_path / "valid"
+    valid.write_text("v" * 32, encoding="utf-8")
+    assert settings._read_oauth_secret(valid) == "v" * 32
+
+
+def _load_fallback_settings(monkeypatch):
+    module_name = "local_shell_mcp._fallback_settings_test"
+    path = Path(settings.__file__)
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    monkeypatch.setitem(sys.modules, "pydantic", None)
+    monkeypatch.setitem(sys.modules, "pydantic_settings", None)
+    spec.loader.exec_module(module)
+    assert module._PYDANTIC_AVAILABLE is False
+    return module
+
+
+def test_dependency_light_fallback_settings(tmp_path, monkeypatch):
+    fallback = _load_fallback_settings(monkeypatch)
+
+    assert fallback._env_bool("YES") is True
+    assert fallback._env_bool("off") is False
+    assert fallback._coerce_env_value("true", False) is True
+    assert fallback._coerce_env_value("12", 1) == 12
+    assert fallback._coerce_env_value("1.5", 1.0) == 1.5
+    assert fallback._coerce_env_value("a,b", []) == ["a", "b"]
+    assert fallback._coerce_env_value("", None) is None
+    assert fallback._coerce_env_value("value", "old") == "value"
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("FALLBACK_ROOT", str(tmp_path / "expanded"))
+    path_value = fallback._coerce_env_value("$FALLBACK_ROOT", Path("."))
+    assert path_value == (tmp_path / "expanded").resolve()
+
+    workspace = tmp_path / "fallback-workspace"
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(workspace))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(tmp_path / "fallback-state"))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_PORT", "9010")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_REMOTE_ENABLED", "false")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_COMMAND_DENYLIST", "one,two")
+    instance = fallback.Settings()
+    assert instance.port == 9010
+    assert instance.remote_enabled is False
+    assert instance.command_denylist == ["one", "two"]
+    assert instance.workspace_root == workspace.resolve()
+
+    dumped = instance.model_dump(mode="json")
+    assert dumped["workspace_root"] == str(workspace.resolve())
+    assert instance.model_copy(update={"port": 9020}).port == 9020
+
+    yaml_path = tmp_path / "fallback.yaml"
+    yaml_path.write_text("port: 9030\nui:\n  wallpaper: none\n", encoding="utf-8")
+    applied = instance.apply_yaml(yaml_path)
+    assert applied.port == 9030
+    assert applied.ui_wallpaper == "none"
+
+    for name in (
+        "LOCAL_SHELL_MCP_WORKSPACE_ROOT",
+        "LOCAL_SHELL_MCP_STATE_DIR",
+        "LOCAL_SHELL_MCP_PORT",
+        "LOCAL_SHELL_MCP_REMOTE_ENABLED",
+        "LOCAL_SHELL_MCP_COMMAND_DENYLIST",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    relative = fallback.Settings(
+        workspace_root=workspace,
+        state_dir=fallback.DEFAULT_STATE_DIR,
+        audit_log_path=fallback.DEFAULT_AUDIT_LOG_PATH,
+        agent_config_dir=fallback.DEFAULT_AGENT_CONFIG_DIR,
+    ).with_workspace_relative_defaults()
+    assert relative.state_dir == workspace.resolve() / ".local-shell-mcp"
+    assert relative.audit_log_path == relative.state_dir / "audit.jsonl"
+
+    unrestricted = fallback.Settings(allow_full_container=True)
+    assert unrestricted.command_denylist == []
+    assert unrestricted.path_denylist == []
+
+
+def test_get_settings_creates_relative_defaults(tmp_path, monkeypatch):
+    workspace = tmp_path / "new-workspace"
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(workspace))
+    monkeypatch.delenv("LOCAL_SHELL_MCP_STATE_DIR", raising=False)
+    monkeypatch.delenv("LOCAL_SHELL_MCP_AUDIT_LOG_PATH", raising=False)
+    monkeypatch.delenv("LOCAL_SHELL_MCP_AGENT_CONFIG_DIR", raising=False)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_AUTH_MODE", "none")
+    monkeypatch.delenv("LOCAL_SHELL_MCP_CONFIG", raising=False)
+    settings.get_settings.cache_clear()
+
+    loaded = settings.get_settings()
+
+    assert loaded.state_dir == workspace.resolve() / ".local-shell-mcp"
+    assert loaded.audit_log_path.parent.is_dir()
+    assert loaded.agent_config_dir.is_dir()

--- a/tests/test_settings_complete.py
+++ b/tests/test_settings_complete.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -19,10 +20,10 @@ def test_ui_path_csv_shell_and_default_helpers(tmp_path, monkeypatch):
     assert settings._split_csv(["a", "b"]) == ["a", "b"]
     assert settings._split_csv(" a, ,b ") == ["a", "b"]
 
-    monkeypatch.setattr(settings.os, "name", "nt")
+    monkeypatch.setattr(settings, "os", SimpleNamespace(name="nt"))
     assert settings.default_shell_executable() == "powershell.exe"
     assert settings.default_python_executable() == "python.exe"
-    monkeypatch.setattr(settings.os, "name", "posix")
+    monkeypatch.setattr(settings, "os", SimpleNamespace(name="posix"))
     assert settings.default_shell_executable() == "/bin/bash"
     assert settings.default_python_executable() == "python3"
 

--- a/tests/test_skills_edge_complete.py
+++ b/tests/test_skills_edge_complete.py
@@ -72,7 +72,7 @@ def test_resolved_directories_regular_files_and_roots(tmp_path, monkeypatch):
     skill = directory / "good"
     skill.mkdir()
     entry = skill / "SKILL.md"
-    entry.write_text("line\r\nnext\r", encoding="utf-8")
+    entry.write_bytes(b"line\r\nnext\r")
     content, size, resolved = skills._open_regular_file(entry, skill, 100)
     assert content == "line\nnext\n"
     assert size > 0 and resolved == entry.resolve()

--- a/tests/test_skills_edge_complete.py
+++ b/tests/test_skills_edge_complete.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import local_shell_mcp.agent_bridge.skills as skills
+from local_shell_mcp.agent_bridge.models import SkillRecord
+
+
+def test_skill_name_and_path_validation_all_rejections(monkeypatch):
+    invalid_names = [None, "", " name", "name ", ".", "..", "a/b", r"a\b", "x" * 256, "a\x01"]
+    for value in invalid_names:
+        with pytest.raises(ValueError):
+            skills.validate_skill_name(value)  # type: ignore[arg-type]
+
+    surrogate = "\ud800"
+    with pytest.raises(ValueError, match="UTF-8"):
+        skills.validate_skill_name(surrogate)
+    assert skills.validate_skill_name("合法-name") == "合法-name"
+
+    invalid_paths = [None, "", "x" * (skills.MAX_SKILL_FILE_PATH_CHARS + 1), r"a\b", "a:b", "a\x01", "/a", "../a", ".", "a//b", "a/./b"]
+    for value in invalid_paths:
+        with pytest.raises(ValueError):
+            skills.validate_skill_file_path(value)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="UTF-8"):
+        skills.validate_skill_file_path(surrogate)
+    assert skills.validate_skill_file_path("docs/guide.md") == Path("docs/guide.md")
+
+
+def test_descriptions_front_matter_and_warning_cap():
+    assert skills._first_sentence("First. Second") == "First."
+    assert skills._first_sentence("No terminator") == "No terminator"
+    assert skills._normalize_description(None) is None
+    assert skills._normalize_description("   ") is None
+    assert skills._normalize_description("x" * 600).endswith("…")
+
+    assert skills._skill_description("\n---\ndescription: Useful skill\n---\n# Heading") == "Useful skill"
+    assert skills._skill_description("+++\ndescription = 'TOML skill'\n+++\nbody") == "TOML skill"
+    assert skills._skill_description("---\n[bad\n---\n# Heading\n```\nignored\n```\n") == "Heading"
+    assert skills._skill_description("```\nignored\n```\n") == "Agent skill"
+    assert skills._front_matter_description(["---", "description: x"], 0) == (None, 0)
+
+    warnings = []
+    for index in range(skills.MAX_SKILL_WARNINGS + 5):
+        skills._append_warning(warnings, str(index))
+    assert len(warnings) == skills.MAX_SKILL_WARNINGS + 1
+    assert warnings[-1] == "Additional Skill warnings were omitted"
+
+
+def test_resolved_directories_regular_files_and_roots(tmp_path, monkeypatch):
+    config = tmp_path / "config"
+    config.mkdir()
+    with pytest.raises(ValueError, match="inside"):
+        skills._resolved_skills_directory(config, "../outside")
+    with pytest.raises(ValueError, match="inside"):
+        skills._resolved_skills_directory(config, "/absolute")
+    root, directory = skills._resolved_skills_directory(config, "skills")
+    assert root == config.resolve()
+    assert directory == config.resolve() / "skills"
+
+    directory.mkdir()
+    with pytest.raises(ValueError, match="Unknown skill"):
+        skills._resolve_skill_root(directory, "missing")
+    file_skill = directory / "file"
+    file_skill.write_text("x", encoding="utf-8")
+    with pytest.raises(ValueError, match="regular directory"):
+        skills._resolve_skill_root(directory, "file")
+
+    skill = directory / "good"
+    skill.mkdir()
+    entry = skill / "SKILL.md"
+    entry.write_text("line\r\nnext\r", encoding="utf-8")
+    content, size, resolved = skills._open_regular_file(entry, skill, 100)
+    assert content == "line\nnext\n"
+    assert size > 0 and resolved == entry.resolve()
+    with pytest.raises(ValueError, match="maximum"):
+        skills._open_regular_file(entry, skill, 1)
+    with pytest.raises(ValueError, match="readable regular"):
+        skills._open_regular_file(skill / "missing", skill, 100)
+
+    if hasattr(os, "symlink"):
+        link = skill / "link.md"
+        try:
+            link.symlink_to(entry)
+        except OSError:
+            pass
+        else:
+            with pytest.raises(ValueError):
+                skills._open_regular_file(link, skill, 100)
+
+
+def test_related_scan_budgets_symlinks_and_failures(tmp_path, monkeypatch):
+    skill = tmp_path / "skill"
+    skill.mkdir()
+    entry = skill / "SKILL.md"
+    entry.write_text("entry", encoding="utf-8")
+    (skill / "b.txt").write_text("b", encoding="utf-8")
+    (skill / "a.txt").write_text("a", encoding="utf-8")
+    nested = skill / "nested"
+    nested.mkdir()
+    (nested / "c.txt").write_text("c", encoding="utf-8")
+
+    related, warnings, scanned = skills._scan_related_files(
+        skill,
+        entry.resolve(),
+        max_related_files=10,
+        max_scan_entries=0,
+        max_path_bytes=100,
+    )
+    assert related == [] and scanned == 0 and "scan budget" in warnings[0]
+    related, warnings, _ = skills._scan_related_files(
+        skill,
+        entry.resolve(),
+        max_related_files=10,
+        max_scan_entries=100,
+        max_path_bytes=0,
+    )
+    assert related == [] and "path budget" in warnings[0]
+
+    related, warnings, _ = skills._scan_related_files(
+        skill,
+        entry.resolve(),
+        max_related_files=1,
+        max_scan_entries=100,
+        max_path_bytes=100,
+    )
+    assert len(related) == 1
+    assert any("truncated" in warning for warning in warnings)
+
+    related, warnings, _ = skills._scan_related_files(
+        skill,
+        entry.resolve(),
+        max_related_files=10,
+        max_scan_entries=2,
+        max_path_bytes=100,
+    )
+    assert any("stopped" in warning for warning in warnings)
+
+    related, warnings, _ = skills._scan_related_files(
+        skill,
+        entry.resolve(),
+        max_related_files=10,
+        max_scan_entries=100,
+        max_path_bytes=1,
+    )
+    assert related == []
+    assert any("UTF-8 bytes" in warning for warning in warnings)
+
+    if hasattr(os, "symlink"):
+        link = skill / "link"
+        try:
+            link.symlink_to(entry)
+        except OSError:
+            pass
+        else:
+            _, warnings, _ = skills._scan_related_files(
+                skill,
+                entry.resolve(),
+                max_related_files=10,
+                max_scan_entries=100,
+                max_path_bytes=1000,
+            )
+            assert any("symlinks" in warning for warning in warnings)
+
+    real_scandir = skills.os.scandir
+
+    def failing(path):
+        if Path(path) == nested:
+            raise OSError("scan failed")
+        return real_scandir(path)
+
+    monkeypatch.setattr(skills.os, "scandir", failing)
+    _, warnings, _ = skills._scan_related_files(
+        skill,
+        entry.resolve(),
+        max_related_files=10,
+        max_scan_entries=100,
+        max_path_bytes=1000,
+    )
+    assert any("Could not scan" in warning for warning in warnings)
+
+
+def test_scan_load_read_and_legacy_activation(tmp_path):
+    config = tmp_path / "config"
+    skills_dir = config / "skills"
+    skills_dir.mkdir(parents=True)
+    assert not skills.scan_agent_skills(config / "missing").skills
+
+    bad_path = config / "not-dir"
+    bad_path.write_text("x", encoding="utf-8")
+    result = skills.scan_agent_skills(config, directory="not-dir")
+    assert "not a directory" in result.warnings[0]
+
+    good = skills_dir / "good"
+    good.mkdir()
+    (good / "SKILL.md").write_text("# Good\nDescription.", encoding="utf-8")
+    (good / "guide.md").write_text("guide", encoding="utf-8")
+    missing = skills_dir / "missing-entry"
+    missing.mkdir()
+    (skills_dir / "plain-file").write_text("x", encoding="utf-8")
+
+    result = skills.scan_agent_skills(config, max_skills=1, max_scan_entries=100)
+    assert list(result.skills) == ["good"]
+    assert any("truncated" in warning for warning in result.warnings)
+    loaded = skills.load_agent_skill(config, "good")
+    assert loaded["description"] == "Description."
+    assert loaded["related_files"] == ["guide.md"]
+    read = skills.read_agent_skill_file(config, "good", "guide.md")
+    assert read["content"] == "guide"
+    with pytest.raises(ValueError, match="skill_load"):
+        skills.read_agent_skill_file(config, "good", "SKILL.md")
+
+    record = SkillRecord(
+        name="good",
+        entry_path="skills/good/SKILL.md",
+        description="Good",
+        related_files=["guide.md"],
+    )
+    activated = skills.activate_skill(config, record)
+    assert activated["content"].startswith("# Good")
+    with pytest.raises(ValueError, match="inside"):
+        skills.activate_skill(
+            config,
+            SimpleNamespace(
+                name="bad",
+                entry_path="../outside.md",
+                description="bad",
+                related_files=[],
+            ),
+        )

--- a/tests/test_storage_complete.py
+++ b/tests/test_storage_complete.py
@@ -55,7 +55,7 @@ def test_filesystem_binary_glob_context_and_limits(tmp_path, monkeypatch):
     assert context["nearest_existing_parent"] == str(tmp_path)
     assert context["truncated"] is True
     outside = fs.relative_display(Path("/outside/value"))
-    assert outside.startswith("/")
+    assert Path(outside).is_absolute()
 
     assert fs._is_probably_binary(b"") is False
     assert fs._is_probably_binary(b"a\x00b") is True

--- a/tests/test_storage_complete.py
+++ b/tests/test_storage_complete.py
@@ -1,0 +1,495 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import io
+import json
+import os
+import tarfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+import local_shell_mcp.downloads as downloads
+import local_shell_mcp.fs_ops as fs
+import local_shell_mcp.remote_transfer as remote_transfer
+import local_shell_mcp.transfer_ops as transfer
+from local_shell_mcp.settings import get_settings
+
+
+def _configure(tmp_path, monkeypatch, **extra):
+    values = {
+        "LOCAL_SHELL_MCP_WORKSPACE_ROOT": str(tmp_path),
+        "LOCAL_SHELL_MCP_STATE_DIR": str(tmp_path / ".state"),
+        "LOCAL_SHELL_MCP_AUDIT_LOG_PATH": str(tmp_path / "audit.jsonl"),
+        "LOCAL_SHELL_MCP_AUTH_MODE": "none",
+        "LOCAL_SHELL_MCP_PUBLIC_BASE_URL": "http://testserver",
+    }
+    values.update({key: str(value) for key, value in extra.items()})
+    for key, value in values.items():
+        monkeypatch.setenv(key, value)
+    get_settings.cache_clear()
+    remote_transfer._TICKETS.clear()
+
+
+def test_filesystem_binary_glob_context_and_limits(tmp_path, monkeypatch):
+    _configure(
+        tmp_path,
+        monkeypatch,
+        LOCAL_SHELL_MCP_MAX_GLOB_RESULTS=1,
+        LOCAL_SHELL_MCP_MAX_READ_MANY_FILES=1,
+        LOCAL_SHELL_MCP_MAX_READ_MANY_TOTAL_BYTES=3,
+    )
+    (tmp_path / "a.txt").write_text("abcd", encoding="utf-8")
+    (tmp_path / "nested").mkdir()
+    (tmp_path / "nested" / "a.py").write_text("x", encoding="utf-8")
+    assert len(fs.glob_paths("a*")) == 1
+    with pytest.raises(NotADirectoryError):
+        fs.list_dir("a.txt")
+
+    context = fs.missing_path_context("missing/child", max_entries=1)
+    assert context["exists"] is False
+    assert context["nearest_existing_parent"] == str(tmp_path)
+    assert context["truncated"] is True
+    outside = fs.relative_display(Path("/outside/value"))
+    assert outside.startswith("/")
+
+    assert fs._is_probably_binary(b"") is False
+    assert fs._is_probably_binary(b"a\x00b") is True
+    assert fs._is_probably_binary(b"\xff") is True
+    assert fs._is_probably_binary(bytes([1, 2, 3, 65])) is True
+    assert fs._is_probably_binary(b"plain\ntext") is False
+
+    binary = tmp_path / "binary.bin"
+    binary.write_bytes(b"\x00abc")
+    metadata = fs._binary_metadata(binary, 4, "hex", 999)
+    assert metadata["preview"] == "00616263"
+    assert metadata["preview_bytes"] == 4
+    metadata = fs._binary_metadata(binary, 4, "base64", 4)
+    assert base64.b64decode(metadata["preview"]) == b"\x00abc"
+    with pytest.raises(ValueError, match="binary_preview"):
+        fs._binary_metadata(binary, 4, "unknown")
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        fs.read_texts([])
+    with pytest.raises(ValueError, match="max is 1"):
+        fs.read_texts(["a.txt", "a.txt"])
+    with pytest.raises(ValueError, match="Refusing to return"):
+        fs.read_texts(["a.txt"])
+
+    missing_parent = fs.resolve_path("missing/child", allow_missing_parent=True)
+    assert missing_parent.name == "child"
+    with pytest.raises(FileNotFoundError):
+        fs.resolve_path("missing/child", allow_missing_parent=False)
+
+
+def test_filesystem_mutation_and_temp_cleanup_edges(tmp_path, monkeypatch):
+    _configure(
+        tmp_path,
+        monkeypatch,
+        LOCAL_SHELL_MCP_MAX_TMP_FILES=1,
+        LOCAL_SHELL_MCP_MAX_TMP_BYTES=3,
+        LOCAL_SHELL_MCP_MAX_FILE_WRITE_BYTES=5,
+    )
+    temp = fs.temp_dir()
+    older = temp / "old"
+    newer = temp / "new"
+    older.write_bytes(b"123")
+    newer.write_bytes(b"456")
+    os.utime(older, (1, 1))
+    os.utime(newer, (2, 2))
+    fs.prune_temp_dir()
+    assert newer.exists()
+    assert not older.exists()
+
+    with pytest.raises(ValueError, match="Refusing to write"):
+        fs.write_text("large.txt", "123456")
+    with pytest.raises(fs.FileConflictError, match="deleted"):
+        fs.write_text("missing.txt", "x", expected_sha256="0" * 64)
+
+    fs.perform_file_action("mkdir", "folder")
+    assert fs.perform_file_action("mkdir", "folder", exist_ok=True)["action"] == "mkdir"
+    with pytest.raises(FileExistsError):
+        fs.perform_file_action("touch", "folder", exist_ok=True)
+    fs.perform_file_action("touch", "file")
+    assert fs.perform_file_action("touch", "file", exist_ok=True)["action"] == "touch"
+    with pytest.raises(FileExistsError):
+        fs.perform_file_action("mkdir", "file", exist_ok=True)
+    with pytest.raises(ValueError, match="destination"):
+        fs.perform_file_action("copy", "file")
+    with pytest.raises(FileNotFoundError):
+        fs.perform_file_action("copy", "file", "missing-parent/target")
+    with pytest.raises(ValueError, match="Unsupported"):
+        fs.perform_file_action("bad", "file")
+
+    fs.perform_file_action("copy", "file", "copy")
+    fs.perform_file_action("move", "copy", "moved")
+    fs.perform_file_action("rename", "moved", "renamed")
+    assert (tmp_path / "renamed").is_file()
+    with pytest.raises(FileExistsError):
+        fs.perform_file_action("copy", "file", "renamed")
+
+    directory = tmp_path / "delete-dir"
+    directory.mkdir()
+    with pytest.raises(IsADirectoryError):
+        fs.delete_path("delete-dir")
+    assert fs.delete_path("delete-dir", recursive=True)["deleted"] == "directory"
+    assert fs.delete_path("renamed")["deleted"] == "file"
+
+    if hasattr(os, "symlink"):
+        target = tmp_path / "target"
+        target.write_text("x", encoding="utf-8")
+        link = tmp_path / "link"
+        try:
+            link.symlink_to(target)
+        except OSError:
+            return
+        fs.perform_file_action("copy", "link", "link-copy")
+        assert (tmp_path / "link-copy").is_symlink()
+        assert fs.delete_path("link")["deleted"] == "link"
+
+
+def test_download_store_urls_coercion_and_corruption(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    assert downloads._snapshot_name("token").endswith(".bin")
+    with pytest.raises(ValueError, match="metadata"):
+        downloads._snapshot_path({"snapshot_name": "../bad"})
+    assert downloads._safe_filename("../bad\x01name.txt", tmp_path / "source") == "badname.txt"
+    assert downloads._safe_filename("\x01", tmp_path / "") == "download"
+
+    monkeypatch.delenv("LOCAL_SHELL_MCP_PUBLIC_BASE_URL")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_HOST", "0.0.0.0")
+    get_settings.cache_clear()
+    assert downloads._public_base_url().startswith("http://127.0.0.1:")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_HOST", "::1")
+    get_settings.cache_clear()
+    assert "[::1]" in downloads._public_base_url()
+
+    with pytest.raises(ValueError, match="positive"):
+        downloads._coerce_ttl(0)
+    assert downloads._coerce_ttl(10**9) == get_settings().file_download_max_ttl_s
+    with pytest.raises(ValueError, match=">= 0"):
+        downloads._coerce_max_downloads(-1)
+
+    store_path = downloads._store_path()
+    snapshot_dir = downloads._snapshot_dir()
+    orphan = snapshot_dir / "orphan.bin"
+    orphan.write_bytes(b"x")
+    store_path.write_text("bad", encoding="utf-8")
+    assert downloads._read_store_locked() == downloads._empty_store()
+    assert not orphan.exists()
+
+    for payload in ({"version": 3, "links": []}, {"version": 2, "links": {}}):
+        orphan.write_bytes(b"x")
+        store_path.write_text(json.dumps(payload), encoding="utf-8")
+        assert downloads._read_store_locked() == downloads._empty_store()
+        assert not orphan.exists()
+
+    store = downloads._empty_store()
+    now = 100.0
+    expired_snapshot = snapshot_dir / "expired.bin"
+    exhausted_snapshot = snapshot_dir / "exhausted.bin"
+    expired_snapshot.write_bytes(b"x")
+    exhausted_snapshot.write_bytes(b"x")
+    store["links"] = {
+        "expired": {"expires_at": 99, "snapshot_name": expired_snapshot.name},
+        "exhausted": {
+            "expires_at": 200,
+            "max_downloads": 1,
+            "downloads": 1,
+            "snapshot_name": exhausted_snapshot.name,
+        },
+    }
+    assert downloads._prune_locked(store, now) is True
+    assert store["links"] == {}
+
+
+def test_download_claim_failures_head_stream_and_link_errors(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    source = tmp_path / "source.txt"
+    source.write_text("payload", encoding="utf-8")
+    link = downloads.create_share_link("source.txt", ttl_s=60, max_downloads=1)
+    token = link["token"]
+
+    app = Starlette(routes=downloads.download_routes())
+    client = TestClient(app)
+    head = client.head(f"/download/{token}")
+    assert head.status_code == 200
+    assert head.headers["content-length"] == "7"
+    get = client.get(f"/download/{token}")
+    assert get.status_code == 200
+    assert get.content == b"payload"
+    assert client.get(f"/download/{token}").status_code == 410
+
+    disabled = get_settings()
+    disabled.file_download_enabled = False
+    response = downloads._claim_download("missing", consume=False)
+    assert response.status_code == 404
+    disabled.file_download_enabled = True
+    assert downloads._claim_download("missing", consume=False).status_code == 404
+
+    store = downloads._empty_store()
+    store["links"] = {
+        "expired": {"expires_at": 0, "snapshot_name": "missing.bin"},
+        "exhausted": {
+            "expires_at": 10**10,
+            "max_downloads": 1,
+            "downloads": 1,
+            "snapshot_name": "missing.bin",
+        },
+        "missing": {
+            "expires_at": 10**10,
+            "max_downloads": 0,
+            "downloads": 0,
+            "snapshot_name": "missing.bin",
+        },
+    }
+    downloads._write_store_locked(store)
+    assert downloads._claim_download("expired", consume=False).status_code == 410
+    assert downloads._claim_download("exhausted", consume=False).status_code == 410
+    assert downloads._claim_download("missing", consume=False).status_code == 404
+
+    monkeypatch.setenv("LOCAL_SHELL_MCP_FILE_DOWNLOAD_ENABLED", "false")
+    get_settings.cache_clear()
+    with pytest.raises(PermissionError):
+        downloads.create_share_link("source.txt")
+
+    monkeypatch.setenv("LOCAL_SHELL_MCP_FILE_DOWNLOAD_ENABLED", "true")
+    get_settings.cache_clear()
+    directory = tmp_path / "directory"
+    directory.mkdir()
+    with pytest.raises(ValueError, match="shareable"):
+        downloads.create_share_link("directory")
+
+    monkeypatch.setattr(downloads, "_write_store_locked", lambda store: (_ for _ in ()).throw(OSError("write")))
+    with pytest.raises(OSError, match="write"):
+        downloads.create_share_link("source.txt")
+    assert not list(downloads._snapshot_dir().glob("*.bin"))
+
+
+def test_transfer_metadata_chunks_and_finish_edges(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    assert transfer.normalize_chunk_size(None) == transfer.DEFAULT_TRANSFER_CHUNK_BYTES
+    assert transfer.normalize_chunk_size(10**9) == transfer.MAX_TRANSFER_CHUNK_BYTES
+    with pytest.raises(ValueError):
+        transfer.normalize_chunk_size(0)
+    with pytest.raises(ValueError, match="transfer_id"):
+        transfer._transfer_temp_path(tmp_path / "x", "bad/id")
+
+    invalid = tmp_path / "invalid.tmp"
+    invalid.write_text("bad", encoding="utf-8")
+    with pytest.raises(ValueError, match="metadata"):
+        transfer._read_transfer_metadata(invalid)
+    transfer._transfer_metadata_path(invalid).write_text("[]", encoding="utf-8")
+    with pytest.raises(ValueError, match="metadata"):
+        transfer._read_transfer_metadata(invalid)
+
+    for raw in ("bad", [[-1, 2]], [[2, 1]], [[1]], [[1, "2"]]):
+        with pytest.raises(ValueError, match="received_ranges"):
+            transfer._received_ranges({"received_ranges": raw})
+    metadata = {"received_ranges": []}
+    transfer._record_received_range(metadata, 0, 0)
+    transfer._record_received_range(metadata, 0, 2)
+    transfer._record_received_range(metadata, 2, 4)
+    assert metadata["received_ranges"] == [[0, 4]]
+    with pytest.raises(ValueError, match="invalid"):
+        transfer._record_received_range(metadata, 2, 1)
+
+    directory = tmp_path / "dir"
+    directory.mkdir()
+    with pytest.raises(IsADirectoryError):
+        transfer.transfer_begin_write("dir")
+    existing = tmp_path / "existing"
+    existing.write_text("x", encoding="utf-8")
+    with pytest.raises(FileExistsError):
+        transfer.transfer_begin_write("existing", overwrite=False)
+    with pytest.raises(ValueError, match="expected_bytes"):
+        transfer.transfer_begin_write("x", expected_bytes=-1)
+
+    begin = transfer.transfer_begin_write("target", expected_bytes=2)
+    with pytest.raises(ValueError, match="offset"):
+        transfer.transfer_write_chunk("target", begin["transfer_id"], -1, "")
+    with pytest.raises(ValueError, match="base64"):
+        transfer.transfer_write_chunk("target", begin["transfer_id"], 0, "***")
+    with pytest.raises(ValueError, match="exceeds"):
+        transfer.transfer_write_bytes("target", begin["transfer_id"], 0, b"123")
+    with pytest.raises(ValueError, match="offset"):
+        transfer.transfer_write_bytes("target", begin["transfer_id"], -1, b"")
+    with pytest.raises(FileNotFoundError):
+        transfer.transfer_write_bytes("target", "missing", 0, b"")
+
+    temp_path = fs.resolve_path(begin["temp_path"])
+    temp_path.write_bytes(b"x")
+    with pytest.raises(ValueError, match="size mismatch"):
+        transfer.transfer_mark_complete_write("target", begin["transfer_id"])
+    temp_path.write_bytes(b"12")
+    assert transfer.transfer_mark_complete_write("target", begin["transfer_id"])["bytes"] == 2
+    finished = transfer.transfer_finish_write("target", begin["transfer_id"], expected_bytes=2)
+    assert finished["completed"] is True
+    assert transfer.transfer_abort_write("target", begin["transfer_id"])["deleted"] is False
+
+    empty = transfer.transfer_begin_write("empty", expected_bytes=0)
+    transfer.transfer_mark_complete_write("empty", empty["transfer_id"])
+    assert transfer.transfer_finish_write("empty", empty["transfer_id"])["bytes"] == 0
+    with pytest.raises(IsADirectoryError):
+        transfer.transfer_read_chunk("dir")
+    with pytest.raises(ValueError, match="offset"):
+        transfer.transfer_read_chunk("target", -1)
+
+
+def _tar_with_members(members):
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w") as archive:
+        for member, content in members:
+            archive.addfile(member, io.BytesIO(content) if content is not None else None)
+    buffer.seek(0)
+    return tarfile.open(fileobj=buffer, mode="r")
+
+
+def test_transfer_archive_validation_pack_and_unpack(tmp_path, monkeypatch):
+    _configure(
+        tmp_path,
+        monkeypatch,
+        LOCAL_SHELL_MCP_MAX_TRANSFER_ARCHIVE_ENTRIES=1,
+        LOCAL_SHELL_MCP_MAX_TRANSFER_UNPACKED_BYTES=2,
+    )
+    (tmp_path / "file").write_text("x", encoding="utf-8")
+    with pytest.raises(NotADirectoryError):
+        transfer.transfer_pack_dir("file")
+
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "a").write_text("x", encoding="utf-8")
+    packed = transfer.transfer_pack_dir("source", compression="none")
+    assert packed["compression"] == "none"
+
+    member = tarfile.TarInfo("a")
+    member.size = 1
+    duplicate = tarfile.TarInfo("a")
+    duplicate.size = 1
+    with (
+        _tar_with_members([(member, b"x"), (duplicate, b"y")]) as archive,
+        pytest.raises(ValueError, match="entries|duplicate"),
+    ):
+        transfer._safe_members(archive, tmp_path / "dst")
+
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_TRANSFER_ARCHIVE_ENTRIES", "10")
+    get_settings.cache_clear()
+    large = tarfile.TarInfo("large")
+    large.size = 3
+    with (
+        _tar_with_members([(large, b"abc")]) as archive,
+        pytest.raises(ValueError, match="expands"),
+    ):
+        transfer._safe_members(archive, tmp_path / "dst")
+    sparse = tarfile.TarInfo("sparse")
+    sparse.size = 0
+    sparse.sparse = [(0, 0)]
+    fake_archive = SimpleNamespace(getmembers=lambda: [sparse])
+    with pytest.raises(ValueError, match="sparse"):
+        transfer._safe_members(fake_archive, tmp_path / "dst")
+
+    archive_path = fs.resolve_path(packed["archive_path"])
+    empty_dst = tmp_path / "empty-dst"
+    empty_dst.mkdir()
+    unpacked = transfer.transfer_unpack_archive(
+        packed["archive_path"], "empty-dst", overwrite=False, cleanup_archive=False
+    )
+    assert unpacked["completed"] is True
+    assert archive_path.exists()
+
+    packed_again = transfer.transfer_pack_dir("source")
+    nonempty = tmp_path / "nonempty"
+    nonempty.mkdir()
+    (nonempty / "existing").write_text("x", encoding="utf-8")
+    with pytest.raises(FileExistsError):
+        transfer.transfer_unpack_archive(packed_again["archive_path"], "nonempty", overwrite=False)
+
+    file_target = tmp_path / "file-target"
+    file_target.write_text("x", encoding="utf-8")
+    transfer._remove_existing_path(file_target)
+    assert not file_target.exists()
+    dir_target = tmp_path / "dir-target"
+    dir_target.mkdir()
+    transfer._remove_existing_path(dir_target)
+    assert not dir_target.exists()
+
+
+def test_remote_transfer_validation_claim_and_endpoint_errors(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    digest = hashlib.sha256(b"data").hexdigest()
+    for size, value in ((-1, digest), (1, "bad")):
+        with pytest.raises(ValueError):
+            remote_transfer._validate_expected(size, value)
+    assert remote_transfer._validate_expected(4, digest) == (4, digest)
+
+    monkeypatch.delenv("LOCAL_SHELL_MCP_PUBLIC_BASE_URL")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_HOST", "::1")
+    get_settings.cache_clear()
+    assert "[::1]" in remote_transfer._public_base_url()
+    assert remote_transfer._ticket_ttl_s() >= 60
+
+    cleanup = tmp_path / "cleanup"
+    cleanup.write_text("x", encoding="utf-8")
+    expired = remote_transfer._TransferTicket(
+        "expired", "upload", "x", 0, hashlib.sha256(b"").hexdigest(), True, 0, 0, cleanup_path=str(cleanup)
+    )
+    remote_transfer._TICKETS["expired"] = expired
+    remote_transfer._prune_locked(now=1)
+    assert not cleanup.exists()
+
+    upload = remote_transfer.create_upload_ticket("dest", 4, digest)
+    token = upload["token"]
+    with pytest.raises(PermissionError, match="direction"):
+        remote_transfer._claim_ticket(token, "download")
+    claimed = remote_transfer._claim_ticket(token, "upload")
+    with pytest.raises(RuntimeError, match="already"):
+        remote_transfer._claim_ticket(token, "upload")
+    remote_transfer._release_ticket(token)
+    assert claimed.claimed is False
+    assert remote_transfer.revoke_transfer_ticket(token)["revoked"] is True
+    assert remote_transfer.revoke_transfer_ticket(token)["revoked"] is False
+
+    app = Starlette(routes=remote_transfer.remote_transfer_routes())
+    client = TestClient(app)
+    assert client.put("/remote/transfer/upload/missing", content=b"").status_code == 404
+
+    ticket = remote_transfer.create_upload_ticket("dest", 4, digest)
+    assert client.put(
+        f"/remote/transfer/upload/{ticket['token']}",
+        content=b"data",
+        headers={"content-length": "invalid"},
+    ).status_code == 400
+    assert client.put(
+        f"/remote/transfer/upload/{ticket['token']}",
+        content=b"data",
+        headers={"content-length": "3"},
+    ).status_code == 400
+    short = remote_transfer.create_upload_ticket("dest", 4, digest)
+    assert client.put(
+        f"/remote/transfer/upload/{short['token']}", content=b"dat"
+    ).status_code == 400
+    long_ticket = remote_transfer.create_upload_ticket("dest", 4, digest)
+    assert client.put(
+        f"/remote/transfer/upload/{long_ticket['token']}", content=b"datax"
+    ).status_code == 400
+
+    source = tmp_path / "source"
+    source.write_bytes(b"data")
+    download = remote_transfer.create_download_ticket("source", 4, digest)
+    remote_transfer._TICKETS[download["token"]].path = str(tmp_path / "missing")
+    assert client.get(
+        f"/remote/transfer/download/{download['token']}"
+    ).status_code == 404
+
+    with pytest.raises(ValueError, match="source is not a file"):
+        directory = tmp_path / "directory"
+        directory.mkdir()
+        remote_transfer.create_download_ticket("directory", 0, hashlib.sha256(b"").hexdigest())
+    with pytest.raises(ValueError, match="size mismatch"):
+        remote_transfer.create_download_ticket("source", 5, digest)
+    with pytest.raises(ValueError, match="sha256"):
+        remote_transfer.create_download_ticket("source", 4, hashlib.sha256(b"other").hexdigest())

--- a/tests/test_tools_complete.py
+++ b/tests/test_tools_complete.py
@@ -1,0 +1,416 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+import local_shell_mcp.downloads as downloads
+import local_shell_mcp.tools as tools
+from local_shell_mcp.models import CommandResult
+from local_shell_mcp.settings import get_settings
+
+
+def _configure(tmp_path, monkeypatch, *, remote_enabled: bool = True):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(tmp_path / ".state"))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_AUDIT_LOG_PATH", str(tmp_path / "audit.jsonl"))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_AUTH_MODE", "none")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_REMOTE_ENABLED", str(remote_enabled).lower())
+    monkeypatch.setenv("LOCAL_SHELL_MCP_PUBLIC_BASE_URL", "http://testserver")
+    get_settings.cache_clear()
+
+
+def _result() -> CommandResult:
+    return CommandResult(
+        ok=True,
+        exit_code=0,
+        timed_out=False,
+        duration_ms=1,
+        cwd=".",
+        command="cmd",
+        stdout="ok",
+        stderr="",
+        truncated=False,
+    )
+
+
+def _raw_tool(mcp, name: str):
+    wrapped = mcp._tool_manager._tools[name].fn
+    original = wrapped.__kwdefaults__["__original"]
+    return original
+
+
+class FakeRemoteManager:
+    def __init__(self):
+        self.calls = []
+
+    async def call(self, machine, tool, args, timeout_s=None):
+        self.calls.append((machine, tool, args, timeout_s))
+        return {"ok": True, "message": "", "data": {"tool": tool}}
+
+    async def create_invite(self, name=None, workdir=None, ttl_s=None):
+        return {"name": name, "workdir": workdir, "ttl_s": ttl_s}
+
+    def list_machines(self):
+        return {"machines": [{"name": "node"}]}
+
+    def revoke(self, machine):
+        return {"machine": machine, "revoked": True}
+
+    def rename(self, machine, new_name):
+        return {"old_name": machine, "new_name": new_name}
+
+
+@pytest.mark.asyncio
+async def test_all_public_tool_wrappers_local_and_remote(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    (tmp_path / "found.txt").write_text("needle\n", encoding="utf-8")
+    fake_remote = FakeRemoteManager()
+    monkeypatch.setattr(tools, "remote_manager", lambda: fake_remote)
+
+    async def async_value(*args, **kwargs):
+        return {"args": list(args), "kwargs": kwargs}
+
+    def sync_value(*args, **kwargs):
+        return {"args": list(args), "kwargs": kwargs}
+
+    async def fake_grep(*args, **kwargs):
+        if kwargs.get("regex") is False:
+            return {
+                "matches": [
+                    {"path": "found.txt", "line": 1},
+                    {"path": "found.txt", "line": 2},
+                    {"path": "", "line": 3},
+                ]
+            }
+        return {"matches": []}
+
+    monkeypatch.setattr(tools, "grep", fake_grep)
+    monkeypatch.setattr(tools, "run_shell", lambda *args, **kwargs: asyncio.sleep(0, result=_result()))
+    monkeypatch.setattr(tools, "public_run_shell", lambda *args, **kwargs: asyncio.sleep(0, result=_result()))
+    for name in (
+        "_run_python",
+        "start_shell",
+        "send_shell",
+        "read_shell",
+        "kill_shell",
+        "list_shells",
+        "start_job",
+        "list_jobs",
+        "tail_job",
+        "stop_job",
+        "retry_job",
+        "tree",
+        "_apply_patch_text",
+        "_transfer_path",
+        "_secret_scan",
+        "browser_capture",
+        "browser_get_text",
+        "playwright_run_script",
+    ):
+        monkeypatch.setattr(tools, name, async_value)
+    for name in (
+        "list_installed_skills",
+        "load_installed_skill",
+        "read_installed_skill_file",
+        "list_dir",
+        "glob_paths",
+        "read_texts",
+        "write_text",
+        "edit_text",
+        "delete_path",
+        "todo_read",
+        "todo_write",
+    ):
+        monkeypatch.setattr(tools, name, sync_value)
+
+    monkeypatch.setattr(downloads, "create_share_link", sync_value)
+    monkeypatch.setattr(downloads, "list_share_links", sync_value)
+    monkeypatch.setattr(downloads, "revoke_share_link", sync_value)
+
+    mcp = tools.build_mcp()
+    local_cases = {
+        "search": {"query": "needle"},
+        "fetch": {"id": "found.txt"},
+        "environment_info": {},
+        "skills_list": {},
+        "skill_load": {"name": "skill"},
+        "skill_read_file": {"name": "skill", "path": "guide.md"},
+        "run_shell_tool": {"command": "true", "purpose": "test", "explanation": "coverage"},
+        "run_python_tool": {"code": "print(1)", "purpose": "test"},
+        "shell_start": {"purpose": "test"},
+        "shell_send": {"session_id": "s", "input_text": "x"},
+        "shell_read": {"session_id": "s"},
+        "shell_kill": {"session_id": "s"},
+        "shell_list": {},
+        "job_start": {"command": "true", "purpose": "test"},
+        "job_list": {},
+        "job_tail": {"job_id": "j"},
+        "job_stop": {"job_id": "j"},
+        "job_retry": {"job_id": "j", "purpose": "test"},
+        "list_files": {},
+        "tree_view": {},
+        "glob_search": {"pattern": "*.py"},
+        "grep_search": {"query": "x"},
+        "read_file": {"path": "x"},
+        "create_file_link": {"path": "found.txt"},
+        "list_file_links": {},
+        "revoke_file_link": {"token": "t"},
+        "write_file": {"path": "x", "content": "y", "purpose": "test"},
+        "edit_file": {"path": "x", "edits": [], "purpose": "test"},
+        "delete_file_or_dir": {"path": "x", "purpose": "test"},
+        "apply_patch": {"patch": "diff", "purpose": "test"},
+        "transfer_path": {"source_path": "a", "destination_path": "b", "destination_machine": "node", "purpose": "test"},
+        "secret_scan": {},
+        "todo_read_tool": {},
+        "todo_write_tool": {"todos": []},
+        "browser_capture_tool": {"url": "https://example.test"},
+        "browser_get_text_tool": {"url": "https://example.test"},
+        "playwright_run_script_tool": {"script": "print(1)"},
+        "audit_tail": {},
+        "remote_invite": {"name": "node"},
+        "remote_list_machines": {},
+        "remote_revoke_machine": {"machine": "node"},
+        "remote_rename_machine": {"machine": "node", "new_name": "renamed"},
+    }
+    assert set(local_cases) == set(mcp._tool_manager._tools)
+    for name, kwargs in local_cases.items():
+        result = await _raw_tool(mcp, name)(**kwargs)
+        assert result is not None, name
+
+    search_payload = json.loads(await _raw_tool(mcp, "search")(query="needle"))
+    assert len(search_payload["results"]) == 1
+    assert search_payload["results"][0]["title"] == "found.txt:1"
+
+    remote_cases = {
+        "environment_info": {},
+        "run_shell_tool": {"command": "true"},
+        "run_python_tool": {"code": "print(1)"},
+        "shell_start": {},
+        "shell_send": {"session_id": "s", "input_text": "x"},
+        "shell_read": {"session_id": "s"},
+        "shell_kill": {"session_id": "s"},
+        "shell_list": {},
+        "job_start": {"command": "true"},
+        "job_list": {},
+        "job_tail": {"job_id": "j"},
+        "job_stop": {"job_id": "j"},
+        "job_retry": {"job_id": "j"},
+        "list_files": {},
+        "tree_view": {},
+        "glob_search": {"pattern": "*"},
+        "grep_search": {"query": "x"},
+        "read_file": {"path": "x"},
+        "write_file": {"path": "x", "content": "y"},
+        "edit_file": {"path": "x", "edits": []},
+        "delete_file_or_dir": {"path": "x"},
+        "apply_patch": {"patch": "diff"},
+        "browser_capture_tool": {"url": "https://x"},
+        "browser_get_text_tool": {"url": "https://x"},
+        "playwright_run_script_tool": {"script": "x"},
+    }
+    for name, kwargs in remote_cases.items():
+        result = await _raw_tool(mcp, name)(**kwargs, machine="node")
+        assert result["ok"] is True, name
+    assert len(fake_remote.calls) == len(remote_cases)
+
+
+@pytest.mark.asyncio
+async def test_tool_wrapper_error_paths_and_remote_disabled(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+
+    async def fail_async(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    def fail_sync(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(tools, "grep", fail_async)
+    monkeypatch.setattr(tools, "read_text", fail_sync)
+    monkeypatch.setattr(tools, "run_shell", fail_async)
+    monkeypatch.setattr(tools, "list_installed_skills", fail_sync)
+    monkeypatch.setattr(tools, "public_run_shell", fail_async)
+    monkeypatch.setattr(tools, "_run_python", fail_async)
+    monkeypatch.setattr(tools, "start_shell", fail_async)
+    monkeypatch.setattr(tools, "send_shell", fail_async)
+    monkeypatch.setattr(tools, "read_shell", fail_async)
+    monkeypatch.setattr(tools, "kill_shell", fail_async)
+    monkeypatch.setattr(tools, "list_shells", fail_async)
+    monkeypatch.setattr(tools, "start_job", fail_async)
+    monkeypatch.setattr(tools, "list_jobs", fail_async)
+    monkeypatch.setattr(tools, "tail_job", fail_async)
+    monkeypatch.setattr(tools, "stop_job", fail_async)
+    monkeypatch.setattr(tools, "retry_job", fail_async)
+    monkeypatch.setattr(tools, "list_dir", fail_sync)
+    monkeypatch.setattr(tools, "tree", fail_async)
+    monkeypatch.setattr(tools, "glob_paths", fail_sync)
+    monkeypatch.setattr(tools, "read_texts", fail_sync)
+    monkeypatch.setattr(tools, "write_text", fail_sync)
+    monkeypatch.setattr(tools, "edit_text", fail_sync)
+    monkeypatch.setattr(tools, "delete_path", fail_sync)
+    monkeypatch.setattr(tools, "_apply_patch_text", fail_async)
+    monkeypatch.setattr(tools, "_transfer_path", fail_async)
+    monkeypatch.setattr(tools, "_secret_scan", fail_async)
+    monkeypatch.setattr(tools, "todo_read", fail_sync)
+    monkeypatch.setattr(tools, "todo_write", fail_sync)
+    monkeypatch.setattr(tools, "browser_capture", fail_async)
+    monkeypatch.setattr(tools, "browser_get_text", fail_async)
+    monkeypatch.setattr(tools, "playwright_run_script", fail_async)
+    monkeypatch.setattr(tools, "_read_audit_tail_entries", fail_sync)
+    fake_remote = FakeRemoteManager()
+    monkeypatch.setattr(tools, "remote_manager", lambda: fake_remote)
+
+    mcp = tools.build_mcp()
+    checks = [
+        ("search", {"query": "x"}),
+        ("fetch", {"id": "missing"}),
+        ("environment_info", {}),
+        ("skills_list", {}),
+        ("run_shell_tool", {"command": "x"}),
+        ("run_python_tool", {"code": "x"}),
+        ("shell_start", {}),
+        ("shell_send", {"session_id": "s", "input_text": "x"}),
+        ("shell_read", {"session_id": "s"}),
+        ("shell_kill", {"session_id": "s"}),
+        ("shell_list", {}),
+        ("job_start", {"command": "x"}),
+        ("job_list", {}),
+        ("job_tail", {"job_id": "j"}),
+        ("job_stop", {"job_id": "j"}),
+        ("job_retry", {"job_id": "j"}),
+        ("list_files", {}),
+        ("tree_view", {}),
+        ("glob_search", {"pattern": "*"}),
+        ("grep_search", {"query": "x"}),
+        ("read_file", {"path": "x"}),
+        ("write_file", {"path": "x", "content": "y"}),
+        ("edit_file", {"path": "x", "edits": []}),
+        ("delete_file_or_dir", {"path": "x"}),
+        ("apply_patch", {"patch": "x"}),
+        ("transfer_path", {"source_path": "a", "destination_path": "b"}),
+        ("secret_scan", {}),
+        ("todo_read_tool", {}),
+        ("todo_write_tool", {"todos": []}),
+        ("browser_capture_tool", {"url": "x"}),
+        ("browser_get_text_tool", {"url": "x"}),
+        ("playwright_run_script_tool", {"script": "x"}),
+        ("audit_tail", {}),
+    ]
+    for name, kwargs in checks:
+        result = await _raw_tool(mcp, name)(**kwargs)
+        if name in {"search", "fetch"}:
+            assert isinstance(result, str)
+        else:
+            assert result["data"]["status"] == "error", name
+
+    _configure(tmp_path, monkeypatch, remote_enabled=False)
+    disabled = tools.build_mcp()
+    assert not any(
+        name.startswith("remote_") or name == "transfer_path"
+        for name in disabled._tool_manager._tools
+    )
+
+
+def test_tool_helpers_redaction_audit_timeout_and_tail(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    assert tools._redact_audit_value("x" * 501).endswith("…<truncated>")
+    assert tools._redact_audit_value((1, 2)) == [1, 2]
+    redacted = tools._redact_audit_value(
+        {
+            "token": "secret",
+            "content": "body",
+            "safe": {"nested": "value"},
+            "items": list(range(30)),
+            "object": object(),
+        }
+    )
+    assert redacted["token"] == "<redacted>"
+    assert redacted["content"] == "<redacted>"
+    assert len(redacted["items"]) == 20
+    assert "object at" in redacted["object"]
+    assert tools._audit_tool_arguments((1, 2), {"password": "x"})["positional_count"] == 2
+
+    assert tools._audit_tool_purpose("x", "  purpose ", " explanation ") == {
+        "purpose": "purpose",
+        "explanation": "explanation",
+    }
+    assert tools._audit_tool_purpose("x", " ", None) == {}
+    with pytest.raises(ValueError, match="purpose"):
+        tools._audit_tool_purpose("x", "x" * 501)
+    with pytest.raises(ValueError, match="explanation"):
+        tools._audit_tool_purpose("x", explanation="x" * 2001)
+
+    search = json.loads(tools._timeout_payload_for_tool("search", TimeoutError("x")))
+    assert search == {"results": []}
+    fetch = json.loads(tools._timeout_payload_for_tool("fetch", TimeoutError("x")))
+    assert fetch["metadata"]["error"] == "TimeoutError"
+    generic = tools._timeout_payload_for_tool("other", TimeoutError("x"))
+    assert generic["data"]["status"] == "error"
+
+    audit_path = tmp_path / "audit.jsonl"
+    audit_path.write_text(
+        '{"event":"one"}\ninvalid\n{"event":"three"}\n', encoding="utf-8"
+    )
+    tail = tools._read_audit_tail_entries(2)
+    assert tail["entries"] == [{"raw": "invalid"}, {"event": "three"}]
+    assert tail["bytes_read"] > 0
+    audit_path.unlink()
+    assert tools._read_audit_tail_entries(10) == {"entries": []}
+
+
+def test_transport_security_secret_helpers_and_remote_unwrap(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    security = tools._transport_security_settings()
+    assert "testserver:*" in security.allowed_hosts
+    assert "http://testserver" in security.allowed_origins
+
+    base = tmp_path / "repo"
+    base.mkdir()
+    (base / ".gitignore").write_text("ignored.txt\n!visible/ignored.txt\n", encoding="utf-8")
+    (base / "ignored.txt").write_text("x", encoding="utf-8")
+    (base / "visible").mkdir()
+    visible = base / "visible" / "ignored.txt"
+    visible.write_text("x", encoding="utf-8")
+    cache = {}
+    assert tools._fallback_path_is_ignored(base / "ignored.txt", base, cache)
+    assert not tools._fallback_path_is_ignored(visible, base, cache)
+    assert tools._gitignore_spec(base, cache) is not None
+    assert tools._gitignore_spec(tmp_path / "missing", {}) is None
+
+    assert tools._is_placeholder_secret_match("generic_assignment", 'token="dummy-value"')
+    assert not tools._is_placeholder_secret_match("github_token", "ghp_abc")
+    assert not tools._is_placeholder_secret_match("generic_assignment", 'token="real-value"')
+
+    assert tools._unwrap_remote_transfer_result(
+        {"ok": True, "data": {"value": 1}}, machine="node", tool="stat"
+    ) == {"value": 1}
+    with pytest.raises(tools.RemoteTransferError, match="failed"):
+        tools._unwrap_remote_transfer_result(
+            {"ok": False, "message": "bad"}, machine="node", tool="stat"
+        )
+    with pytest.raises(tools.RemoteTransferError, match="Boom"):
+        tools._unwrap_remote_transfer_result(
+            {"ok": True, "data": {"status": "error", "error_type": "Boom", "message": "bad"}},
+            machine="node",
+            tool="stat",
+        )
+
+
+def test_handled_error_missing_path_and_sync(monkeypatch, tmp_path):
+    _configure(tmp_path, monkeypatch)
+    result = tools._handled_error(FileNotFoundError("missing.txt"))
+    assert result["data"]["status"] == "not_found"
+    assert result["data"]["path"].endswith("missing.txt")
+    generic = tools._handled_error(ValueError("bad"))
+    assert generic["data"]["error_type"] == "ValueError"
+
+    async def value():
+        return 42
+
+    loop = asyncio.new_event_loop()
+    monkeypatch.setattr(asyncio, "get_event_loop", lambda: loop)
+    try:
+        assert tools._sync(value()) == 42
+    finally:
+        loop.close()

--- a/ui/package.json
+++ b/ui/package.json
@@ -8,7 +8,7 @@
     "build:web": "bun run scripts/build.ts",
     "compile:tui": "bun run build:tui",
     "typecheck": "bunx tsc --noEmit",
-    "test": "bun test"
+    "test": "bun test --coverage"
   },
   "dependencies": {
     "@opentui/core": "0.4.3",

--- a/ui/src/api.test.ts
+++ b/ui/src/api.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { API_BASE, api, formatError } from "./api"
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+function success(data: unknown = { value: true }): Response {
+  return new Response(JSON.stringify({ ok: true, message: "", data }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+describe("API client endpoint wrappers", () => {
+  test("encodes every shared UI endpoint consistently", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = []
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ url: String(input), init })
+      return success()
+    }) as unknown as typeof fetch
+
+    await api.bootstrap()
+    await api.machines()
+    await api.files("worker a", "src path")
+    await api.filePreview("local", "")
+    await api.fileContent("local", "a/b")
+    await api.fileAction("rename item", { path: "a", destination: "b" })
+    await api.terminals("worker a")
+    await api.terminalRead("worker a", "session/1", 25)
+    await api.terminalAction("send input", { session_id: "s", input_text: "x" })
+    await api.todos()
+    await api.writeTodos(
+      [{ id: "a", content: "A", status: "pending", priority: "medium" }],
+      7,
+    )
+    await api.audit({ node: "worker a", empty: "", zero: 0, enabled: false, omitted: null })
+    await api.remotes()
+    await api.invite({ name: "node", workdir: "/work", ttl_s: 60 })
+    await api.remoteAction("rename node", { machine: "node", new_name: "next" })
+
+    expect(calls.map((call) => call.url)).toEqual([
+      `${API_BASE}/bootstrap`,
+      `${API_BASE}/machines`,
+      `${API_BASE}/files?machine=worker+a&path=src+path`,
+      `${API_BASE}/files/preview?machine=local`,
+      `${API_BASE}/files/content?machine=local&path=a%2Fb`,
+      `${API_BASE}/files/rename%20item`,
+      `${API_BASE}/terminals?machine=worker+a`,
+      `${API_BASE}/terminals/read?machine=worker+a&session_id=session%2F1&lines=25`,
+      `${API_BASE}/terminals/send%20input`,
+      `${API_BASE}/todos`,
+      `${API_BASE}/todos`,
+      `${API_BASE}/audit?node=worker+a&zero=0&enabled=false`,
+      `${API_BASE}/remotes`,
+      `${API_BASE}/remotes`,
+      `${API_BASE}/remotes/rename%20node`,
+    ])
+
+    expect(calls[5]!.init?.method).toBe("POST")
+    expect(JSON.parse(String(calls[5]!.init?.body))).toEqual({ path: "a", destination: "b" })
+    expect(calls[10]!.init?.method).toBe("PUT")
+    expect(JSON.parse(String(calls[10]!.init?.body))).toEqual({
+      todos: [{ id: "a", content: "A", status: "pending", priority: "medium" }],
+      expected_revision: 7,
+    })
+    expect(calls[13]!.init?.method).toBe("POST")
+    expect(calls.every((call) => new Headers(call.init?.headers).get("Accept") === "application/json")).toBe(true)
+    expect(calls.every((call) => new Headers(call.init?.headers).get("Content-Type") === "application/json")).toBe(true)
+  })
+
+  test("propagates an already-aborted external signal", async () => {
+    const external = new AbortController()
+    external.abort(new Error("cancelled"))
+    let observed: AbortSignal | undefined
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      observed = init?.signal as AbortSignal
+      return success()
+    }) as unknown as typeof fetch
+
+    await api.files("local", ".", external.signal)
+
+    expect(observed?.aborted).toBe(true)
+    expect((observed?.reason as Error).message).toBe("cancelled")
+  })
+})
+
+describe("API response handling", () => {
+  test("returns envelope data", async () => {
+    globalThis.fetch = (async () => success({ answer: 42 })) as unknown as typeof fetch
+    expect(await api.bootstrap()).toEqual({ answer: 42 } as never)
+  })
+
+  test("uses server message or error for failed envelopes", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ ok: false, message: "conflict", error: "fallback" }), {
+        status: 409,
+        statusText: "Conflict",
+      })) as unknown as typeof fetch
+    expect(api.todos()).rejects.toThrow("conflict")
+
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ ok: false, message: "", error: "typed-error" }), {
+        status: 400,
+        statusText: "Bad Request",
+      })) as unknown as typeof fetch
+    expect(api.todos()).rejects.toThrow("typed-error")
+  })
+
+  test("reports status text when JSON is unavailable or the envelope has no detail", async () => {
+    globalThis.fetch = (async () =>
+      new Response("not-json", { status: 502, statusText: "Bad Gateway" })) as unknown as typeof fetch
+    expect(api.todos()).rejects.toThrow("502 Bad Gateway")
+
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ ok: true, data: null }), {
+        status: 503,
+        statusText: "Unavailable",
+      })) as unknown as typeof fetch
+    expect(api.todos()).rejects.toThrow("503 Unavailable")
+  })
+})
+
+describe("formatError", () => {
+  test("formats Error instances and arbitrary values", () => {
+    expect(formatError(new Error("boom"))).toBe("boom")
+    expect(formatError(42)).toBe("42")
+    expect(formatError(null)).toBe("null")
+  })
+})

--- a/vscode-extension/.vscodeignore
+++ b/vscode-extension/.vscodeignore
@@ -2,6 +2,7 @@
 .vscode-test/**
 node_modules/**
 src/**
-*.map
+**/*.map
+test/**
 tsconfig.json
 package-lock.json

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -127,7 +127,8 @@
   "scripts": {
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "package:vsix": "node scripts/package-vsix.cjs"
+    "package:vsix": "node scripts/package-vsix.cjs",
+    "test": "npm run compile && node --test test/*.test.cjs"
   },
   "devDependencies": {
     "@types/node": "^20.14.10",

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 let output: vscode.OutputChannel;
 let serverProcess: cp.ChildProcessWithoutNullStreams | undefined;
 
-function waitForExit(proc: cp.ChildProcessWithoutNullStreams, timeoutMs: number): Promise<boolean> {
+export function waitForExit(proc: cp.ChildProcessWithoutNullStreams, timeoutMs: number): Promise<boolean> {
   if (proc.exitCode !== null || proc.signalCode !== null) {
     return Promise.resolve(true);
   }
@@ -23,44 +23,58 @@ function waitForExit(proc: cp.ChildProcessWithoutNullStreams, timeoutMs: number)
   });
 }
 
-function signalPosixProcessTree(proc: cp.ChildProcessWithoutNullStreams, signal: NodeJS.Signals): void {
+export function signalPosixProcessTree(
+  proc: cp.ChildProcessWithoutNullStreams,
+  signal: NodeJS.Signals,
+  killProcess: typeof process.kill = process.kill,
+): void {
   if (!proc.pid) {
     proc.kill(signal);
     return;
   }
   try {
-    process.kill(-proc.pid, signal);
+    killProcess(-proc.pid, signal);
   } catch {
     proc.kill(signal);
   }
 }
 
-async function stopProcessTree(proc: cp.ChildProcessWithoutNullStreams): Promise<void> {
+type ExecFile = typeof cp.execFile;
+type WaitForExit = typeof waitForExit;
+type SignalPosixProcessTree = typeof signalPosixProcessTree;
+
+export async function stopProcessTree(
+  proc: cp.ChildProcessWithoutNullStreams,
+  platform: NodeJS.Platform = process.platform,
+  execFile: ExecFile = cp.execFile,
+  wait: WaitForExit = waitForExit,
+  signalTree: SignalPosixProcessTree = signalPosixProcessTree,
+): Promise<void> {
   if (proc.exitCode !== null || proc.signalCode !== null) {
     return;
   }
-  if (process.platform === 'win32' && proc.pid) {
+  if (platform === 'win32' && proc.pid) {
     await new Promise<void>((resolve) => {
-      cp.execFile('taskkill', ['/PID', String(proc.pid), '/T', '/F'], (error) => {
+      execFile('taskkill', ['/PID', String(proc.pid), '/T', '/F'], (error) => {
         if (error) {
           proc.kill();
         }
         resolve();
       });
     });
-    await waitForExit(proc, 2000);
+    await wait(proc, 2000);
     return;
   }
 
-  signalPosixProcessTree(proc, 'SIGTERM');
-  if (await waitForExit(proc, 2000)) {
+  signalTree(proc, 'SIGTERM');
+  if (await wait(proc, 2000)) {
     return;
   }
-  signalPosixProcessTree(proc, 'SIGKILL');
-  await waitForExit(proc, 1000);
+  signalTree(proc, 'SIGKILL');
+  await wait(proc, 1000);
 }
 
-interface ExtensionConfig {
+export interface ExtensionConfig {
   executablePath: string;
   host: string;
   port: number;
@@ -101,19 +115,19 @@ function getConfig(): ExtensionConfig {
   };
 }
 
-function normalizeBaseUrl(value: string): string {
+export function normalizeBaseUrl(value: string): string {
   return value.trim().replace(/\/+$/, '');
 }
 
-function localBaseUrl(config: ExtensionConfig): string {
+export function localBaseUrl(config: ExtensionConfig): string {
   return `http://${config.host}:${config.port}`;
 }
 
-function mcpBaseUrl(config: ExtensionConfig): string {
+export function mcpBaseUrl(config: ExtensionConfig): string {
   return config.publicBaseUrl || localBaseUrl(config);
 }
 
-function mcpUrl(config: ExtensionConfig): string {
+export function mcpUrl(config: ExtensionConfig): string {
   return `${mcpBaseUrl(config)}/mcp`;
 }
 
@@ -128,7 +142,7 @@ async function getOrCreateJwtSecret(context: vscode.ExtensionContext): Promise<s
   return generated;
 }
 
-function stringifyExtraEnv(extraEnv: Record<string, unknown>): Record<string, string> {
+export function stringifyExtraEnv(extraEnv: Record<string, unknown>): Record<string, string> {
   const env: Record<string, string> = {};
   for (const [key, value] of Object.entries(extraEnv)) {
     if (!key || value === undefined || value === null) {

--- a/vscode-extension/test/extension.test.cjs
+++ b/vscode-extension/test/extension.test.cjs
@@ -1,0 +1,133 @@
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const Module = require('node:module');
+const test = require('node:test');
+
+const originalLoad = Module._load;
+const fakeVscode = {
+  window: {
+    createOutputChannel: () => ({ append() {}, appendLine() {}, show() {}, dispose() {} }),
+    showInformationMessage: async () => undefined,
+    showWarningMessage: async () => undefined,
+    showErrorMessage: async () => undefined,
+    showTextDocument: async () => undefined,
+  },
+  workspace: {
+    workspaceFolders: undefined,
+    getConfiguration: () => ({ get: (_key, defaultValue) => defaultValue }),
+    openTextDocument: async () => ({}),
+  },
+  commands: { registerCommand: () => ({ dispose() {} }) },
+  env: { clipboard: { writeText: async () => undefined } },
+  Uri: { joinPath: (...parts) => parts.join('/') },
+};
+Module._load = function(request, parent, isMain) {
+  if (request === 'vscode') return fakeVscode;
+  return originalLoad.call(this, request, parent, isMain);
+};
+const extension = require('../out/extension.js');
+Module._load = originalLoad;
+
+class FakeChild extends EventEmitter {
+  constructor({ pid = 123, exitCode = null, signalCode = null } = {}) {
+    super();
+    this.pid = pid;
+    this.exitCode = exitCode;
+    this.signalCode = signalCode;
+    this.killCalls = [];
+  }
+  kill(signal) {
+    this.killCalls.push(signal);
+    return true;
+  }
+}
+
+test('URL and environment helpers normalize user configuration', () => {
+  const config = {
+    executablePath: 'local-shell-mcp', host: '127.0.0.1', port: 9000,
+    workspaceRoot: '/workspace', authMode: 'oauth', publicBaseUrl: '',
+    oauthAdminPin: '', allowFullContainer: false, extraEnv: {},
+  };
+  assert.equal(extension.normalizeBaseUrl(' https://example.test/// '), 'https://example.test');
+  assert.equal(extension.localBaseUrl(config), 'http://127.0.0.1:9000');
+  assert.equal(extension.mcpBaseUrl(config), 'http://127.0.0.1:9000');
+  assert.equal(extension.mcpUrl(config), 'http://127.0.0.1:9000/mcp');
+  config.publicBaseUrl = 'https://public.test';
+  assert.equal(extension.mcpUrl(config), 'https://public.test/mcp');
+  assert.deepEqual(extension.stringifyExtraEnv({ A: 1, B: false, C: null, D: undefined, '': 'x' }), { A: '1', B: 'false' });
+});
+
+test('waitForExit handles already-exited, emitted, and timed-out processes', async () => {
+  assert.equal(await extension.waitForExit(new FakeChild({ exitCode: 0 }), 1), true);
+  const emitted = new FakeChild();
+  setImmediate(() => emitted.emit('exit', 0, null));
+  assert.equal(await extension.waitForExit(emitted, 100), true);
+  assert.equal(await extension.waitForExit(new FakeChild(), 1), false);
+});
+
+test('signalPosixProcessTree uses process group and falls back safely', () => {
+  const child = new FakeChild({ pid: 42 });
+  const calls = [];
+  extension.signalPosixProcessTree(child, 'SIGTERM', (pid, signal) => {
+    calls.push([pid, signal]);
+    return true;
+  });
+  assert.deepEqual(calls, [[-42, 'SIGTERM']]);
+  extension.signalPosixProcessTree(child, 'SIGKILL', () => { throw new Error('no group'); });
+  assert.deepEqual(child.killCalls, ['SIGKILL']);
+  const noPid = new FakeChild({ pid: null });
+  extension.signalPosixProcessTree(noPid, 'SIGTERM', () => true);
+  assert.deepEqual(noPid.killCalls, ['SIGTERM']);
+});
+
+test('POSIX stop escalates from SIGTERM to SIGKILL only when needed', async () => {
+  const child = new FakeChild();
+  const signals = [];
+  const waits = [];
+  await extension.stopProcessTree(
+    child,
+    'linux',
+    () => { throw new Error('unused'); },
+    async (_proc, timeout) => { waits.push(timeout); return waits.length === 2; },
+    (_proc, signal) => signals.push(signal),
+  );
+  assert.deepEqual(signals, ['SIGTERM', 'SIGKILL']);
+  assert.deepEqual(waits, [2000, 1000]);
+
+  const graceful = new FakeChild();
+  const gracefulSignals = [];
+  await extension.stopProcessTree(
+    graceful,
+    'darwin',
+    () => { throw new Error('unused'); },
+    async () => true,
+    (_proc, signal) => gracefulSignals.push(signal),
+  );
+  assert.deepEqual(gracefulSignals, ['SIGTERM']);
+});
+
+test('Windows stop uses taskkill and falls back to child.kill on error', async () => {
+  const child = new FakeChild({ pid: 77 });
+  const waits = [];
+  let invocation;
+  await extension.stopProcessTree(
+    child,
+    'win32',
+    ((file, args, callback) => {
+      invocation = [file, args];
+      callback(new Error('taskkill unavailable'), '', '');
+      return {};
+    }),
+    async (_proc, timeout) => { waits.push(timeout); return true; },
+  );
+  assert.deepEqual(invocation, ['taskkill', ['/PID', '77', '/T', '/F']]);
+  assert.deepEqual(child.killCalls, [undefined]);
+  assert.deepEqual(waits, [2000]);
+});
+
+test('already exited process is a no-op', async () => {
+  const child = new FakeChild({ exitCode: 0 });
+  let invoked = false;
+  await extension.stopProcessTree(child, 'linux', () => { invoked = true; }, async () => { invoked = true; return true; });
+  assert.equal(invoked, false);
+});


### PR DESCRIPTION
## Summary
- raise combined Python line/branch coverage from 68.5% to 93.9%
- enforce 93% total, 90% per-module, and 92% critical-module coverage floors
- add real controller/worker process E2E with streaming file and directory transfers plus reconnect
- add Human UI API coverage and VS Code process-tree lifecycle tests
- build and smoke-test Linux and Windows standalone executables in normal CI
- reclaim hosted-runner disk before Docker builds and include every matrix job in the aggregate gate
- fix fallback Settings updates being overwritten by environment reloads
- normalize punctuation-only persistent job names to a safe default

## Local validation
- 360 Python tests passed
- combined branch coverage: 93.93%
- Bun: 12 tests, 100% line coverage for tested shared modules
- VS Code: 6 lifecycle tests and VSIX packaging passed
- Ruff, ShellCheck, strict MkDocs, schema export, release matrix, wheel install, PTY/browser smoke, and Linux PyInstaller smoke passed

Docker and Windows-native builds are left to the GitHub Actions matrix because Docker is unavailable in the local execution environment.
