### PR TITLE
Persist and manage remote workers without repeated bootstrap downloads

### DIFF
--- a/src/local_shell_mcp/main.py
+++ b/src/local_shell_mcp/main.py
@@ -22,7 +22,7 @@ def _with_oauth_routes(inner_app):  # noqa: ANN001
         oauth_server_metadata,
         oauth_token,
     )
-    from .remote import remote_routes
+    from .remote_worker_routes import remote_routes
     from .settings import get_settings
 
     @asynccontextmanager
@@ -102,8 +102,6 @@ def run_mcp() -> None:
         uvicorn.run(app, host=settings.host, port=settings.port)
         return
 
-    # Fallback for older MCP SDKs. OAuth metadata cannot be attached in this mode, so this is
-    # suitable only for localhost/stdio-style testing.
     try:
         mcp.run(transport="streamable-http")
     except TypeError:
@@ -130,7 +128,7 @@ def main(argv: list[str] | None = None) -> None:
         run_job_runner_cli(argv[1:])
         return
     if argv and argv[0] == "worker":
-        from .remote import run_worker_cli
+        from .remote_worker_cli import run_worker_cli
 
         run_worker_cli(argv[1:])
         return
@@ -153,8 +151,16 @@ def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="local-shell-mcp")
     parser.add_argument("--mode", choices=["mcp", "http", "stdio"], default=None)
     parser.add_argument("--config", default=None, help="Path to config YAML")
-    parser.add_argument("--remote", dest="remote", action="store_true", default=None, help="Enable remote worker mode (default)")
-    parser.add_argument("--no-remote", dest="remote", action="store_false", help="Disable remote worker mode")
+    parser.add_argument(
+        "--remote",
+        dest="remote",
+        action="store_true",
+        default=None,
+        help="Enable remote worker mode (default)",
+    )
+    parser.add_argument(
+        "--no-remote", dest="remote", action="store_false", help="Disable remote worker mode"
+    )
     args = parser.parse_args(argv)
     if args.config:
         os.environ["LOCAL_SHELL_MCP_CONFIG"] = args.config

--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -1620,8 +1620,8 @@ async def run_worker(
     persist: bool = False,
 ) -> None:  # noqa: ARG001
     workdir = str(Path(workdir or os.getcwd()).expanduser().resolve())
-    os.environ.setdefault("LOCAL_SHELL_MCP_WORKSPACE_ROOT", workdir)
-    os.environ.setdefault("LOCAL_SHELL_MCP_ALLOW_FULL_CONTAINER", "true")
+    os.environ["LOCAL_SHELL_MCP_WORKSPACE_ROOT"] = workdir
+    os.environ["LOCAL_SHELL_MCP_ALLOW_FULL_CONTAINER"] = "true"
     from .settings import get_settings as _get_settings
 
     _get_settings.cache_clear()

--- a/src/local_shell_mcp/remote_worker.py
+++ b/src/local_shell_mcp/remote_worker.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 
-from .remote import run_worker_cli
+from .remote_worker_cli import run_worker_cli
 
 if __name__ == "__main__":
     run_worker_cli(sys.argv[1:])

--- a/src/local_shell_mcp/remote_worker_cli.py
+++ b/src/local_shell_mcp/remote_worker_cli.py
@@ -23,6 +23,7 @@ from .remote_worker_state import (
     read_worker_config,
     write_worker_config,
 )
+from .shell_environment import is_frozen_app
 
 
 def _read_invite(args: argparse.Namespace) -> str:
@@ -147,6 +148,17 @@ async def run_enrolled_worker() -> None:
     )
 
 
+def _worker_run_exec_argv() -> list[str]:
+    if is_frozen_app():
+        return [sys.executable, "worker", "run"]
+    return [sys.executable, "-m", "local_shell_mcp.main", "worker", "run"]
+
+
+def _reexec_worker_run() -> None:
+    argv = _worker_run_exec_argv()
+    os.execv(argv[0], argv)
+
+
 async def _connect(args: argparse.Namespace) -> None:
     await enroll_worker(
         server=args.server,
@@ -156,7 +168,14 @@ async def _connect(args: argparse.Namespace) -> None:
         runtime_digest=args.runtime_digest,
         runtime_version=args.runtime_version,
     )
-    await run_enrolled_worker()
+    _reexec_worker_run()
+
+
+def _prepare_worker_start() -> None:
+    config = _load_config_or_migrate()
+    install_or_update_runtime(str(config["server"]))
+    install_launcher()
+    ensure_user_bin_on_path()
 
 
 def _add_enrollment_arguments(parser: argparse.ArgumentParser) -> None:
@@ -213,13 +232,13 @@ def _run_command(args: argparse.Namespace) -> None:
     elif args.command == "run":
         asyncio.run(run_enrolled_worker())
     elif args.command == "start":
-        install_launcher()
-        ensure_user_bin_on_path()
+        _prepare_worker_start()
         _print_result(start_service())
     elif args.command == "stop":
         _print_result(stop_service())
     elif args.command == "restart":
         stop_service()
+        _prepare_worker_start()
         _print_result(start_service())
     elif args.command == "status":
         _print_result(service_status())

--- a/src/local_shell_mcp/remote_worker_cli.py
+++ b/src/local_shell_mcp/remote_worker_cli.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from . import remote
+from .remote_worker_installer import install_or_update_runtime
+from .remote_worker_service import (
+    install_service,
+    service_status,
+    start_service,
+    stop_service,
+    uninstall_service,
+)
+from .remote_worker_state import (
+    ensure_user_bin_on_path,
+    install_launcher,
+    read_worker_config,
+    write_worker_config,
+)
+
+
+def _read_invite(args: argparse.Namespace) -> str:
+    invite = str(getattr(args, "invite", "") or "")
+    if getattr(args, "invite_stdin", False):
+        invite = sys.stdin.readline().strip()
+    if not invite:
+        raise ValueError("an invite is required; pass --invite or --invite-stdin")
+    return invite
+
+
+def _worker_payload(name: str | None, workdir: str, invite: str) -> dict[str, Any]:
+    return {
+        "invite": invite,
+        "name": name,
+        "workdir": workdir,
+        "capabilities": remote.worker_capabilities(),
+        "info": remote.worker_info(workdir),
+    }
+
+
+def _enrollment_payload(name: str | None, workdir: str, invite: str) -> dict[str, Any]:
+    from .settings import get_settings
+
+    temporary_environment = {
+        "LOCAL_SHELL_MCP_WORKSPACE_ROOT": workdir,
+        "LOCAL_SHELL_MCP_ALLOW_FULL_CONTAINER": "true",
+    }
+    introduced = []
+    for variable, value in temporary_environment.items():
+        if variable not in os.environ:
+            os.environ[variable] = value
+            introduced.append(variable)
+    get_settings.cache_clear()
+    try:
+        return _worker_payload(name, workdir, invite)
+    finally:
+        for variable in introduced:
+            os.environ.pop(variable, None)
+        get_settings.cache_clear()
+
+
+async def enroll_worker(
+    *,
+    server: str,
+    invite: str,
+    name: str | None = None,
+    workdir: str | None = None,
+    runtime_digest: str = "",
+    runtime_version: str = "",
+) -> dict[str, Any]:
+    server = server.rstrip("/")
+    resolved_workdir = str(Path(workdir or os.getcwd()).expanduser().resolve())
+    payload = _enrollment_payload(name, resolved_workdir, invite)
+    identity = remote._read_worker_identity(server, name)  # noqa: SLF001
+    body: dict[str, Any] | None = None
+    access = ""
+    if identity:
+        access = str(identity["access"])
+        headers = {"Authorization": "Bearer " + access}
+        resume_payload = {**payload, "name": str(identity["name"])}
+        body = await remote._worker_resume_or_none(  # noqa: SLF001
+            f"{server}{remote.REMOTE_API_PREFIX}/resume", resume_payload, headers, 30
+        )
+    if body is None:
+        body = await remote._worker_post_json_forever(  # noqa: SLF001
+            f"{server}{remote.REMOTE_API_PREFIX}/register", payload, None, 30, "register"
+        )
+        if not body.get("ok"):
+            raise RuntimeError(body.get("message") or body)
+        data = body["data"]
+        access = str(data["token"])
+    elif not body.get("ok"):
+        raise RuntimeError(body.get("message") or body)
+    else:
+        data = body["data"]
+    machine_name = str(data["name"])
+    remote._write_worker_identity(  # noqa: SLF001
+        {"server": server, "name": machine_name, "access": access, "workdir": resolved_workdir}
+    )
+    config = write_worker_config(
+        server=server,
+        name=machine_name,
+        workdir=resolved_workdir,
+        runtime_digest=runtime_digest,
+        runtime_version=runtime_version,
+    )
+    return config
+
+
+def _load_config_or_migrate() -> dict[str, Any]:
+    try:
+        return read_worker_config()
+    except FileNotFoundError:
+        path = remote._worker_identity_path()  # noqa: SLF001
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            raise ValueError("stored worker identity is invalid") from None
+        return write_worker_config(
+            server=str(data.get("server") or ""),
+            name=str(data.get("name") or ""),
+            workdir=str(data.get("workdir") or os.getcwd()),
+        )
+
+
+async def run_enrolled_worker() -> None:
+    config = _load_config_or_migrate()
+    identity = remote._read_worker_identity(
+        str(config["server"]), str(config.get("name") or "")
+    )  # noqa: SLF001
+    if not identity:
+        raise RuntimeError("worker identity is missing or invalid; run the join command again")
+    await remote.run_worker(
+        str(config["server"]),
+        "",
+        str(config.get("name") or "") or None,
+        str(config.get("workdir") or "") or None,
+    )
+
+
+async def _connect(args: argparse.Namespace) -> None:
+    await enroll_worker(
+        server=args.server,
+        invite=_read_invite(args),
+        name=args.name,
+        workdir=args.workdir,
+        runtime_digest=args.runtime_digest,
+        runtime_version=args.runtime_version,
+    )
+    await run_enrolled_worker()
+
+
+def _add_enrollment_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--server", required=True)
+    invite = parser.add_mutually_exclusive_group(required=True)
+    invite.add_argument("--invite")
+    invite.add_argument("--invite-stdin", action="store_true")
+    parser.add_argument("--name", default=None)
+    parser.add_argument("--workdir", default=None)
+    parser.add_argument("--runtime-digest", default="")
+    parser.add_argument("--runtime-version", default="")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Manage the local-shell-mcp remote worker")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    _add_enrollment_arguments(subparsers.add_parser("enroll", help="register this machine once"))
+    _add_enrollment_arguments(
+        subparsers.add_parser("connect", help="register if needed and run in the foreground")
+    )
+    subparsers.add_parser("run", help="run using the stored worker identity")
+    subparsers.add_parser("start", help="start the installed worker")
+    subparsers.add_parser("stop", help="stop the installed worker")
+    subparsers.add_parser("restart", help="restart the installed worker")
+    subparsers.add_parser("status", help="show worker service status")
+    update = subparsers.add_parser("update", help="update the cached worker runtime")
+    update.add_argument("--force", action="store_true")
+    install = subparsers.add_parser("install-service", help="install the user service")
+    install.add_argument("--no-start", action="store_true")
+    subparsers.add_parser("uninstall-service", help="remove the user service")
+    subparsers.add_parser("install-launcher", help="install the management command and PATH entry")
+    return parser
+
+
+def _print_result(result: Any) -> None:
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+def _run_command(args: argparse.Namespace) -> None:
+    if args.command == "enroll":
+        result = asyncio.run(
+            enroll_worker(
+                server=args.server,
+                invite=_read_invite(args),
+                name=args.name,
+                workdir=args.workdir,
+                runtime_digest=args.runtime_digest,
+                runtime_version=args.runtime_version,
+            )
+        )
+        _print_result(result)
+    elif args.command == "connect":
+        asyncio.run(_connect(args))
+    elif args.command == "run":
+        asyncio.run(run_enrolled_worker())
+    elif args.command == "start":
+        install_launcher()
+        ensure_user_bin_on_path()
+        _print_result(start_service())
+    elif args.command == "stop":
+        _print_result(stop_service())
+    elif args.command == "restart":
+        stop_service()
+        _print_result(start_service())
+    elif args.command == "status":
+        _print_result(service_status())
+    elif args.command == "update":
+        config = _load_config_or_migrate()
+        before = service_status()
+        result = install_or_update_runtime(str(config["server"]), force=args.force)
+        if result["updated"] and before["running"]:
+            stop_service()
+            start_service()
+        _print_result(result)
+    elif args.command == "install-service":
+        _print_result(install_service(start=not args.no_start))
+    elif args.command == "uninstall-service":
+        _print_result(uninstall_service())
+    elif args.command == "install-launcher":
+        launcher = install_launcher()
+        changed = ensure_user_bin_on_path()
+        _print_result({"launcher": str(launcher), "path_files": [str(path) for path in changed]})
+    else:  # pragma: no cover - argparse enforces the command choices
+        raise AssertionError(args.command)
+
+
+def run_worker_cli(argv: list[str] | None = None) -> None:
+    argv = sys.argv[1:] if argv is None else list(argv)
+    if argv and argv[0].startswith("-"):
+        remote.run_worker_cli(argv)
+        return
+    try:
+        _run_command(_parser().parse_args(argv))
+    except KeyboardInterrupt:
+        print("\nStatus: disconnected by user.", file=sys.stderr, flush=True)
+        raise SystemExit(130) from None
+    except Exception as exc:  # noqa: BLE001
+        print(f"Status: worker command failed: {exc}", file=sys.stderr, flush=True)
+        raise SystemExit(1) from None

--- a/src/local_shell_mcp/remote_worker_cli.py
+++ b/src/local_shell_mcp/remote_worker_cli.py
@@ -51,17 +51,21 @@ def _enrollment_payload(name: str | None, workdir: str, invite: str) -> dict[str
         "LOCAL_SHELL_MCP_WORKSPACE_ROOT": workdir,
         "LOCAL_SHELL_MCP_ALLOW_FULL_CONTAINER": "true",
     }
-    introduced = []
+    previous_environment = {
+        variable: os.environ.get(variable) for variable in temporary_environment
+    }
+    present_environment = set(os.environ).intersection(temporary_environment)
     for variable, value in temporary_environment.items():
-        if variable not in os.environ:
-            os.environ[variable] = value
-            introduced.append(variable)
+        os.environ[variable] = value
     get_settings.cache_clear()
     try:
         return _worker_payload(name, workdir, invite)
     finally:
-        for variable in introduced:
-            os.environ.pop(variable, None)
+        for variable, previous in previous_environment.items():
+            if variable in present_environment:
+                os.environ[variable] = previous or ""
+            else:
+                os.environ.pop(variable, None)
         get_settings.cache_clear()
 
 
@@ -228,6 +232,8 @@ def _run_command(args: argparse.Namespace) -> None:
             start_service()
         _print_result(result)
     elif args.command == "install-service":
+        config = _load_config_or_migrate()
+        install_or_update_runtime(str(config["server"]))
         _print_result(install_service(start=not args.no_start))
     elif args.command == "uninstall-service":
         _print_result(uninstall_service())

--- a/src/local_shell_mcp/remote_worker_installer.py
+++ b/src/local_shell_mcp/remote_worker_installer.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import tarfile
+import tempfile
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from .remote_worker_state import (
+    read_worker_config,
+    update_runtime_metadata,
+    worker_runtime_dir,
+    worker_state_dir,
+)
+
+_WORKER_MANIFEST_PATH = "/remote/worker-bundle.tgz?manifest=1"
+
+
+def _fetch_bytes(url: str, timeout: float = 60) -> bytes:
+    with urllib.request.urlopen(url, timeout=timeout) as response:  # noqa: S310
+        return response.read()
+
+
+def fetch_manifest(server: str) -> dict[str, Any]:
+    url = server.rstrip("/") + _WORKER_MANIFEST_PATH
+    data = json.loads(_fetch_bytes(url).decode("utf-8"))
+    if not isinstance(data, dict) or data.get("schema_version") != 1:
+        raise ValueError("invalid remote worker manifest")
+    digest = str(data.get("sha256") or "")
+    bundle_url = str(data.get("url") or "")
+    if len(digest) != 64 or not bundle_url:
+        raise ValueError("remote worker manifest is incomplete")
+    data["url"] = urllib.parse.urljoin(server.rstrip("/") + "/", bundle_url)
+    return data
+
+
+def _safe_extract(archive: Path, destination: Path) -> None:
+    destination_resolved = destination.resolve()
+    with tarfile.open(archive, mode="r:gz") as tar:
+        for member in tar.getmembers():
+            target = (destination / member.name).resolve()
+            if target != destination_resolved and destination_resolved not in target.parents:
+                raise ValueError(f"unsafe worker bundle path: {member.name}")
+            if member.issym() or member.islnk():
+                raise ValueError(f"worker bundle links are not supported: {member.name}")
+        tar.extractall(destination)  # noqa: S202
+
+
+def install_or_update_runtime(server: str, *, force: bool = False) -> dict[str, Any]:
+    manifest = fetch_manifest(server)
+    digest = str(manifest["sha256"])
+    version = str(manifest.get("bundle_version") or "")
+    runtime = worker_runtime_dir()
+    try:
+        current = read_worker_config()
+    except (FileNotFoundError, ValueError):
+        current = {}
+    if not force and runtime.is_dir() and current.get("runtime_digest") == digest:
+        return {"updated": False, "sha256": digest, "version": version, "runtime": str(runtime)}
+
+    state_dir = worker_state_dir()
+    state_dir.mkdir(parents=True, exist_ok=True)
+    payload = _fetch_bytes(str(manifest["url"]), timeout=120)
+    actual = hashlib.sha256(payload).hexdigest()
+    if actual != digest:
+        raise ValueError(f"worker bundle checksum mismatch: expected {digest}, got {actual}")
+
+    with tempfile.TemporaryDirectory(prefix="runtime-install-", dir=state_dir) as temporary:
+        temporary_path = Path(temporary)
+        archive = temporary_path / "worker.tgz"
+        extracted = temporary_path / "runtime"
+        archive.write_bytes(payload)
+        extracted.mkdir()
+        _safe_extract(archive, extracted)
+        if not (extracted / "local_shell_mcp").is_dir():
+            raise ValueError("worker bundle does not contain local_shell_mcp")
+
+        staged = state_dir / f"runtime.next.{os.getpid()}"
+        backup = state_dir / f"runtime.previous.{os.getpid()}"
+        shutil.rmtree(staged, ignore_errors=True)
+        shutil.rmtree(backup, ignore_errors=True)
+        shutil.copytree(extracted, staged)
+        try:
+            if runtime.exists():
+                runtime.replace(backup)
+            staged.replace(runtime)
+        except Exception:
+            if not runtime.exists() and backup.exists():
+                backup.replace(runtime)
+            raise
+        finally:
+            shutil.rmtree(staged, ignore_errors=True)
+            shutil.rmtree(backup, ignore_errors=True)
+
+    if current:
+        update_runtime_metadata(digest, version)
+    return {"updated": True, "sha256": digest, "version": version, "runtime": str(runtime)}

--- a/src/local_shell_mcp/remote_worker_routes.py
+++ b/src/local_shell_mcp/remote_worker_routes.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import functools
+import gzip
+import hashlib
+import io
+import shlex
+import tarfile
+from pathlib import Path
+from typing import Any
+
+from . import __version__, remote
+from .remote_transfer import remote_transfer_routes
+from .settings import get_settings
+
+REMOTE_WORKER_MANIFEST_PATH = "/remote/worker-manifest.json"
+REMOTE_WORKER_PUBLIC_MANIFEST_URL = remote.REMOTE_WORKER_BUNDLE_PATH + "?manifest=1"
+
+
+def _normalized_tar_info(info: tarfile.TarInfo) -> tarfile.TarInfo:
+    info.uid = 0
+    info.gid = 0
+    info.uname = ""
+    info.gname = ""
+    info.mtime = 0
+    return info
+
+
+@functools.lru_cache(maxsize=1)
+def worker_bundle_bytes() -> bytes:
+    package_root = Path(remote.__file__).resolve().parent
+    buffer = io.BytesIO()
+    with (
+        gzip.GzipFile(fileobj=buffer, mode="wb", filename="", mtime=0) as compressed,
+        tarfile.open(fileobj=compressed, mode="w") as tar,
+    ):
+        for path in sorted(package_root.rglob("*")):
+            if not path.is_file():
+                continue
+            relative = path.relative_to(package_root)
+            is_python = path.suffix == ".py"
+            is_helper = relative.parts[:1] == ("helpers",) and path.name in {
+                "tmux",
+                "tmux.LICENSE",
+            }
+            if is_python or is_helper:
+                tar.add(
+                    path,
+                    arcname=str(path.relative_to(package_root.parent)),
+                    filter=_normalized_tar_info,
+                )
+        seen: set[str] = set()
+        for dist_name in remote.REMOTE_WORKER_DISTRIBUTIONS:
+            remote._add_distribution_to_tar(tar, dist_name, seen)  # noqa: SLF001
+    return buffer.getvalue()
+
+
+def _worker_manifest_data() -> dict[str, Any]:
+    settings = get_settings()
+    server = (settings.public_base_url or f"http://{settings.host}:{settings.port}").rstrip("/")
+    payload = worker_bundle_bytes()
+    return {
+        "schema_version": 1,
+        "bundle_version": __version__,
+        "sha256": hashlib.sha256(payload).hexdigest(),
+        "size": len(payload),
+        "url": server + remote.REMOTE_WORKER_BUNDLE_PATH,
+    }
+
+
+async def worker_bundle(request: Any):  # noqa: ANN201
+    from starlette.responses import JSONResponse, Response
+
+    query = getattr(request, "query_params", {}) if request is not None else {}
+    if query.get("manifest") == "1":
+        return JSONResponse(_worker_manifest_data())
+    return Response(worker_bundle_bytes(), media_type="application/gzip")
+
+
+async def worker_manifest(request: Any):  # noqa: ARG001, ANN201
+    from starlette.responses import JSONResponse
+
+    return JSONResponse(_worker_manifest_data())
+
+
+async def join_script(request: Any):  # noqa: ARG001, ANN201
+    from starlette.responses import PlainTextResponse
+
+    settings = get_settings()
+    server = (settings.public_base_url or f"http://{settings.host}:{settings.port}").rstrip("/")
+    script = r'''#!/usr/bin/env bash
+set -euo pipefail
+SERVER=__SERVER__
+MANIFEST_URL="$SERVER__PUBLIC_MANIFEST_URL__"
+INVITE=""
+NAME=""
+WORKDIR=""
+BACKGROUND=0
+PERSIST=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --invite) INVITE="${2:-}"; shift 2 ;;
+    --name) NAME="${2:-}"; shift 2 ;;
+    --workdir) WORKDIR="${2:-}"; shift 2 ;;
+    --background) BACKGROUND=1; shift ;;
+    --persist) PERSIST=1; shift ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+if [ -z "$INVITE" ]; then echo "--invite is required" >&2; exit 2; fi
+if [ -z "$WORKDIR" ]; then WORKDIR="$PWD"; fi
+if ! command -v python3 >/dev/null 2>&1; then echo "python3 is required" >&2; exit 2; fi
+if ! command -v curl >/dev/null 2>&1; then echo "curl is required" >&2; exit 2; fi
+if ! command -v tar >/dev/null 2>&1; then echo "tar is required" >&2; exit 2; fi
+TMPDIR="$(mktemp -d)"
+cleanup() { rm -rf "$TMPDIR"; }
+trap cleanup EXIT
+curl -fsSL "$MANIFEST_URL" -o "$TMPDIR/manifest.json"
+manifest_value() {
+  python3 -c 'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))[sys.argv[2]])' "$TMPDIR/manifest.json" "$1"
+}
+BUNDLE_URL="$(manifest_value url)"
+REMOTE_DIGEST="$(manifest_value sha256)"
+REMOTE_VERSION="$(manifest_value bundle_version)"
+STATE_HOME="${LOCAL_SHELL_MCP_WORKER_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/local-shell-mcp-worker}"
+RUNTIME_ROOT="$TMPDIR/runtime"
+if [ "$BACKGROUND" = "1" ] || [ "$PERSIST" = "1" ]; then
+  RUNTIME_ROOT="$STATE_HOME/runtime"
+  LOCAL_DIGEST=""
+  if [ -f "$STATE_HOME/bundle.sha256" ]; then LOCAL_DIGEST="$(cat "$STATE_HOME/bundle.sha256")"; fi
+  if [ ! -d "$RUNTIME_ROOT/local_shell_mcp" ] || [ "$LOCAL_DIGEST" != "$REMOTE_DIGEST" ]; then
+    echo "Downloading worker bundle..." >&2
+    curl -fL --progress-bar "$BUNDLE_URL" -o "$TMPDIR/worker.tgz"
+    ACTUAL_DIGEST="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(open(sys.argv[1], "rb").read()).hexdigest())' "$TMPDIR/worker.tgz")"
+    if [ "$ACTUAL_DIGEST" != "$REMOTE_DIGEST" ]; then
+      echo "worker bundle checksum mismatch" >&2
+      exit 1
+    fi
+    mkdir -p "$STATE_HOME"
+    RUNTIME_NEXT="$STATE_HOME/runtime.next.$$"
+    RUNTIME_PREVIOUS="$STATE_HOME/runtime.previous.$$"
+    rm -rf "$RUNTIME_NEXT" "$RUNTIME_PREVIOUS"
+    mkdir -p "$RUNTIME_NEXT"
+    tar -xzf "$TMPDIR/worker.tgz" -C "$RUNTIME_NEXT"
+    if [ -d "$RUNTIME_ROOT" ]; then mv "$RUNTIME_ROOT" "$RUNTIME_PREVIOUS"; fi
+    if ! mv "$RUNTIME_NEXT" "$RUNTIME_ROOT"; then
+      if [ -d "$RUNTIME_PREVIOUS" ]; then mv "$RUNTIME_PREVIOUS" "$RUNTIME_ROOT"; fi
+      exit 1
+    fi
+    rm -rf "$RUNTIME_PREVIOUS"
+    printf '%s\n' "$REMOTE_DIGEST" > "$STATE_HOME/bundle.sha256"
+  else
+    echo "Worker bundle is already current ($REMOTE_VERSION)." >&2
+  fi
+else
+  echo "Downloading worker bundle..." >&2
+  curl -fL --progress-bar "$BUNDLE_URL" -o "$TMPDIR/worker.tgz"
+  ACTUAL_DIGEST="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(open(sys.argv[1], "rb").read()).hexdigest())' "$TMPDIR/worker.tgz")"
+  if [ "$ACTUAL_DIGEST" != "$REMOTE_DIGEST" ]; then
+    echo "worker bundle checksum mismatch" >&2
+    exit 1
+  fi
+  mkdir -p "$RUNTIME_ROOT"
+  tar -xzf "$TMPDIR/worker.tgz" -C "$RUNTIME_ROOT"
+fi
+export PYTHONPATH="$RUNTIME_ROOT:$RUNTIME_ROOT/vendor${PYTHONPATH:+:$PYTHONPATH}"
+ENROLL_ARGS=(enroll --server "$SERVER" --invite-stdin --workdir "$WORKDIR" --runtime-digest "$REMOTE_DIGEST" --runtime-version "$REMOTE_VERSION")
+if [ -n "$NAME" ]; then ENROLL_ARGS+=(--name "$NAME"); fi
+printf '%s\n' "$INVITE" | python3 -m local_shell_mcp.remote_worker "${ENROLL_ARGS[@]}"
+unset INVITE
+if [ "$PERSIST" = "1" ]; then
+  python3 -m local_shell_mcp.remote_worker install-service
+  export PATH="$HOME/.local/bin:$PATH"
+  echo "local-shell-mcp worker installed and started."
+  echo "Management: local-shell-mcp worker status"
+  exit 0
+fi
+if [ "$BACKGROUND" = "1" ]; then
+  python3 -m local_shell_mcp.remote_worker install-launcher
+  python3 -m local_shell_mcp.remote_worker start
+  export PATH="$HOME/.local/bin:$PATH"
+  echo "local-shell-mcp worker started in background."
+  echo "Management: local-shell-mcp worker status"
+  exit 0
+fi
+exec python3 -m local_shell_mcp.remote_worker run
+'''
+    script = script.replace("__SERVER__", shlex.quote(server))
+    script = script.replace("__PUBLIC_MANIFEST_URL__", REMOTE_WORKER_PUBLIC_MANIFEST_URL)
+    return PlainTextResponse(script, media_type="text/x-shellscript")
+
+
+def remote_routes() -> list[Any]:
+    from starlette.routing import Route
+
+    return [
+        Route(remote.REMOTE_JOIN_PATH, join_script, methods=["GET"]),
+        Route(REMOTE_WORKER_MANIFEST_PATH, worker_manifest, methods=["GET"]),
+        Route(remote.REMOTE_WORKER_BUNDLE_PATH, worker_bundle, methods=["GET"]),
+        Route(f"{remote.REMOTE_API_PREFIX}/register", remote.register_endpoint, methods=["POST"]),
+        Route(f"{remote.REMOTE_API_PREFIX}/resume", remote.resume_endpoint, methods=["POST"]),
+        Route(f"{remote.REMOTE_API_PREFIX}/poll", remote.poll_endpoint, methods=["POST"]),
+        Route(f"{remote.REMOTE_API_PREFIX}/heartbeat", remote.heartbeat_endpoint, methods=["POST"]),
+        Route(f"{remote.REMOTE_API_PREFIX}/result", remote.result_endpoint, methods=["POST"]),
+        *remote_transfer_routes(),
+    ]

--- a/src/local_shell_mcp/remote_worker_service.py
+++ b/src/local_shell_mcp/remote_worker_service.py
@@ -1,0 +1,394 @@
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import platform
+import plistlib
+import shlex
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+from .remote_worker_state import (
+    ensure_user_bin_on_path,
+    install_launcher,
+    user_home,
+    worker_launcher_path,
+    worker_log_path,
+    worker_pid_path,
+    worker_runtime_dir,
+    worker_state_dir,
+)
+
+_SERVICE_NAME = "local-shell-mcp-worker"
+_LAUNCHD_LABEL = "com.fwerkor.local-shell-mcp-worker"
+
+
+def _systemd_unit_path() -> Path:
+    return user_home() / ".config" / "systemd" / "user" / f"{_SERVICE_NAME}.service"
+
+
+def _launchd_plist_path() -> Path:
+    return user_home() / "Library" / "LaunchAgents" / f"{_LAUNCHD_LABEL}.plist"
+
+
+def _run(command: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, check=check, capture_output=True, text=True)  # noqa: S603
+
+
+def _user_id() -> int:
+    getuid = getattr(os, "getuid", None)
+    return int(getuid()) if getuid else 0
+
+
+def _systemd_user_available() -> bool:
+    if not shutil.which("systemctl"):
+        return False
+    result = _run(["systemctl", "--user", "show-environment"], check=False)
+    return result.returncode == 0
+
+
+def service_kind() -> str:
+    system = platform.system()
+    if system == "Linux" and _systemd_user_available():
+        return "systemd"
+    if system == "Darwin" and shutil.which("launchctl"):
+        return "launchd"
+    return "process"
+
+
+def _write_systemd_unit() -> Path:
+    path = _systemd_unit_path()
+    launcher = shlex.quote(str(worker_launcher_path()))
+    content = f"""[Unit]
+Description=local-shell-mcp remote worker
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart={launcher} worker run
+Restart=always
+RestartSec=5
+Environment=PYTHONUNBUFFERED=1
+
+[Install]
+WantedBy=default.target
+"""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _write_launchd_plist() -> Path:
+    path = _launchd_plist_path()
+    payload = {
+        "Label": _LAUNCHD_LABEL,
+        "ProgramArguments": [str(worker_launcher_path()), "worker", "run"],
+        "RunAtLoad": True,
+        "KeepAlive": True,
+        "StandardOutPath": str(worker_log_path()),
+        "StandardErrorPath": str(worker_log_path()),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(plistlib.dumps(payload, fmt=plistlib.FMT_XML, sort_keys=False))
+    return path
+
+
+def _pid_is_running(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def _is_worker_command(command: str) -> bool:
+    normalized = command.replace("\\", "/")
+    module = "local_shell_mcp.main" in normalized or "local_shell_mcp.remote_worker" in normalized
+    return module and "worker" in normalized and "run" in normalized
+
+
+def _linux_process_identity(pid: int) -> str | None:
+    proc = Path("/proc") / str(pid)
+    try:
+        stat_text = (proc / "stat").read_text(encoding="utf-8")
+        command = (proc / "cmdline").read_bytes().replace(b"\0", b" ").decode(
+            "utf-8", errors="replace"
+        )
+    except OSError:
+        return None
+    closing = stat_text.rfind(")")
+    if closing < 0 or not _is_worker_command(command):
+        return None
+    fields = stat_text[closing + 2 :].split()
+    if len(fields) <= 19:
+        return None
+    start_ticks = fields[19]
+    digest = hashlib.sha256(command.encode("utf-8")).hexdigest()
+    return f"linux:{start_ticks}:{digest}"
+
+
+def _windows_process_identity(pid: int) -> str | None:
+    shell = shutil.which("pwsh") or shutil.which("powershell")
+    if not shell:
+        return None
+    script = (
+        f'$p=Get-CimInstance Win32_Process -Filter "ProcessId = {pid}"; '
+        'if ($p) { Write-Output ($p.CreationDate + "|" + $p.CommandLine) }'
+    )
+    result = _run([shell, "-NoProfile", "-Command", script], check=False)
+    value = result.stdout.strip()
+    if result.returncode or "|" not in value:
+        return None
+    created, command = value.split("|", 1)
+    if not created or not _is_worker_command(command):
+        return None
+    digest = hashlib.sha256(command.encode("utf-8")).hexdigest()
+    return f"windows:{created}:{digest}"
+
+
+def _posix_process_identity(pid: int) -> str | None:
+    result = _run(["ps", "-p", str(pid), "-o", "lstart=", "-o", "command="], check=False)
+    value = result.stdout.strip()
+    if result.returncode or not value or not _is_worker_command(value):
+        return None
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()
+    return f"posix:{digest}"
+
+
+def _process_identity(pid: int) -> str | None:
+    if not _pid_is_running(pid):
+        return None
+    system = platform.system()
+    if system == "Linux" and Path("/proc").is_dir():
+        return _linux_process_identity(pid)
+    if system == "Windows":
+        return _windows_process_identity(pid)
+    return _posix_process_identity(pid)
+
+
+def _write_pid(pid: int, identity: str) -> None:
+    worker_pid_path().parent.mkdir(parents=True, exist_ok=True)
+    worker_pid_path().write_text(
+        json.dumps({"version": 1, "pid": pid, "identity": identity}, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    with contextlib.suppress(OSError):
+        worker_pid_path().chmod(0o600)
+
+
+def _read_pid() -> int | None:
+    path = worker_pid_path()
+    try:
+        raw = path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return None
+    expected = ""
+    try:
+        data = json.loads(raw)
+        if not isinstance(data, dict) or data.get("version") != 1:
+            raise ValueError
+        pid = int(data["pid"])
+        expected = str(data.get("identity") or "")
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+        try:
+            pid = int(raw)
+        except ValueError:
+            path.unlink(missing_ok=True)
+            return None
+    actual = _process_identity(pid)
+    if not actual or (expected and actual != expected):
+        path.unlink(missing_ok=True)
+        return None
+    if not expected:
+        _write_pid(pid, actual)
+    return pid
+
+
+def _process_environment() -> dict[str, str]:
+    env = os.environ.copy()
+    runtime = worker_runtime_dir()
+    current = env.get("PYTHONPATH", "")
+    pythonpath = os.pathsep.join((str(runtime), str(runtime / "vendor")))
+    env["PYTHONPATH"] = pythonpath + (os.pathsep + current if current else "")
+    env["LOCAL_SHELL_MCP_WORKER_STATE_DIR"] = str(worker_state_dir().resolve())
+    return env
+
+
+def _start_process() -> None:
+    if _read_pid():
+        return
+    worker_state_dir().mkdir(parents=True, exist_ok=True)
+    command = [sys.executable, "-m", "local_shell_mcp.main", "worker", "run"]
+    with worker_log_path().open("ab") as log:
+        if os.name == "nt":
+            flags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0) | getattr(
+                subprocess, "DETACHED_PROCESS", 0
+            )
+            process = subprocess.Popen(  # noqa: S603
+                command,
+                stdin=subprocess.DEVNULL,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                creationflags=flags,
+                env=_process_environment(),
+            )
+        else:
+            process = subprocess.Popen(  # noqa: S603
+                command,
+                stdin=subprocess.DEVNULL,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+                env=_process_environment(),
+            )
+    identity = None
+    for _ in range(40):
+        identity = _process_identity(process.pid)
+        if identity:
+            break
+        time.sleep(0.05)
+    if not identity:
+        with contextlib.suppress(OSError):
+            process.terminate()
+        raise RuntimeError("worker process started but its identity could not be verified")
+    _write_pid(process.pid, identity)
+
+
+def _stop_process() -> None:
+    pid = _read_pid()
+    if not pid:
+        worker_pid_path().unlink(missing_ok=True)
+        return
+    os.kill(pid, signal.SIGTERM)
+    for _ in range(50):
+        if not _pid_is_running(pid):
+            break
+        time.sleep(0.1)
+    else:
+        if _read_pid() == pid:
+            force_signal = getattr(signal, "SIGKILL", signal.SIGTERM)
+            os.kill(pid, force_signal)
+    worker_pid_path().unlink(missing_ok=True)
+
+
+def install_service(*, start: bool = True) -> dict[str, Any]:
+    launcher = install_launcher()
+    changed_path_files = ensure_user_bin_on_path()
+    worker_state_dir().mkdir(parents=True, exist_ok=True)
+    kind = service_kind()
+    if kind == "systemd":
+        _stop_process()
+        service_file = _write_systemd_unit()
+        _run(["systemctl", "--user", "daemon-reload"])
+        command = ["systemctl", "--user", "enable"]
+        if start:
+            command.append("--now")
+        command.append(f"{_SERVICE_NAME}.service")
+        _run(command)
+    elif kind == "launchd":
+        _stop_process()
+        service_file = _write_launchd_plist()
+        domain = f"gui/{_user_id()}"
+        _run(["launchctl", "bootout", domain, str(service_file)], check=False)
+        if start:
+            _run(["launchctl", "bootstrap", domain, str(service_file)])
+    else:
+        service_file = None
+        if start:
+            _start_process()
+    return {
+        "kind": kind,
+        "launcher": str(launcher),
+        "service_file": str(service_file) if service_file else None,
+        "path_files": [str(path) for path in changed_path_files],
+        "started": start,
+    }
+
+
+def uninstall_service() -> dict[str, Any]:
+    kind = service_kind()
+    stop_service()
+    if _systemd_unit_path().exists():
+        _run(["systemctl", "--user", "disable", f"{_SERVICE_NAME}.service"], check=False)
+        _systemd_unit_path().unlink(missing_ok=True)
+        _run(["systemctl", "--user", "daemon-reload"], check=False)
+    if _launchd_plist_path().exists():
+        _launchd_plist_path().unlink(missing_ok=True)
+    return {"kind": kind, "uninstalled": True}
+
+
+def start_service() -> dict[str, Any]:
+    kind = service_kind()
+    if kind == "systemd" and _systemd_unit_path().exists():
+        _run(["systemctl", "--user", "start", f"{_SERVICE_NAME}.service"])
+    elif kind == "launchd" and _launchd_plist_path().exists():
+        domain = f"gui/{_user_id()}"
+        result = _run(["launchctl", "kickstart", "-k", f"{domain}/{_LAUNCHD_LABEL}"], check=False)
+        if result.returncode:
+            _run(["launchctl", "bootstrap", domain, str(_launchd_plist_path())])
+    else:
+        _start_process()
+    return service_status()
+
+
+def stop_service() -> dict[str, Any]:
+    kind = service_kind()
+    if kind == "systemd" and _systemd_unit_path().exists():
+        _run(["systemctl", "--user", "stop", f"{_SERVICE_NAME}.service"], check=False)
+    elif kind == "launchd" and _launchd_plist_path().exists():
+        _run(
+            ["launchctl", "bootout", f"gui/{_user_id()}", str(_launchd_plist_path())],
+            check=False,
+        )
+    else:
+        _stop_process()
+    return service_status()
+
+
+def service_status() -> dict[str, Any]:
+    native_kind = service_kind()
+    pid = None
+    installed = False
+    running = False
+    detail = ""
+    kind = native_kind
+    if native_kind == "systemd" and _systemd_unit_path().exists():
+        installed = True
+        result = _run(
+            ["systemctl", "--user", "is-active", f"{_SERVICE_NAME}.service"],
+            check=False,
+        )
+        running = result.returncode == 0 and result.stdout.strip() == "active"
+        detail = result.stdout.strip() or result.stderr.strip()
+    elif native_kind == "launchd" and _launchd_plist_path().exists():
+        installed = True
+        result = _run(
+            ["launchctl", "print", f"gui/{_user_id()}/{_LAUNCHD_LABEL}"],
+            check=False,
+        )
+        running = result.returncode == 0
+        detail = result.stdout.strip() or result.stderr.strip()
+    else:
+        kind = "process"
+        installed = worker_launcher_path().exists()
+        pid = _read_pid()
+        running = pid is not None
+    return {
+        "kind": kind,
+        "installed": installed,
+        "running": running,
+        "pid": pid,
+        "detail": detail,
+        "launcher": str(worker_launcher_path()),
+        "log": str(worker_log_path()),
+    }

--- a/src/local_shell_mcp/remote_worker_service.py
+++ b/src/local_shell_mcp/remote_worker_service.py
@@ -216,6 +216,8 @@ def _read_pid() -> int | None:
 
 def _process_environment() -> dict[str, str]:
     env = os.environ.copy()
+    env.pop("LOCAL_SHELL_MCP_WORKSPACE_ROOT", None)
+    env.pop("LOCAL_SHELL_MCP_ALLOW_FULL_CONTAINER", None)
     runtime = worker_runtime_dir()
     current = env.get("PYTHONPATH", "")
     pythonpath = os.pathsep.join((str(runtime), str(runtime / "vendor")))

--- a/src/local_shell_mcp/remote_worker_state.py
+++ b/src/local_shell_mcp/remote_worker_state.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import shlex
+import stat
+import sys
+from pathlib import Path
+from typing import Any
+
+_CONFIG_FILE_NAME = "config.json"
+_PATH_MARKER = "# local-shell-mcp"
+
+
+def _is_windows() -> bool:
+    return os.name == "nt"
+
+
+def user_home() -> Path:
+    configured = os.getenv("HOME") or os.getenv("USERPROFILE")
+    return Path(configured).expanduser() if configured else Path.home()
+
+
+def worker_state_dir() -> Path:
+    configured = os.getenv("LOCAL_SHELL_MCP_WORKER_STATE_DIR")
+    if configured:
+        return Path(configured).expanduser()
+    xdg_state_home = os.getenv("XDG_STATE_HOME")
+    if xdg_state_home:
+        return Path(xdg_state_home).expanduser() / "local-shell-mcp-worker"
+    return user_home() / ".local" / "state" / "local-shell-mcp-worker"
+
+
+def worker_runtime_dir() -> Path:
+    return worker_state_dir() / "runtime"
+
+
+def worker_config_path() -> Path:
+    return worker_state_dir() / _CONFIG_FILE_NAME
+
+
+def worker_log_path() -> Path:
+    return worker_state_dir() / "worker.log"
+
+
+def worker_pid_path() -> Path:
+    return worker_state_dir() / "worker.pid"
+
+
+def worker_launcher_path() -> Path:
+    configured = os.getenv("LOCAL_SHELL_MCP_WORKER_BIN_DIR")
+    root = Path(configured).expanduser() if configured else user_home() / ".local" / "bin"
+    name = "local-shell-mcp.cmd" if _is_windows() else "local-shell-mcp"
+    return root / name
+
+
+def _atomic_write_text(
+    path: Path,
+    content: str,
+    mode: int = 0o600,
+    *,
+    preserve_existing_mode: bool = False,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    effective_mode = mode
+    if preserve_existing_mode:
+        with contextlib.suppress(OSError):
+            effective_mode = stat.S_IMODE(path.stat().st_mode)
+    temporary = path.with_name(path.name + ".tmp")
+    temporary.write_text(content, encoding="utf-8")
+    with contextlib.suppress(OSError):
+        temporary.chmod(effective_mode)
+    temporary.replace(path)
+
+
+def read_worker_config() -> dict[str, Any]:
+    path = worker_config_path()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or data.get("version") != 1:
+        raise ValueError(f"unsupported or invalid worker config: {path}")
+    if not str(data.get("server") or ""):
+        raise ValueError(f"worker config does not contain a server: {path}")
+    return data
+
+
+def write_worker_config(
+    *,
+    server: str,
+    name: str,
+    workdir: str,
+    runtime_digest: str = "",
+    runtime_version: str = "",
+) -> dict[str, Any]:
+    data = {
+        "version": 1,
+        "server": server.rstrip("/"),
+        "name": name,
+        "workdir": workdir,
+        "runtime_digest": runtime_digest,
+        "runtime_version": runtime_version,
+    }
+    _atomic_write_text(worker_config_path(), json.dumps(data, indent=2, sort_keys=True) + "\n")
+    return data
+
+
+def update_runtime_metadata(digest: str, version: str) -> dict[str, Any]:
+    data = read_worker_config()
+    data["runtime_digest"] = digest
+    data["runtime_version"] = version
+    _atomic_write_text(worker_config_path(), json.dumps(data, indent=2, sort_keys=True) + "\n")
+    return data
+
+
+def install_launcher() -> Path:
+    launcher = worker_launcher_path()
+    state_home = str(worker_state_dir().resolve())
+    python = str(Path(sys.executable).resolve())
+    if _is_windows():
+        script = f'''@echo off
+setlocal
+set "STATE_HOME={state_home}"
+set "RUNTIME=%STATE_HOME%\\runtime"
+if not exist "%RUNTIME%\\local_shell_mcp" (
+  echo local-shell-mcp worker runtime is not installed: %RUNTIME% 1>&2
+  exit /b 1
+)
+set "PYTHONPATH=%RUNTIME%;%RUNTIME%\\vendor;%PYTHONPATH%"
+"{python}" -m local_shell_mcp.main %*
+exit /b %ERRORLEVEL%
+'''
+    else:
+        script = f'''#!/bin/sh
+set -eu
+STATE_HOME={shlex.quote(state_home)}
+RUNTIME="$STATE_HOME/runtime"
+if [ ! -d "$RUNTIME/local_shell_mcp" ]; then
+  echo "local-shell-mcp worker runtime is not installed: $RUNTIME" >&2
+  exit 1
+fi
+export PYTHONPATH="$RUNTIME:$RUNTIME/vendor${{PYTHONPATH:+:$PYTHONPATH}}"
+exec {shlex.quote(python)} -m local_shell_mcp.main "$@"
+'''
+    _atomic_write_text(launcher, script, 0o755)
+    return launcher
+
+
+def _append_path_line(path: Path, line: str) -> bool:
+    try:
+        existing = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        existing = ""
+    if _PATH_MARKER in existing:
+        return False
+    separator = "" if not existing or existing.endswith("\n") else "\n"
+    _atomic_write_text(
+        path,
+        existing + separator + line + "\n",
+        0o644,
+        preserve_existing_mode=True,
+    )
+    return True
+
+
+def _ensure_windows_user_path(bin_dir: Path) -> None:
+    import winreg
+
+    with winreg.CreateKeyEx(
+        winreg.HKEY_CURRENT_USER,
+        "Environment",
+        0,
+        winreg.KEY_QUERY_VALUE | winreg.KEY_SET_VALUE,
+    ) as key:
+        try:
+            value, value_type = winreg.QueryValueEx(key, "Path")
+        except FileNotFoundError:
+            value, value_type = "", winreg.REG_EXPAND_SZ
+        entries = [entry for entry in str(value).split(os.pathsep) if entry]
+        normalized = {os.path.normcase(os.path.normpath(entry)) for entry in entries}
+        candidate = str(bin_dir)
+        if os.path.normcase(os.path.normpath(candidate)) not in normalized:
+            entries.insert(0, candidate)
+            winreg.SetValueEx(key, "Path", 0, value_type, os.pathsep.join(entries))
+
+
+def ensure_user_bin_on_path(shell: str | None = None) -> list[Path]:
+    bin_dir = worker_launcher_path().parent
+    current = os.environ.get("PATH", "").split(os.pathsep)
+    if str(bin_dir) not in current:
+        os.environ["PATH"] = str(bin_dir) + os.pathsep + os.environ.get("PATH", "")
+
+    if _is_windows():
+        _ensure_windows_user_path(bin_dir)
+        return []
+
+    home = user_home()
+    default_bin = home / ".local" / "bin"
+    posix_bin = '"$HOME/.local/bin"' if bin_dir == default_bin else shlex.quote(str(bin_dir))
+    fish_bin = '"$HOME/.local/bin"' if bin_dir == default_bin else shlex.quote(str(bin_dir))
+    shell_name = Path(shell or os.getenv("SHELL") or "sh").name
+    targets: list[tuple[Path, str]] = [
+        (home / ".profile", f"export PATH={posix_bin}:$PATH {_PATH_MARKER}")
+    ]
+    if shell_name == "bash":
+        targets.append((home / ".bashrc", f"export PATH={posix_bin}:$PATH {_PATH_MARKER}"))
+    elif shell_name == "zsh":
+        targets.append((home / ".zshrc", f"export PATH={posix_bin}:$PATH {_PATH_MARKER}"))
+    elif shell_name == "fish":
+        targets.append(
+            (
+                home / ".config" / "fish" / "config.fish",
+                f"fish_add_path --prepend {fish_bin} {_PATH_MARKER}",
+            )
+        )
+
+    changed = []
+    for path, line in targets:
+        if _append_path_line(path, line):
+            changed.append(path)
+    return changed

--- a/tests/test_main_complete.py
+++ b/tests/test_main_complete.py
@@ -7,7 +7,7 @@ import pytest
 import local_shell_mcp.human_ui as human_ui
 import local_shell_mcp.jobs as jobs
 import local_shell_mcp.main as main_module
-import local_shell_mcp.remote as remote
+import local_shell_mcp.remote_worker_cli as remote_worker_cli
 import local_shell_mcp.settings as settings_module
 import local_shell_mcp.tools as tools
 import local_shell_mcp.version as version
@@ -147,7 +147,7 @@ def test_run_http(monkeypatch):
 def test_main_subcommands_and_version(monkeypatch, capsys):
     calls = []
     monkeypatch.setattr(jobs, "run_job_runner_cli", lambda argv: calls.append(("job", argv)))
-    monkeypatch.setattr(remote, "run_worker_cli", lambda argv: calls.append(("worker", argv)))
+    monkeypatch.setattr(remote_worker_cli, "run_worker_cli", lambda argv: calls.append(("worker", argv)))
     monkeypatch.setattr(human_ui, "run_tui_cli", lambda argv: calls.append(("tui", argv)))
     monkeypatch.setattr(version, "format_version_info", lambda: "version-info")
 

--- a/tests/test_remote_worker_cli.py
+++ b/tests/test_remote_worker_cli.py
@@ -187,13 +187,12 @@ def test_cli_legacy_and_lifecycle_dispatch(tmp_path, monkeypatch, capsys):
     assert '"running": true' in capsys.readouterr().out
 
     calls = []
-    monkeypatch.setattr(cli, "install_launcher", lambda: tmp_path / "bin" / "local-shell-mcp")
-    monkeypatch.setattr(cli, "ensure_user_bin_on_path", lambda: [tmp_path / ".profile"])
+    monkeypatch.setattr(cli, "_prepare_worker_start", lambda: calls.append("prepare"))
     monkeypatch.setattr(cli, "start_service", lambda: calls.append("start") or {"running": True})
     monkeypatch.setattr(cli, "stop_service", lambda: calls.append("stop") or {"running": False})
     cli.run_worker_cli(["start"])
     cli.run_worker_cli(["restart"])
-    assert calls == ["start", "stop", "start"]
+    assert calls == ["prepare", "start", "stop", "prepare", "start"]
 
 
 def test_cli_update_restarts_running_service(tmp_path, monkeypatch, capsys):
@@ -261,20 +260,58 @@ def test_load_config_rejects_non_mapping_legacy_identity(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_connect_enrolls_then_runs(monkeypatch):
+async def test_connect_enrolls_then_reexecs_without_invite(monkeypatch):
     calls = []
+
     async def fake_enroll(**kwargs):
         calls.append(("enroll", kwargs))
-    async def fake_run():
-        calls.append(("run", None))
+
     monkeypatch.setattr(cli, "enroll_worker", fake_enroll)
-    monkeypatch.setattr(cli, "run_enrolled_worker", fake_run)
+    monkeypatch.setattr(cli, "_reexec_worker_run", lambda: calls.append(("reexec", None)))
     args = cli.argparse.Namespace(
         server="https://s", invite="i", invite_stdin=False, name="n", workdir="/w",
         runtime_digest="d", runtime_version="v",
     )
     await cli._connect(args)  # noqa: SLF001
-    assert [item[0] for item in calls] == ["enroll", "run"]
+    assert [item[0] for item in calls] == ["enroll", "reexec"]
+    assert calls[0][1]["invite"] == "i"
+
+
+def test_worker_run_reexec_uses_token_free_argv(monkeypatch):
+    monkeypatch.setattr(cli, "is_frozen_app", lambda: False)
+    assert cli._worker_run_exec_argv() == [  # noqa: SLF001
+        cli.sys.executable,
+        "-m",
+        "local_shell_mcp.main",
+        "worker",
+        "run",
+    ]
+    monkeypatch.setattr(cli, "is_frozen_app", lambda: True)
+    assert cli._worker_run_exec_argv() == [cli.sys.executable, "worker", "run"]  # noqa: SLF001
+
+    calls = []
+    monkeypatch.setattr(cli.os, "execv", lambda executable, argv: calls.append((executable, argv)))
+    cli._reexec_worker_run()  # noqa: SLF001
+    assert calls == [(cli.sys.executable, [cli.sys.executable, "worker", "run"])]
+
+
+def test_prepare_worker_start_installs_runtime_before_launcher(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    state.write_worker_config(server="https://example.test", name="worker", workdir=str(tmp_path))
+    calls = []
+    monkeypatch.setattr(
+        cli,
+        "install_or_update_runtime",
+        lambda server: calls.append(("runtime", server)),
+    )
+    monkeypatch.setattr(cli, "install_launcher", lambda: calls.append(("launcher", None)))
+    monkeypatch.setattr(cli, "ensure_user_bin_on_path", lambda: calls.append(("path", None)))
+    cli._prepare_worker_start()  # noqa: SLF001
+    assert calls == [
+        ("runtime", "https://example.test"),
+        ("launcher", None),
+        ("path", None),
+    ]
 
 
 def test_all_remaining_lifecycle_command_branches(tmp_path, monkeypatch, capsys):

--- a/tests/test_remote_worker_cli.py
+++ b/tests/test_remote_worker_cli.py
@@ -33,6 +33,48 @@ def test_enrollment_payload_restores_temporary_environment(tmp_path, monkeypatch
     assert "LOCAL_SHELL_MCP_ALLOW_FULL_CONTAINER" not in os.environ
 
 
+def test_enrollment_payload_overrides_and_restores_existing_environment(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", "/stale/workspace")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_ALLOW_FULL_CONTAINER", "false")
+
+    def capabilities():
+        assert os.environ["LOCAL_SHELL_MCP_WORKSPACE_ROOT"] == str(tmp_path)
+        assert os.environ["LOCAL_SHELL_MCP_ALLOW_FULL_CONTAINER"] == "true"
+        return ["shell"]
+
+    monkeypatch.setattr(cli.remote, "worker_capabilities", capabilities)
+    monkeypatch.setattr(cli.remote, "worker_info", lambda workdir: {"workdir": workdir})
+    cli._enrollment_payload("worker", str(tmp_path), "invite")  # noqa: SLF001
+    assert os.environ["LOCAL_SHELL_MCP_WORKSPACE_ROOT"] == "/stale/workspace"
+    assert os.environ["LOCAL_SHELL_MCP_ALLOW_FULL_CONTAINER"] == "false"
+
+
+@pytest.mark.asyncio
+async def test_run_worker_overrides_stale_scope(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", "/stale/workspace")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_ALLOW_FULL_CONTAINER", "false")
+    monkeypatch.setattr(cli.remote, "worker_capabilities", lambda: [])
+    monkeypatch.setattr(cli.remote, "worker_info", lambda workdir: {})
+    monkeypatch.setattr(cli.remote, "_read_worker_identity", lambda server, name=None: None)
+    monkeypatch.setattr(cli.remote, "_write_worker_identity", lambda data: None)
+    calls = 0
+
+    async def fake_post(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        assert os.environ["LOCAL_SHELL_MCP_WORKSPACE_ROOT"] == str(tmp_path)
+        assert os.environ["LOCAL_SHELL_MCP_ALLOW_FULL_CONTAINER"] == "true"
+        if calls == 1:
+            return {"ok": True, "data": {"token": "access", "name": "worker"}}
+        raise RuntimeError("stop polling")
+
+    monkeypatch.setattr(cli.remote, "_worker_post_json_forever", fake_post)
+    with pytest.raises(RuntimeError, match="stop polling"):
+        await cli.remote.run_worker(
+            "https://example.test", "invite", workdir=str(tmp_path)
+        )
+
+
 @pytest.mark.asyncio
 async def test_enroll_worker_registers_and_persists(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
@@ -245,7 +287,13 @@ def test_all_remaining_lifecycle_command_branches(tmp_path, monkeypatch, capsys)
     monkeypatch.setattr(cli, "stop_service", lambda: calls.append(("stop", None)) or {"running": False})
     monkeypatch.setattr(cli, "service_status", lambda: {"running": False})
     monkeypatch.setattr(cli, "_load_config_or_migrate", lambda: {"server": "https://s"})
-    monkeypatch.setattr(cli, "install_or_update_runtime", lambda server, force=False: {"updated": False})
+    runtime_installs = []
+    monkeypatch.setattr(
+        cli,
+        "install_or_update_runtime",
+        lambda server, force=False: runtime_installs.append((server, force))
+        or {"updated": False},
+    )
     monkeypatch.setattr(cli, "install_service", lambda start=True: {"service": start})
     monkeypatch.setattr(cli, "uninstall_service", lambda: {"uninstalled": True})
     monkeypatch.setattr(cli, "install_launcher", lambda: tmp_path / "local-shell-mcp")
@@ -263,6 +311,7 @@ def test_all_remaining_lifecycle_command_branches(tmp_path, monkeypatch, capsys)
     assert '"service": false' in output
     assert '"uninstalled": true' in output
     assert str(tmp_path / ".profile") in output
+    assert runtime_installs == [("https://s", False), ("https://s", False)]
 
 
 def test_cli_keyboard_interrupt_is_clean(monkeypatch, capsys):

--- a/tests/test_remote_worker_cli.py
+++ b/tests/test_remote_worker_cli.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from local_shell_mcp import remote_worker_cli as cli
+from local_shell_mcp import remote_worker_state as state
+
+
+def _configure(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKER_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+
+
+def test_enrollment_payload_restores_temporary_environment(tmp_path, monkeypatch):
+    monkeypatch.delenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", raising=False)
+    monkeypatch.delenv("LOCAL_SHELL_MCP_ALLOW_FULL_CONTAINER", raising=False)
+
+    def capabilities():
+        assert os.environ["LOCAL_SHELL_MCP_WORKSPACE_ROOT"] == str(tmp_path)
+        assert os.environ["LOCAL_SHELL_MCP_ALLOW_FULL_CONTAINER"] == "true"
+        return ["shell"]
+
+    monkeypatch.setattr(cli.remote, "worker_capabilities", capabilities)
+    monkeypatch.setattr(cli.remote, "worker_info", lambda workdir: {"workdir": workdir})
+    payload = cli._enrollment_payload("worker", str(tmp_path), "invite")  # noqa: SLF001
+    assert payload["capabilities"] == ["shell"]
+    assert "LOCAL_SHELL_MCP_WORKSPACE_ROOT" not in os.environ
+    assert "LOCAL_SHELL_MCP_ALLOW_FULL_CONTAINER" not in os.environ
+
+
+@pytest.mark.asyncio
+async def test_enroll_worker_registers_and_persists(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setattr(cli.remote, "worker_capabilities", lambda: ["shell"])
+    monkeypatch.setattr(cli.remote, "worker_info", lambda workdir: {"workdir": workdir})
+    monkeypatch.setattr(cli.remote, "_read_worker_identity", lambda server, name=None: None)
+    captured = {}
+    monkeypatch.setattr(
+        cli.remote,
+        "_write_worker_identity",
+        lambda data: captured.update(identity=data),
+    )
+
+    async def fake_post(url, payload, headers=None, timeout=None, operation="request"):
+        assert url.endswith("/remote/register")
+        assert payload["invite"] == "invite"
+        return {"ok": True, "data": {"token": "access", "name": "worker-a"}}
+
+    monkeypatch.setattr(cli.remote, "_worker_post_json_forever", fake_post)
+    result = await cli.enroll_worker(
+        server="https://example.test/",
+        invite="invite",
+        name="worker-a",
+        workdir=str(tmp_path),
+        runtime_digest="abc",
+        runtime_version="3.0.0",
+    )
+    assert result["server"] == "https://example.test"
+    assert result["runtime_digest"] == "abc"
+    assert captured["identity"]["access"] == "access"
+    assert state.read_worker_config()["name"] == "worker-a"
+
+
+@pytest.mark.asyncio
+async def test_enroll_worker_reuses_stored_identity(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setattr(cli.remote, "worker_capabilities", lambda: [])
+    monkeypatch.setattr(cli.remote, "worker_info", lambda workdir: {})
+    monkeypatch.setattr(
+        cli.remote,
+        "_read_worker_identity",
+        lambda server, name=None: {"access": "stored", "name": "worker-a"},
+    )
+    monkeypatch.setattr(cli.remote, "_write_worker_identity", lambda data: None)
+
+    async def fake_resume(url, payload, headers, timeout=None):
+        assert headers["Authorization"] == "Bearer stored"
+        return {"ok": True, "data": {"name": "worker-a"}}
+
+    monkeypatch.setattr(cli.remote, "_worker_resume_or_none", fake_resume)
+    monkeypatch.setattr(
+        cli.remote,
+        "_worker_post_json_forever",
+        lambda *args, **kwargs: pytest.fail("registered again"),
+    )
+    result = await cli.enroll_worker(
+        server="https://example.test", invite="unused", workdir=str(tmp_path)
+    )
+    assert result["name"] == "worker-a"
+
+
+@pytest.mark.asyncio
+async def test_run_enrolled_worker_and_migrate_legacy_identity(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    identity_path = tmp_path / "identity.json"
+    identity_path.write_text(
+        json.dumps(
+            {
+                "server": "https://example.test",
+                "name": "worker-a",
+                "access": "stored",
+                "workdir": str(tmp_path),
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(cli.remote, "_worker_identity_path", lambda: identity_path)
+    monkeypatch.setattr(
+        cli.remote, "_read_worker_identity", lambda server, name=None: {"access": "stored"}
+    )
+    calls = []
+
+    async def fake_run(server, invite, name=None, workdir=None, persist=False):
+        calls.append((server, invite, name, workdir, persist))
+
+    monkeypatch.setattr(cli.remote, "run_worker", fake_run)
+    await cli.run_enrolled_worker()
+    assert calls == [("https://example.test", "", "worker-a", str(tmp_path), False)]
+    assert state.worker_config_path().exists()
+
+
+@pytest.mark.asyncio
+async def test_run_enrolled_worker_rejects_missing_identity(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    state.write_worker_config(server="https://example.test", name="worker", workdir=str(tmp_path))
+    monkeypatch.setattr(cli.remote, "_read_worker_identity", lambda server, name=None: None)
+    with pytest.raises(RuntimeError, match="join command again"):
+        await cli.run_enrolled_worker()
+
+
+def test_cli_legacy_and_lifecycle_dispatch(tmp_path, monkeypatch, capsys):
+    _configure(tmp_path, monkeypatch)
+    legacy = []
+    monkeypatch.setattr(cli.remote, "run_worker_cli", lambda argv: legacy.append(argv))
+    cli.run_worker_cli(["--server", "https://example.test", "--invite", "x"])
+    assert legacy
+
+    monkeypatch.setattr(cli, "service_status", lambda: {"running": True})
+    cli.run_worker_cli(["status"])
+    assert '"running": true' in capsys.readouterr().out
+
+    calls = []
+    monkeypatch.setattr(cli, "install_launcher", lambda: tmp_path / "bin" / "local-shell-mcp")
+    monkeypatch.setattr(cli, "ensure_user_bin_on_path", lambda: [tmp_path / ".profile"])
+    monkeypatch.setattr(cli, "start_service", lambda: calls.append("start") or {"running": True})
+    monkeypatch.setattr(cli, "stop_service", lambda: calls.append("stop") or {"running": False})
+    cli.run_worker_cli(["start"])
+    cli.run_worker_cli(["restart"])
+    assert calls == ["start", "stop", "start"]
+
+
+def test_cli_update_restarts_running_service(tmp_path, monkeypatch, capsys):
+    _configure(tmp_path, monkeypatch)
+    state.write_worker_config(server="https://example.test", name="worker", workdir=str(tmp_path))
+    calls = []
+    monkeypatch.setattr(cli, "service_status", lambda: {"running": True})
+    monkeypatch.setattr(
+        cli,
+        "install_or_update_runtime",
+        lambda server, force=False: {"updated": True, "server": server, "force": force},
+    )
+    monkeypatch.setattr(cli, "stop_service", lambda: calls.append("stop"))
+    monkeypatch.setattr(cli, "start_service", lambda: calls.append("start"))
+    cli.run_worker_cli(["update", "--force"])
+    assert calls == ["stop", "start"]
+    assert '"force": true' in capsys.readouterr().out
+
+
+def test_cli_errors_are_clean(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "_run_command", lambda args: (_ for _ in ()).throw(ValueError("bad")))
+    with pytest.raises(SystemExit) as exc:
+        cli.run_worker_cli(["status"])
+    assert exc.value.code == 1
+    assert "Status: worker command failed: bad" in capsys.readouterr().err
+
+
+def test_read_invite_sources_and_validation(monkeypatch):
+    direct = cli.argparse.Namespace(invite="direct", invite_stdin=False)
+    assert cli._read_invite(direct) == "direct"  # noqa: SLF001
+    monkeypatch.setattr(cli.sys, "stdin", __import__("io").StringIO("from-stdin\n"))
+    stdin = cli.argparse.Namespace(invite=None, invite_stdin=True)
+    assert cli._read_invite(stdin) == "from-stdin"  # noqa: SLF001
+    with pytest.raises(ValueError, match="invite is required"):
+        cli._read_invite(cli.argparse.Namespace(invite="", invite_stdin=False))  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("resume", [False, True])
+async def test_enroll_worker_rejects_unsuccessful_server_response(tmp_path, monkeypatch, resume):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setattr(cli.remote, "worker_capabilities", lambda: [])
+    monkeypatch.setattr(cli.remote, "worker_info", lambda workdir: {})
+    identity = {"access": "stored", "name": "worker-a"} if resume else None
+    monkeypatch.setattr(cli.remote, "_read_worker_identity", lambda server, name=None: identity)
+    if resume:
+        async def failed_resume(*args, **kwargs):
+            return {"ok": False, "message": "resume denied"}
+        monkeypatch.setattr(cli.remote, "_worker_resume_or_none", failed_resume)
+    else:
+        async def failed_register(*args, **kwargs):
+            return {"ok": False, "message": "register denied"}
+        monkeypatch.setattr(cli.remote, "_worker_post_json_forever", failed_register)
+    with pytest.raises(RuntimeError, match="denied"):
+        await cli.enroll_worker(server="https://example.test", invite="invite", workdir=str(tmp_path))
+
+
+def test_load_config_rejects_non_mapping_legacy_identity(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    identity_path = tmp_path / "legacy.json"
+    identity_path.write_text("[]", encoding="utf-8")
+    monkeypatch.setattr(cli.remote, "_worker_identity_path", lambda: identity_path)
+    with pytest.raises(ValueError, match="stored worker identity is invalid"):
+        cli._load_config_or_migrate()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_connect_enrolls_then_runs(monkeypatch):
+    calls = []
+    async def fake_enroll(**kwargs):
+        calls.append(("enroll", kwargs))
+    async def fake_run():
+        calls.append(("run", None))
+    monkeypatch.setattr(cli, "enroll_worker", fake_enroll)
+    monkeypatch.setattr(cli, "run_enrolled_worker", fake_run)
+    args = cli.argparse.Namespace(
+        server="https://s", invite="i", invite_stdin=False, name="n", workdir="/w",
+        runtime_digest="d", runtime_version="v",
+    )
+    await cli._connect(args)  # noqa: SLF001
+    assert [item[0] for item in calls] == ["enroll", "run"]
+
+
+def test_all_remaining_lifecycle_command_branches(tmp_path, monkeypatch, capsys):
+    _configure(tmp_path, monkeypatch)
+    calls = []
+    monkeypatch.setattr(cli.asyncio, "run", lambda value: calls.append(("async", value)) or {"ok": True})
+    monkeypatch.setattr(cli, "enroll_worker", lambda **kwargs: ("enroll", kwargs))
+    monkeypatch.setattr(cli, "_connect", lambda args: ("connect", args.server))
+    monkeypatch.setattr(cli, "run_enrolled_worker", lambda: "run")
+    monkeypatch.setattr(cli, "stop_service", lambda: calls.append(("stop", None)) or {"running": False})
+    monkeypatch.setattr(cli, "service_status", lambda: {"running": False})
+    monkeypatch.setattr(cli, "_load_config_or_migrate", lambda: {"server": "https://s"})
+    monkeypatch.setattr(cli, "install_or_update_runtime", lambda server, force=False: {"updated": False})
+    monkeypatch.setattr(cli, "install_service", lambda start=True: {"service": start})
+    monkeypatch.setattr(cli, "uninstall_service", lambda: {"uninstalled": True})
+    monkeypatch.setattr(cli, "install_launcher", lambda: tmp_path / "local-shell-mcp")
+    monkeypatch.setattr(cli, "ensure_user_bin_on_path", lambda: [tmp_path / ".profile"])
+
+    cli._run_command(cli._parser().parse_args(["enroll", "--server", "https://s", "--invite", "i"]))  # noqa: SLF001
+    cli._run_command(cli._parser().parse_args(["connect", "--server", "https://s", "--invite", "i"]))  # noqa: SLF001
+    cli._run_command(cli._parser().parse_args(["run"]))  # noqa: SLF001
+    cli._run_command(cli._parser().parse_args(["stop"]))  # noqa: SLF001
+    cli._run_command(cli._parser().parse_args(["update"]))  # noqa: SLF001
+    cli._run_command(cli._parser().parse_args(["install-service", "--no-start"]))  # noqa: SLF001
+    cli._run_command(cli._parser().parse_args(["uninstall-service"]))  # noqa: SLF001
+    cli._run_command(cli._parser().parse_args(["install-launcher"]))  # noqa: SLF001
+    output = capsys.readouterr().out
+    assert '"service": false' in output
+    assert '"uninstalled": true' in output
+    assert str(tmp_path / ".profile") in output
+
+
+def test_cli_keyboard_interrupt_is_clean(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "_run_command", lambda args: (_ for _ in ()).throw(KeyboardInterrupt))
+    with pytest.raises(SystemExit) as exc:
+        cli.run_worker_cli(["status"])
+    assert exc.value.code == 130
+    assert "disconnected by user" in capsys.readouterr().err

--- a/tests/test_remote_worker_cli.py
+++ b/tests/test_remote_worker_cli.py
@@ -310,7 +310,7 @@ def test_all_remaining_lifecycle_command_branches(tmp_path, monkeypatch, capsys)
     output = capsys.readouterr().out
     assert '"service": false' in output
     assert '"uninstalled": true' in output
-    assert str(tmp_path / ".profile") in output
+    assert json.dumps(str(tmp_path / ".profile")) in output
     assert runtime_installs == [("https://s", False), ("https://s", False)]
 
 

--- a/tests/test_remote_worker_installer.py
+++ b/tests/test_remote_worker_installer.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import tarfile
+
+import pytest
+
+from local_shell_mcp import remote_worker_installer as installer
+from local_shell_mcp import remote_worker_state as state
+
+
+def _bundle() -> bytes:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+        content = b"value = 1\n"
+        info = tarfile.TarInfo("local_shell_mcp/example.py")
+        info.size = len(content)
+        tar.addfile(info, io.BytesIO(content))
+    return buffer.getvalue()
+
+
+def _configure(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKER_STATE_DIR", str(tmp_path / "state"))
+    state.write_worker_config(server="https://example.test", name="worker", workdir=str(tmp_path))
+
+
+def test_install_update_and_cache_runtime(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    payload = _bundle()
+    digest = hashlib.sha256(payload).hexdigest()
+    monkeypatch.setattr(
+        installer,
+        "fetch_manifest",
+        lambda server: {
+            "schema_version": 1,
+            "sha256": digest,
+            "bundle_version": "3.0.1",
+            "url": "https://example.test/bundle.tgz",
+        },
+    )
+    monkeypatch.setattr(installer, "_fetch_bytes", lambda url, timeout=60: payload)
+
+    result = installer.install_or_update_runtime("https://example.test")
+    assert result["updated"] is True
+    assert (state.worker_runtime_dir() / "local_shell_mcp" / "example.py").exists()
+    assert state.read_worker_config()["runtime_digest"] == digest
+
+    monkeypatch.setattr(installer, "_fetch_bytes", lambda *args, **kwargs: pytest.fail("downloaded"))
+    cached = installer.install_or_update_runtime("https://example.test")
+    assert cached["updated"] is False
+
+
+def test_runtime_checksum_and_archive_validation(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    payload = _bundle()
+    monkeypatch.setattr(
+        installer,
+        "fetch_manifest",
+        lambda server: {
+            "schema_version": 1,
+            "sha256": "0" * 64,
+            "bundle_version": "3.0.1",
+            "url": "https://example.test/bundle.tgz",
+        },
+    )
+    monkeypatch.setattr(installer, "_fetch_bytes", lambda url, timeout=60: payload)
+    with pytest.raises(ValueError, match="checksum mismatch"):
+        installer.install_or_update_runtime("https://example.test")
+
+    archive = tmp_path / "unsafe.tgz"
+    with tarfile.open(archive, mode="w:gz") as tar:
+        info = tarfile.TarInfo("../escape")
+        info.size = 1
+        tar.addfile(info, io.BytesIO(b"x"))
+    with pytest.raises(ValueError, match="unsafe worker bundle path"):
+        installer._safe_extract(archive, tmp_path / "extract")  # noqa: SLF001
+
+    link_archive = tmp_path / "link.tgz"
+    with tarfile.open(link_archive, mode="w:gz") as tar:
+        info = tarfile.TarInfo("local_shell_mcp/link")
+        info.type = tarfile.SYMTYPE
+        info.linkname = "target"
+        tar.addfile(info)
+    with pytest.raises(ValueError, match="links are not supported"):
+        installer._safe_extract(link_archive, tmp_path / "extract-links")  # noqa: SLF001
+
+
+def test_fetch_manifest_validation(monkeypatch):
+    valid = {
+        "schema_version": 1,
+        "sha256": "a" * 64,
+        "bundle_version": "3.0.0",
+        "url": "/remote/worker-bundle.tgz",
+    }
+    requested = []
+
+    def fetch(url):
+        requested.append(url)
+        return json.dumps(valid).encode()
+
+    monkeypatch.setattr(installer, "_fetch_bytes", fetch)
+    result = installer.fetch_manifest("https://example.test/base")
+    assert requested == ["https://example.test/base/remote/worker-bundle.tgz?manifest=1"]
+    assert result["url"] == "https://example.test/remote/worker-bundle.tgz"
+
+    monkeypatch.setattr(installer, "_fetch_bytes", lambda url: b"{}")
+    with pytest.raises(ValueError, match="invalid remote worker manifest"):
+        installer.fetch_manifest("https://example.test")
+
+    incomplete = {"schema_version": 1, "sha256": "short", "url": ""}
+    monkeypatch.setattr(installer, "_fetch_bytes", lambda url: json.dumps(incomplete).encode())
+    with pytest.raises(ValueError, match="manifest is incomplete"):
+        installer.fetch_manifest("https://example.test")
+
+
+def test_fetch_bytes_uses_urlopen(monkeypatch):
+    class Response:
+        def __enter__(self):
+            return self
+        def __exit__(self, *args):
+            return False
+        def read(self):
+            return b"payload"
+    captured = []
+    monkeypatch.setattr(
+        installer.urllib.request,
+        "urlopen",
+        lambda url, timeout=60: captured.append((url, timeout)) or Response(),
+    )
+    assert installer._fetch_bytes("https://example.test/file", timeout=7) == b"payload"  # noqa: SLF001
+    assert captured == [("https://example.test/file", 7)]
+
+
+def test_install_without_existing_config_rejects_incomplete_bundle(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKER_STATE_DIR", str(tmp_path / "state"))
+    payload_buffer = io.BytesIO()
+    with tarfile.open(fileobj=payload_buffer, mode="w:gz") as tar:
+        content = b"not a package"
+        info = tarfile.TarInfo("other.txt")
+        info.size = len(content)
+        tar.addfile(info, io.BytesIO(content))
+    payload = payload_buffer.getvalue()
+    digest = hashlib.sha256(payload).hexdigest()
+    monkeypatch.setattr(
+        installer,
+        "fetch_manifest",
+        lambda server: {"sha256": digest, "bundle_version": "v", "url": "https://s/b.tgz"},
+    )
+    monkeypatch.setattr(installer, "_fetch_bytes", lambda *args, **kwargs: payload)
+    with pytest.raises(ValueError, match="does not contain local_shell_mcp"):
+        installer.install_or_update_runtime("https://s")

--- a/tests/test_remote_worker_routes.py
+++ b/tests/test_remote_worker_routes.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from local_shell_mcp import remote_worker_routes as routes
+from local_shell_mcp.settings import get_settings
+
+
+@pytest.mark.asyncio
+async def test_worker_bundle_and_manifest_are_stable(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_PUBLIC_BASE_URL", "https://example.test")
+    get_settings.cache_clear()
+    routes.worker_bundle_bytes.cache_clear()
+    first = routes.worker_bundle_bytes()
+    routes.worker_bundle_bytes.cache_clear()
+    second = routes.worker_bundle_bytes()
+    assert first == second
+
+    response = await routes.worker_manifest(None)  # type: ignore[arg-type]
+    data = json.loads(response.body)
+    assert data["sha256"] == hashlib.sha256(first).hexdigest()
+    assert data["url"] == "https://example.test/remote/worker-bundle.tgz"
+
+    public_manifest = await routes.worker_bundle(SimpleNamespace(query_params={"manifest": "1"}))
+    assert json.loads(public_manifest.body) == data
+    bundle = await routes.worker_bundle(None)  # type: ignore[arg-type]
+    assert bundle.body == first
+
+
+@pytest.mark.asyncio
+async def test_join_script_caches_bundle_and_removes_invite_from_worker_process(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_PUBLIC_BASE_URL", "https://example.test")
+    get_settings.cache_clear()
+    response = await routes.join_script(None)  # type: ignore[arg-type]
+    script = response.body.decode("utf-8")
+    assert "/remote/worker-bundle.tgz?manifest=1" in script
+    assert "bundle.sha256" in script
+    assert "checksum mismatch" in script
+    assert "install-service" in script
+    assert "install-launcher" in script
+    assert 'export PATH="$HOME/.local/bin:$PATH"' in script
+    assert "--invite-stdin" in script
+    assert "exec python3 -m local_shell_mcp.remote_worker run" in script
+    assert "remote_worker run --invite" not in script
+
+
+def test_remote_routes_replace_worker_bootstrap_endpoints():
+    paths = [route.path for route in routes.remote_routes()]
+    assert paths[:3] == [
+        "/join",
+        "/remote/worker-manifest.json",
+        "/remote/worker-bundle.tgz",
+    ]
+    assert "/remote/register" in paths
+    assert "/remote/resume" in paths

--- a/tests/test_remote_worker_service.py
+++ b/tests/test_remote_worker_service.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from local_shell_mcp import remote_worker_service as service
+
+
+def _configure(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKER_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.setenv("PATH", "/usr/bin")
+
+
+def test_install_and_manage_systemd_service(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    calls = []
+    monkeypatch.setattr(service, "service_kind", lambda: "systemd")
+
+    def fake_run(command, *, check=True):
+        calls.append((command, check))
+        output = "active\n" if "is-active" in command else ""
+        return subprocess.CompletedProcess(command, 0, stdout=output, stderr="")
+
+    monkeypatch.setattr(service, "_run", fake_run)
+    result = service.install_service(start=True)
+    assert result["kind"] == "systemd"
+    assert service._systemd_unit_path().exists()  # noqa: SLF001
+    assert any(command[:3] == ["systemctl", "--user", "enable"] for command, _ in calls)
+
+    status = service.service_status()
+    assert status["installed"] is True
+    assert status["running"] is True
+    service.stop_service()
+    service.start_service()
+    removed = service.uninstall_service()
+    assert removed["uninstalled"] is True
+    assert not service._systemd_unit_path().exists()  # noqa: SLF001
+
+
+def test_systemd_detection_requires_a_working_user_manager(monkeypatch):
+    monkeypatch.setattr(service.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(service.shutil, "which", lambda name: "/usr/bin/systemctl")
+    monkeypatch.setattr(
+        service,
+        "_run",
+        lambda command, check=False: subprocess.CompletedProcess(command, 1, stdout="", stderr="no bus"),
+    )
+    assert service.service_kind() == "process"
+
+
+def test_service_kind_detects_launchd_and_process(monkeypatch):
+    monkeypatch.setattr(service.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(service.shutil, "which", lambda name: "/bin/launchctl")
+    assert service.service_kind() == "launchd"
+    monkeypatch.setattr(service.shutil, "which", lambda name: None)
+    assert service.service_kind() == "process"
+
+
+def test_launchd_install_start_and_status(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    calls = []
+    monkeypatch.setattr(service, "service_kind", lambda: "launchd")
+    monkeypatch.setattr(service.os, "getuid", lambda: 501, raising=False)
+
+    def fake_run(command, *, check=True):
+        calls.append((command, check))
+        return subprocess.CompletedProcess(command, 0, stdout="loaded", stderr="")
+
+    monkeypatch.setattr(service, "_run", fake_run)
+    service.install_service(start=True)
+    assert service._launchd_plist_path().exists()  # noqa: SLF001
+    assert service.service_status()["running"] is True
+    service.start_service()
+    service.stop_service()
+    assert any(command[1] == "bootstrap" for command, _ in calls if command[0] == "launchctl")
+
+
+def test_process_fallback_start_stop_and_stale_pid(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setattr(service, "service_kind", lambda: "process")
+    process = SimpleNamespace(pid=123, terminate=lambda: None)
+    popen_calls = []
+
+    def fake_popen(*args, **kwargs):
+        popen_calls.append((args, kwargs))
+        return process
+
+    monkeypatch.setattr(service.subprocess, "Popen", fake_popen)
+    running = {123: True}
+    monkeypatch.setattr(service, "_pid_is_running", lambda pid: running.get(pid, False))
+    monkeypatch.setattr(
+        service,
+        "_process_identity",
+        lambda pid: "worker-identity" if running.get(pid, False) else None,
+    )
+    signals = []
+
+    def fake_kill(pid, sig):
+        signals.append((pid, sig))
+        running[pid] = False
+
+    monkeypatch.setattr(service.os, "kill", fake_kill)
+    service.install_service(start=True)
+    record = json.loads(service.worker_pid_path().read_text(encoding="utf-8"))
+    assert record == {"identity": "worker-identity", "pid": 123, "version": 1}
+    assert popen_calls[0][0][0][-3:] == ["local_shell_mcp.main", "worker", "run"]
+    assert "PYTHONPATH" in popen_calls[0][1]["env"]
+    assert service.service_status()["running"] is True
+    service.stop_service()
+    assert signals
+    assert not service.worker_pid_path().exists()
+
+    service.worker_pid_path().write_text(
+        json.dumps({"version": 1, "pid": 999, "identity": "old"}), encoding="utf-8"
+    )
+    monkeypatch.setattr(service, "_process_identity", lambda pid: "different")
+    assert service.service_status()["pid"] is None
+    assert not service.worker_pid_path().exists()
+
+
+def test_process_fallback_is_reported_without_native_service_file(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    service.install_launcher()
+    monkeypatch.setattr(service, "service_kind", lambda: "systemd")
+    monkeypatch.setattr(service, "_read_pid", lambda: 77)
+    status = service.service_status()
+    assert status["kind"] == "process"
+    assert status["installed"] is True
+    assert status["running"] is True
+    assert status["pid"] == 77
+
+
+def test_legacy_pid_is_migrated_only_after_identity_verification(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    service.worker_pid_path().parent.mkdir(parents=True)
+    service.worker_pid_path().write_text("42\n", encoding="utf-8")
+    monkeypatch.setattr(service, "_process_identity", lambda pid: "verified")
+    assert service._read_pid() == 42  # noqa: SLF001
+    record = json.loads(service.worker_pid_path().read_text(encoding="utf-8"))
+    assert record["identity"] == "verified"
+
+
+def test_process_identity_helpers(monkeypatch):
+    monkeypatch.setattr(service, "_is_worker_command", lambda command: True)
+    if service.Path("/proc").is_dir():
+        identity = service._linux_process_identity(os.getpid())  # noqa: SLF001
+        assert identity and identity.startswith("linux:")
+
+    monkeypatch.setattr(
+        service,
+        "_run",
+        lambda command, check=False: subprocess.CompletedProcess(
+            command,
+            0,
+            stdout="Mon Jul 16 12:00:00 2026 python -m local_shell_mcp.main worker run\n",
+            stderr="",
+        ),
+    )
+    assert service._posix_process_identity(10).startswith("posix:")  # noqa: SLF001
+
+    monkeypatch.setattr(service.shutil, "which", lambda name: "powershell")
+    monkeypatch.setattr(
+        service,
+        "_run",
+        lambda command, check=False: subprocess.CompletedProcess(
+            command,
+            0,
+            stdout="20260716120000|python -m local_shell_mcp.main worker run\n",
+            stderr="",
+        ),
+    )
+    assert service._windows_process_identity(10).startswith("windows:")  # noqa: SLF001
+
+
+def test_process_identity_dispatch_and_rejections(monkeypatch):
+    monkeypatch.setattr(service, "_pid_is_running", lambda pid: False)
+    assert service._process_identity(1) is None  # noqa: SLF001
+    monkeypatch.setattr(service, "_pid_is_running", lambda pid: True)
+    monkeypatch.setattr(service.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(service, "_windows_process_identity", lambda pid: "windows-id")
+    assert service._process_identity(1) == "windows-id"  # noqa: SLF001
+    monkeypatch.setattr(service.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(service, "_posix_process_identity", lambda pid: "posix-id")
+    assert service._process_identity(1) == "posix-id"  # noqa: SLF001
+
+
+def test_start_process_rejects_unverifiable_child(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    terminated = []
+    process = SimpleNamespace(pid=55, terminate=lambda: terminated.append(True))
+    monkeypatch.setattr(service, "_read_pid", lambda: None)
+    monkeypatch.setattr(service.subprocess, "Popen", lambda *args, **kwargs: process)
+    monkeypatch.setattr(service, "_process_identity", lambda pid: None)
+    monkeypatch.setattr(service.time, "sleep", lambda delay: None)
+    with pytest.raises(RuntimeError, match="could not be verified"):
+        service._start_process()  # noqa: SLF001
+    assert terminated
+
+
+def test_low_level_service_helpers(monkeypatch):
+    captured = []
+    monkeypatch.setattr(
+        service.subprocess,
+        "run",
+        lambda command, **kwargs: captured.append((command, kwargs))
+        or subprocess.CompletedProcess(command, 0, stdout="ok", stderr=""),
+    )
+    assert service._run(["tool"]).stdout == "ok"  # noqa: SLF001
+    assert captured[0][1]["capture_output"] is True
+
+    monkeypatch.delattr(service.os, "getuid", raising=False)
+    assert service._user_id() == 0  # noqa: SLF001
+    monkeypatch.setattr(service.shutil, "which", lambda name: None)
+    assert service._systemd_user_available() is False  # noqa: SLF001
+
+    monkeypatch.setattr(service.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(service, "_systemd_user_available", lambda: True)
+    assert service.service_kind() == "systemd"
+
+
+def test_pid_and_command_validation(monkeypatch):
+    assert service._pid_is_running(0) is False  # noqa: SLF001
+    monkeypatch.setattr(service.os, "kill", lambda pid, sig: None)
+    assert service._pid_is_running(3) is True  # noqa: SLF001
+    monkeypatch.setattr(service.os, "kill", lambda pid, sig: (_ for _ in ()).throw(OSError()))
+    assert service._pid_is_running(3) is False  # noqa: SLF001
+
+    assert service._is_worker_command("python -m local_shell_mcp.main worker run") is True  # noqa: SLF001
+    assert service._is_worker_command("python -m local_shell_mcp.remote_worker run") is True  # noqa: SLF001
+    assert service._is_worker_command("python something else") is False  # noqa: SLF001
+
+
+def test_process_identity_failure_branches(tmp_path, monkeypatch):
+    monkeypatch.setattr(service, "Path", lambda value: tmp_path / str(value).lstrip("/"))
+    assert service._linux_process_identity(1) is None  # noqa: SLF001
+
+    proc = tmp_path / "proc" / "2"
+    proc.mkdir(parents=True)
+    (proc / "stat").write_text("invalid", encoding="utf-8")
+    (proc / "cmdline").write_bytes(b"not-worker\0")
+    assert service._linux_process_identity(2) is None  # noqa: SLF001
+
+    (proc / "stat").write_text("2 (worker) S short", encoding="utf-8")
+    (proc / "cmdline").write_bytes(b"python\0-m\0local_shell_mcp.main\0worker\0run\0")
+    assert service._linux_process_identity(2) is None  # noqa: SLF001
+
+    monkeypatch.setattr(service.shutil, "which", lambda name: None)
+    assert service._windows_process_identity(1) is None  # noqa: SLF001
+    monkeypatch.setattr(service.shutil, "which", lambda name: "powershell")
+    monkeypatch.setattr(
+        service,
+        "_run",
+        lambda *args, **kwargs: subprocess.CompletedProcess([], 1, stdout="", stderr="bad"),
+    )
+    assert service._windows_process_identity(1) is None  # noqa: SLF001
+    monkeypatch.setattr(
+        service,
+        "_run",
+        lambda *args, **kwargs: subprocess.CompletedProcess([], 0, stdout="|not-worker", stderr=""),
+    )
+    assert service._windows_process_identity(1) is None  # noqa: SLF001
+    assert service._posix_process_identity(1) is None  # noqa: SLF001
+
+
+def test_read_pid_missing_and_malformed(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    assert service._read_pid() is None  # noqa: SLF001
+    service.worker_pid_path().parent.mkdir(parents=True)
+    service.worker_pid_path().write_text("not-json-or-pid", encoding="utf-8")
+    assert service._read_pid() is None  # noqa: SLF001
+    assert not service.worker_pid_path().exists()
+
+
+def test_start_process_returns_when_already_running(monkeypatch):
+    monkeypatch.setattr(service, "_read_pid", lambda: 99)
+    monkeypatch.setattr(service.subprocess, "Popen", lambda *args, **kwargs: pytest.fail("spawned"))
+    service._start_process()  # noqa: SLF001
+
+
+def test_windows_process_start_branch(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    process = SimpleNamespace(pid=77, terminate=lambda: None)
+    captured = []
+    monkeypatch.setattr(service, "_read_pid", lambda: None)
+    monkeypatch.setattr(
+        service,
+        "os",
+        SimpleNamespace(name="nt", environ=os.environ, pathsep=os.pathsep),
+    )
+    monkeypatch.setattr(service.subprocess, "CREATE_NEW_PROCESS_GROUP", 1, raising=False)
+    monkeypatch.setattr(service.subprocess, "DETACHED_PROCESS", 2, raising=False)
+    monkeypatch.setattr(
+        service.subprocess,
+        "Popen",
+        lambda *args, **kwargs: captured.append(kwargs) or process,
+    )
+    monkeypatch.setattr(service, "_process_identity", lambda pid: "verified")
+    written = []
+    monkeypatch.setattr(service, "_write_pid", lambda pid, identity: written.append((pid, identity)))
+    service._start_process()  # noqa: SLF001
+    assert captured[0]["creationflags"] == 3
+    assert "start_new_session" not in captured[0]
+    assert written == [(77, "verified")]
+
+
+def test_stop_process_force_kills_only_verified_pid(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setattr(service, "_read_pid", lambda: 42)
+    monkeypatch.setattr(service, "_pid_is_running", lambda pid: True)
+    monkeypatch.setattr(service.time, "sleep", lambda delay: None)
+    signals = []
+    monkeypatch.setattr(service.os, "kill", lambda pid, sig: signals.append((pid, sig)))
+    service._stop_process()  # noqa: SLF001
+    assert len(signals) == 2
+
+
+def test_install_without_start_and_launchd_retry_paths(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setattr(service, "install_launcher", lambda: tmp_path / "launcher")
+    monkeypatch.setattr(service, "ensure_user_bin_on_path", lambda: [])
+    monkeypatch.setattr(service, "_stop_process", lambda: None)
+    calls = []
+    monkeypatch.setattr(
+        service,
+        "_run",
+        lambda command, check=True: calls.append((command, check))
+        or subprocess.CompletedProcess(command, 1 if "kickstart" in command else 0, stdout="", stderr=""),
+    )
+
+    monkeypatch.setattr(service, "service_kind", lambda: "systemd")
+    result = service.install_service(start=False)
+    assert result["started"] is False
+    assert not any("--now" in command for command, _ in calls)
+
+    monkeypatch.setattr(service, "service_kind", lambda: "launchd")
+    service._write_launchd_plist()  # noqa: SLF001
+    service.start_service()
+    assert any(command[1] == "bootstrap" for command, _ in calls if command[0] == "launchctl")
+
+
+def test_uninstall_removes_launchd_plist(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setattr(service, "service_kind", lambda: "process")
+    monkeypatch.setattr(service, "stop_service", lambda: {})
+    plist = service._write_launchd_plist()  # noqa: SLF001
+    assert plist.exists()
+    service.uninstall_service()
+    assert not plist.exists()

--- a/tests/test_remote_worker_service.py
+++ b/tests/test_remote_worker_service.py
@@ -124,6 +124,16 @@ def test_process_fallback_start_stop_and_stale_pid(tmp_path, monkeypatch):
     assert not service.worker_pid_path().exists()
 
 
+def test_process_environment_scrubs_inherited_worker_scope(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", "/stale/workspace")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_ALLOW_FULL_CONTAINER", "false")
+    env = service._process_environment()  # noqa: SLF001
+    assert "LOCAL_SHELL_MCP_WORKSPACE_ROOT" not in env
+    assert "LOCAL_SHELL_MCP_ALLOW_FULL_CONTAINER" not in env
+    assert env["LOCAL_SHELL_MCP_WORKER_STATE_DIR"] == str((tmp_path / "state").resolve())
+
+
 def test_process_fallback_is_reported_without_native_service_file(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
     service.install_launcher()

--- a/tests/test_remote_worker_state.py
+++ b/tests/test_remote_worker_state.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from local_shell_mcp import remote_worker_state as state
+
+
+def _configure(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKER_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.delenv("LOCAL_SHELL_MCP_WORKER_BIN_DIR", raising=False)
+
+
+def test_worker_config_round_trip_and_runtime_metadata(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    written = state.write_worker_config(
+        server="https://example.test/",
+        name="worker-a",
+        workdir="/workspace",
+        runtime_digest="abc",
+        runtime_version="3.0.0",
+    )
+
+    assert written["server"] == "https://example.test"
+    assert state.read_worker_config() == written
+    updated = state.update_runtime_metadata("def", "3.0.1")
+    assert updated["runtime_digest"] == "def"
+    assert json.loads(state.worker_config_path().read_text(encoding="utf-8"))["runtime_version"] == "3.0.1"
+    if os.name != "nt":
+        assert stat.S_IMODE(state.worker_config_path().stat().st_mode) == 0o600
+
+
+def test_worker_config_validation(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    state.worker_config_path().parent.mkdir(parents=True)
+    state.worker_config_path().write_text('{"version": 2}', encoding="utf-8")
+    try:
+        state.read_worker_config()
+    except ValueError as exc:
+        assert "invalid worker config" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected invalid config")
+
+
+def test_install_launcher_and_path_configuration_are_idempotent(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setattr(state, "_is_windows", lambda: False)
+    monkeypatch.setenv("PATH", "/usr/bin")
+    launcher = state.install_launcher()
+    script = launcher.read_text(encoding="utf-8")
+    assert str(state.worker_state_dir().resolve()) in script
+    assert str(Path(sys.executable).resolve()) in script
+    assert "-m local_shell_mcp.main" in script
+    if os.name != "nt":
+        assert stat.S_IMODE(launcher.stat().st_mode) == 0o755
+
+    private_bashrc = tmp_path / ".bashrc"
+    private_bashrc.write_text("# private\n", encoding="utf-8")
+    private_bashrc.chmod(0o600)
+    changed = state.ensure_user_bin_on_path("bash")
+    assert changed == [tmp_path / ".profile", private_bashrc]
+    assert str(tmp_path / ".local" / "bin") == os.environ["PATH"].split(os.pathsep)[0]
+    assert state.ensure_user_bin_on_path("bash") == []
+    assert private_bashrc.read_text(encoding="utf-8").count("# local-shell-mcp") == 1
+    if os.name != "nt":
+        assert stat.S_IMODE(private_bashrc.stat().st_mode) == 0o600
+
+
+def test_custom_bin_path_is_written_to_shell_profile(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setattr(state, "_is_windows", lambda: False)
+    custom = tmp_path / "commands"
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKER_BIN_DIR", str(custom))
+    state.ensure_user_bin_on_path("sh")
+    profile = (tmp_path / ".profile").read_text(encoding="utf-8")
+    assert str(custom) in profile
+
+
+def test_fish_path_configuration(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setattr(state, "_is_windows", lambda: False)
+    changed = state.ensure_user_bin_on_path("fish")
+    fish = tmp_path / ".config" / "fish" / "config.fish"
+    assert fish in changed
+    assert "fish_add_path" in fish.read_text(encoding="utf-8")
+
+
+def test_windows_launcher_and_user_path(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setattr(state, "_is_windows", lambda: True)
+    monkeypatch.setattr(state.os, "pathsep", ";")
+    launcher = state.install_launcher()
+    assert launcher.name == "local-shell-mcp.cmd"
+    script = launcher.read_text(encoding="utf-8")
+    assert "@echo off" in script
+    assert str(state.worker_state_dir().resolve()) in script
+    assert str(Path(sys.executable).resolve()) in script
+
+    stored = {"Path": ("C:\\Windows", 2)}
+    writes = []
+
+    class Key:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    def query_value(_key, name):
+        if name not in stored:
+            raise FileNotFoundError
+        return stored[name]
+
+    def set_value(_key, name, _reserved, value_type, value):
+        stored[name] = (value, value_type)
+        writes.append(value)
+
+    fake_winreg = SimpleNamespace(
+        HKEY_CURRENT_USER=object(),
+        KEY_QUERY_VALUE=1,
+        KEY_SET_VALUE=2,
+        REG_EXPAND_SZ=2,
+        CreateKeyEx=lambda *args: Key(),
+        QueryValueEx=query_value,
+        SetValueEx=set_value,
+    )
+    monkeypatch.setitem(sys.modules, "winreg", fake_winreg)
+    monkeypatch.setenv("PATH", "C:\\Windows")
+    assert state.ensure_user_bin_on_path() == []
+    assert writes and str(launcher.parent) in writes[-1]
+
+
+def test_user_home_falls_back_to_userprofile(tmp_path, monkeypatch):
+    monkeypatch.delenv("HOME", raising=False)
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    assert state.user_home() == tmp_path


### PR DESCRIPTION
## Summary

- add a deterministic remote-worker bundle manifest with SHA-256 verification
- cache persistent worker runtimes and update them atomically only when the digest changes
- split one-time enrollment from long-running reconnects so invite tokens do not remain in worker process arguments
- add `worker run/start/stop/restart/status/update` and service installation commands
- support systemd user services, launchd agents, and a background-process fallback
- install `local-shell-mcp` into `~/.local/bin` and idempotently add that directory to the current user's shell PATH configuration
- preserve the legacy `local-shell-mcp worker --server ... --invite ...` invocation

Closes #10