### PR TITLE
feat: make persistent remote workers installable and manageable

### DIFF
--- a/src/local_shell_mcp/main.py
+++ b/src/local_shell_mcp/main.py
@@ -22,8 +22,8 @@ def _with_oauth_routes(inner_app):  # noqa: ANN001
         oauth_server_metadata,
         oauth_token,
     )
-    from .remote import remote_routes
     from .settings import get_settings
+    from .worker_lifecycle import remote_routes
 
     @asynccontextmanager
     async def lifespan(app):  # noqa: ANN001
@@ -130,7 +130,7 @@ def main(argv: list[str] | None = None) -> None:
         run_job_runner_cli(argv[1:])
         return
     if argv and argv[0] == "worker":
-        from .remote import run_worker_cli
+        from .worker_lifecycle import run_worker_cli
 
         run_worker_cli(argv[1:])
         return
@@ -153,8 +153,16 @@ def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="local-shell-mcp")
     parser.add_argument("--mode", choices=["mcp", "http", "stdio"], default=None)
     parser.add_argument("--config", default=None, help="Path to config YAML")
-    parser.add_argument("--remote", dest="remote", action="store_true", default=None, help="Enable remote worker mode (default)")
-    parser.add_argument("--no-remote", dest="remote", action="store_false", help="Disable remote worker mode")
+    parser.add_argument(
+        "--remote",
+        dest="remote",
+        action="store_true",
+        default=None,
+        help="Enable remote worker mode (default)",
+    )
+    parser.add_argument(
+        "--no-remote", dest="remote", action="store_false", help="Disable remote worker mode"
+    )
     args = parser.parse_args(argv)
     if args.config:
         os.environ["LOCAL_SHELL_MCP_CONFIG"] = args.config

--- a/src/local_shell_mcp/remote_worker.py
+++ b/src/local_shell_mcp/remote_worker.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 
-from .remote import run_worker_cli
+from .worker_lifecycle import run_worker_cli
 
 if __name__ == "__main__":
     run_worker_cli(sys.argv[1:])

--- a/src/local_shell_mcp/worker_lifecycle.py
+++ b/src/local_shell_mcp/worker_lifecycle.py
@@ -6,11 +6,11 @@ import contextlib
 import hashlib
 import json
 import os
-import platform
 import shlex
 import signal
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -22,6 +22,7 @@ from .remote import (
     _write_worker_identity,
     remote_routes as legacy_remote_routes,
     run_worker,
+    run_worker_cli as legacy_run_worker_cli,
     worker_bundle,
     worker_capabilities,
     worker_info,
@@ -124,8 +125,7 @@ def start_worker() -> int:
     env = os.environ.copy()
     current = env.get("PYTHONPATH", "")
     env["PYTHONPATH"] = _runtime_pythonpath() + (os.pathsep + current if current else "")
-    log = worker_log_path().open("ab")
-    try:
+    with worker_log_path().open("ab") as log:
         process = subprocess.Popen(
             _worker_command(),
             stdin=subprocess.DEVNULL,
@@ -134,8 +134,6 @@ def start_worker() -> int:
             start_new_session=True,
             env=env,
         )
-    finally:
-        log.close()
     worker_pid_path().write_text(str(process.pid), encoding="utf-8")
     return process.pid
 
@@ -146,10 +144,8 @@ def stop_worker(timeout_s: float = 10.0) -> bool:
         return False
     with contextlib.suppress(ProcessLookupError):
         os.kill(pid, signal.SIGTERM)
-    deadline = asyncio.get_event_loop_policy().get_event_loop().time() + timeout_s
-    while _pid_is_running(pid) and asyncio.get_event_loop_policy().get_event_loop().time() < deadline:
-        import time
-
+    deadline = time.monotonic() + timeout_s
+    while _pid_is_running(pid) and time.monotonic() < deadline:
         time.sleep(0.05)
     if _pid_is_running(pid):
         with contextlib.suppress(ProcessLookupError):
@@ -159,9 +155,8 @@ def stop_worker(timeout_s: float = 10.0) -> bool:
 
 
 def worker_status() -> dict[str, Any]:
-    config: dict[str, Any] | None
     try:
-        config = read_worker_config()
+        config: dict[str, Any] | None = read_worker_config()
     except RuntimeError:
         config = None
     pid = read_worker_pid()
@@ -198,12 +193,7 @@ async def enroll_worker(server: str, invite: str, name: str | None, workdir: str
     _write_worker_identity(
         {"server": server, "name": machine_name, "access": access, "workdir": workdir}
     )
-    config = {
-        "version": 1,
-        "server": server,
-        "name": machine_name,
-        "workdir": workdir,
-    }
+    config = {"version": 1, "server": server, "name": machine_name, "workdir": workdir}
     write_worker_config(config)
     return config
 
@@ -222,10 +212,10 @@ async def run_installed_worker() -> None:
 async def worker_manifest(request: Any):  # noqa: ARG001, ANN201
     from starlette.responses import JSONResponse
 
-    response = await worker_bundle(request)
-    payload = bytes(response.body)
     from . import __version__
 
+    response = await worker_bundle(request)
+    payload = bytes(response.body)
     return JSONResponse(
         {
             "schema_version": 1,
@@ -238,10 +228,9 @@ async def worker_manifest(request: Any):  # noqa: ARG001, ANN201
 
 
 def _join_script(server: str) -> str:
-    quoted_server = shlex.quote(server)
     return f'''#!/usr/bin/env bash
 set -euo pipefail
-SERVER={quoted_server}
+SERVER={shlex.quote(server)}
 BUNDLE_URL="$SERVER{REMOTE_WORKER_BUNDLE_PATH}"
 MANIFEST_URL="$SERVER{WORKER_MANIFEST_PATH}"
 INVITE=""
@@ -269,9 +258,9 @@ trap 'rm -rf "$TMPDIR"' EXIT
 if [ "$PERSIST" = "1" ]; then
   STATE_HOME="${{XDG_STATE_HOME:-$HOME/.local/state}}/local-shell-mcp-worker"
   RUNTIME="$STATE_HOME/runtime"
-  MANIFEST="$TMPDIR/manifest.json"
-  curl -fsSL "$MANIFEST_URL" -o "$MANIFEST"
-  EXPECTED="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["sha256"])' "$MANIFEST")"
+  mkdir -p "$STATE_HOME"
+  curl -fsSL "$MANIFEST_URL" -o "$TMPDIR/manifest.json"
+  EXPECTED="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["sha256"])' "$TMPDIR/manifest.json")"
   CURRENT="$(cat "$STATE_HOME/runtime.sha256" 2>/dev/null || true)"
   if [ "$CURRENT" != "$EXPECTED" ] || [ ! -d "$RUNTIME/local_shell_mcp" ]; then
     echo "Downloading worker bundle..." >&2
@@ -292,9 +281,9 @@ if [ "$PERSIST" = "1" ]; then
   mkdir -p "$BIN_DIR"
   cat > "$BIN_DIR/local-shell-mcp" <<'EOF'
 #!/bin/sh
-STATE_HOME="${{XDG_STATE_HOME:-$HOME/.local/state}}/local-shell-mcp-worker"
-export PYTHONPATH="$STATE_HOME/runtime:$STATE_HOME/runtime/vendor${{PYTHONPATH:+:$PYTHONPATH}}"
-exec python3 -m local_shell_mcp "$@"
+STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}/local-shell-mcp-worker"
+export PYTHONPATH="$STATE_HOME/runtime:$STATE_HOME/runtime/vendor${PYTHONPATH:+:$PYTHONPATH}"
+exec python3 -m local_shell_mcp.main "$@"
 EOF
   chmod 755 "$BIN_DIR/local-shell-mcp"
   PATH_LINE='export PATH="$HOME/.local/bin:$PATH"'
@@ -346,12 +335,12 @@ async def join_script(request: Any):  # noqa: ARG001, ANN201
 def remote_routes() -> list[Any]:
     from starlette.routing import Route
 
-    routes = []
-    for route in legacy_remote_routes():
-        if getattr(route, "path", None) == REMOTE_JOIN_PATH:
-            routes.append(Route(REMOTE_JOIN_PATH, join_script, methods=["GET"]))
-        else:
-            routes.append(route)
+    routes = [
+        Route(REMOTE_JOIN_PATH, join_script, methods=["GET"])
+        if getattr(route, "path", None) == REMOTE_JOIN_PATH
+        else route
+        for route in legacy_remote_routes()
+    ]
     routes.append(Route(WORKER_MANIFEST_PATH, worker_manifest, methods=["GET"]))
     return routes
 
@@ -370,20 +359,20 @@ def _print_status(status: dict[str, Any]) -> None:
 
 
 def run_worker_cli(argv: list[str] | None = None) -> None:
+    argv = list(argv or [])
+    if argv and argv[0].startswith("-"):
+        legacy_run_worker_cli(argv)
+        return
+
     parser = argparse.ArgumentParser(description="Manage the local-shell-mcp remote worker")
     subparsers = parser.add_subparsers(dest="command", required=True)
-
     enroll = subparsers.add_parser("enroll")
     enroll.add_argument("--server", required=True)
     enroll.add_argument("--invite", required=True)
     enroll.add_argument("--name", default=None)
     enroll.add_argument("--workdir", default=os.getcwd())
-
-    subparsers.add_parser("run")
-    subparsers.add_parser("start")
-    subparsers.add_parser("stop")
-    subparsers.add_parser("restart")
-    subparsers.add_parser("status")
+    for command in ("run", "start", "stop", "restart", "status"):
+        subparsers.add_parser(command)
 
     args = parser.parse_args(argv)
     try:

--- a/src/local_shell_mcp/worker_lifecycle.py
+++ b/src/local_shell_mcp/worker_lifecycle.py
@@ -25,8 +25,12 @@ from .remote import (
     worker_capabilities,
     worker_info,
 )
-from .remote import remote_routes as legacy_remote_routes
-from .remote import run_worker_cli as legacy_run_worker_cli
+from .remote import (
+    remote_routes as legacy_remote_routes,
+)
+from .remote import (
+    run_worker_cli as legacy_run_worker_cli,
+)
 
 WORKER_MANIFEST_PATH = "/remote/worker-manifest.json"
 WORKER_CONFIG_FILE_NAME = "config.json"

--- a/src/local_shell_mcp/worker_lifecycle.py
+++ b/src/local_shell_mcp/worker_lifecycle.py
@@ -1,0 +1,423 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import hashlib
+import json
+import os
+import platform
+import shlex
+import signal
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from .remote import (
+    REMOTE_API_PREFIX,
+    REMOTE_JOIN_PATH,
+    REMOTE_WORKER_BUNDLE_PATH,
+    _worker_post_json_forever,
+    _write_worker_identity,
+    remote_routes as legacy_remote_routes,
+    run_worker,
+    worker_bundle,
+    worker_capabilities,
+    worker_info,
+)
+
+WORKER_MANIFEST_PATH = "/remote/worker-manifest.json"
+WORKER_CONFIG_FILE_NAME = "config.json"
+WORKER_PID_FILE_NAME = "worker.pid"
+WORKER_LOG_FILE_NAME = "worker.log"
+PATH_MARKER = "# local-shell-mcp user bin"
+
+
+def worker_state_dir() -> Path:
+    configured = os.getenv("LOCAL_SHELL_MCP_WORKER_STATE_DIR")
+    if configured:
+        return Path(configured).expanduser()
+    xdg_state_home = os.getenv("XDG_STATE_HOME")
+    if xdg_state_home:
+        return Path(xdg_state_home).expanduser() / "local-shell-mcp-worker"
+    return Path.home() / ".local" / "state" / "local-shell-mcp-worker"
+
+
+def worker_config_path() -> Path:
+    return worker_state_dir() / WORKER_CONFIG_FILE_NAME
+
+
+def worker_pid_path() -> Path:
+    return worker_state_dir() / WORKER_PID_FILE_NAME
+
+
+def worker_log_path() -> Path:
+    return worker_state_dir() / WORKER_LOG_FILE_NAME
+
+
+def read_worker_config() -> dict[str, Any]:
+    path = worker_config_path()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise RuntimeError("worker is not installed; run the persistent join command first") from exc
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"worker configuration is unreadable: {path}") from exc
+    if not isinstance(data, dict) or int(data.get("version") or 0) != 1:
+        raise RuntimeError(f"unsupported worker configuration: {path}")
+    for key in ("server", "name", "workdir"):
+        if not str(data.get(key) or "").strip():
+            raise RuntimeError(f"worker configuration is missing {key}: {path}")
+    return data
+
+
+def write_worker_config(data: dict[str, Any]) -> None:
+    path = worker_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+    with contextlib.suppress(OSError):
+        tmp.chmod(0o600)
+    tmp.replace(path)
+
+
+def _pid_is_running(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def read_worker_pid() -> int | None:
+    try:
+        pid = int(worker_pid_path().read_text(encoding="utf-8").strip())
+    except (FileNotFoundError, OSError, ValueError):
+        return None
+    if _pid_is_running(pid):
+        return pid
+    worker_pid_path().unlink(missing_ok=True)
+    return None
+
+
+def _runtime_pythonpath() -> str:
+    root = worker_state_dir() / "runtime"
+    return os.pathsep.join((str(root), str(root / "vendor")))
+
+
+def _worker_command() -> list[str]:
+    return [sys.executable, "-m", "local_shell_mcp.remote_worker", "run"]
+
+
+def start_worker() -> int:
+    existing = read_worker_pid()
+    if existing:
+        return existing
+    read_worker_config()
+    state = worker_state_dir()
+    state.mkdir(parents=True, exist_ok=True)
+    env = os.environ.copy()
+    current = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = _runtime_pythonpath() + (os.pathsep + current if current else "")
+    log = worker_log_path().open("ab")
+    try:
+        process = subprocess.Popen(
+            _worker_command(),
+            stdin=subprocess.DEVNULL,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+            env=env,
+        )
+    finally:
+        log.close()
+    worker_pid_path().write_text(str(process.pid), encoding="utf-8")
+    return process.pid
+
+
+def stop_worker(timeout_s: float = 10.0) -> bool:
+    pid = read_worker_pid()
+    if not pid:
+        return False
+    with contextlib.suppress(ProcessLookupError):
+        os.kill(pid, signal.SIGTERM)
+    deadline = asyncio.get_event_loop_policy().get_event_loop().time() + timeout_s
+    while _pid_is_running(pid) and asyncio.get_event_loop_policy().get_event_loop().time() < deadline:
+        import time
+
+        time.sleep(0.05)
+    if _pid_is_running(pid):
+        with contextlib.suppress(ProcessLookupError):
+            os.kill(pid, signal.SIGKILL)
+    worker_pid_path().unlink(missing_ok=True)
+    return True
+
+
+def worker_status() -> dict[str, Any]:
+    config: dict[str, Any] | None
+    try:
+        config = read_worker_config()
+    except RuntimeError:
+        config = None
+    pid = read_worker_pid()
+    return {
+        "installed": config is not None,
+        "running": pid is not None,
+        "pid": pid,
+        "server": config.get("server") if config else None,
+        "name": config.get("name") if config else None,
+        "workdir": config.get("workdir") if config else None,
+        "state_dir": str(worker_state_dir()),
+        "log": str(worker_log_path()),
+    }
+
+
+async def enroll_worker(server: str, invite: str, name: str | None, workdir: str) -> dict[str, Any]:
+    server = server.rstrip("/")
+    workdir = str(Path(workdir).expanduser().resolve())
+    payload = {
+        "invite": invite,
+        "name": name,
+        "workdir": workdir,
+        "capabilities": worker_capabilities(),
+        "info": worker_info(workdir),
+    }
+    body = await _worker_post_json_forever(
+        f"{server}{REMOTE_API_PREFIX}/register", payload, None, 30, "register"
+    )
+    if not body.get("ok"):
+        raise RuntimeError(body.get("message") or body)
+    data = body["data"]
+    access = str(data["token"])
+    machine_name = str(data["name"])
+    _write_worker_identity(
+        {"server": server, "name": machine_name, "access": access, "workdir": workdir}
+    )
+    config = {
+        "version": 1,
+        "server": server,
+        "name": machine_name,
+        "workdir": workdir,
+    }
+    write_worker_config(config)
+    return config
+
+
+async def run_installed_worker() -> None:
+    config = read_worker_config()
+    await run_worker(
+        str(config["server"]),
+        "",
+        str(config["name"]),
+        str(config["workdir"]),
+        False,
+    )
+
+
+async def worker_manifest(request: Any):  # noqa: ARG001, ANN201
+    from starlette.responses import JSONResponse
+
+    response = await worker_bundle(request)
+    payload = bytes(response.body)
+    from . import __version__
+
+    return JSONResponse(
+        {
+            "schema_version": 1,
+            "bundle_version": __version__,
+            "sha256": hashlib.sha256(payload).hexdigest(),
+            "size": len(payload),
+            "url": REMOTE_WORKER_BUNDLE_PATH,
+        }
+    )
+
+
+def _join_script(server: str) -> str:
+    quoted_server = shlex.quote(server)
+    return f'''#!/usr/bin/env bash
+set -euo pipefail
+SERVER={quoted_server}
+BUNDLE_URL="$SERVER{REMOTE_WORKER_BUNDLE_PATH}"
+MANIFEST_URL="$SERVER{WORKER_MANIFEST_PATH}"
+INVITE=""
+NAME=""
+WORKDIR=""
+BACKGROUND=0
+PERSIST=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --invite) INVITE="${{2:-}}"; shift 2 ;;
+    --name) NAME="${{2:-}}"; shift 2 ;;
+    --workdir) WORKDIR="${{2:-}}"; shift 2 ;;
+    --background) BACKGROUND=1; shift ;;
+    --persist) PERSIST=1; shift ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+[ -n "$INVITE" ] || {{ echo "--invite is required" >&2; exit 2; }}
+[ -n "$WORKDIR" ] || WORKDIR="$PWD"
+command -v python3 >/dev/null 2>&1 || {{ echo "python3 is required" >&2; exit 2; }}
+command -v curl >/dev/null 2>&1 || {{ echo "curl is required" >&2; exit 2; }}
+command -v tar >/dev/null 2>&1 || {{ echo "tar is required" >&2; exit 2; }}
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+if [ "$PERSIST" = "1" ]; then
+  STATE_HOME="${{XDG_STATE_HOME:-$HOME/.local/state}}/local-shell-mcp-worker"
+  RUNTIME="$STATE_HOME/runtime"
+  MANIFEST="$TMPDIR/manifest.json"
+  curl -fsSL "$MANIFEST_URL" -o "$MANIFEST"
+  EXPECTED="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["sha256"])' "$MANIFEST")"
+  CURRENT="$(cat "$STATE_HOME/runtime.sha256" 2>/dev/null || true)"
+  if [ "$CURRENT" != "$EXPECTED" ] || [ ! -d "$RUNTIME/local_shell_mcp" ]; then
+    echo "Downloading worker bundle..." >&2
+    curl -fL --progress-bar "$BUNDLE_URL" -o "$TMPDIR/worker.tgz"
+    ACTUAL="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' "$TMPDIR/worker.tgz")"
+    [ "$ACTUAL" = "$EXPECTED" ] || {{ echo "worker bundle checksum mismatch" >&2; exit 1; }}
+    NEXT="$STATE_HOME/runtime.next.$$"
+    rm -rf "$NEXT"
+    mkdir -p "$NEXT"
+    tar -xzf "$TMPDIR/worker.tgz" -C "$NEXT"
+    rm -rf "$RUNTIME"
+    mv "$NEXT" "$RUNTIME"
+    printf '%s\n' "$EXPECTED" > "$STATE_HOME/runtime.sha256"
+  else
+    echo "Worker bundle is up to date." >&2
+  fi
+  BIN_DIR="$HOME/.local/bin"
+  mkdir -p "$BIN_DIR"
+  cat > "$BIN_DIR/local-shell-mcp" <<'EOF'
+#!/bin/sh
+STATE_HOME="${{XDG_STATE_HOME:-$HOME/.local/state}}/local-shell-mcp-worker"
+export PYTHONPATH="$STATE_HOME/runtime:$STATE_HOME/runtime/vendor${{PYTHONPATH:+:$PYTHONPATH}}"
+exec python3 -m local_shell_mcp "$@"
+EOF
+  chmod 755 "$BIN_DIR/local-shell-mcp"
+  PATH_LINE='export PATH="$HOME/.local/bin:$PATH"'
+  case "${{SHELL:-}}" in
+    */zsh) RC="$HOME/.zshrc" ;;
+    */bash) RC="$HOME/.bashrc" ;;
+    *) RC="$HOME/.profile" ;;
+  esac
+  touch "$RC"
+  grep -Fqx '{PATH_MARKER}' "$RC" || printf '\n%s\n%s\n' '{PATH_MARKER}' "$PATH_LINE" >> "$RC"
+  export PATH="$BIN_DIR:$PATH"
+  export PYTHONPATH="$RUNTIME:$RUNTIME/vendor${{PYTHONPATH:+:$PYTHONPATH}}"
+  ARGS=(worker enroll --server "$SERVER" --invite "$INVITE" --workdir "$WORKDIR")
+  [ -n "$NAME" ] && ARGS+=(--name "$NAME")
+  "$BIN_DIR/local-shell-mcp" "${{ARGS[@]}}"
+  "$BIN_DIR/local-shell-mcp" worker start
+  echo "Persistent worker installed and started."
+  echo "Management command: local-shell-mcp worker status"
+  exit 0
+fi
+echo "Downloading worker bundle..." >&2
+curl -fL --progress-bar "$BUNDLE_URL" -o "$TMPDIR/worker.tgz"
+RUNTIME="$TMPDIR/runtime"
+mkdir -p "$RUNTIME"
+tar -xzf "$TMPDIR/worker.tgz" -C "$RUNTIME"
+export PYTHONPATH="$RUNTIME:$RUNTIME/vendor${{PYTHONPATH:+:$PYTHONPATH}}"
+ARGS=(--server "$SERVER" --invite "$INVITE" --workdir "$WORKDIR")
+[ -n "$NAME" ] && ARGS+=(--name "$NAME")
+if [ "$BACKGROUND" = "1" ]; then
+  mkdir -p "$HOME/.local/state/local-shell-mcp-worker"
+  nohup python3 -m local_shell_mcp.remote_worker "${{ARGS[@]}}" > "$HOME/.local/state/local-shell-mcp-worker/worker.log" 2>&1 &
+  echo "local-shell-mcp worker started in background."
+else
+  exec python3 -m local_shell_mcp.remote_worker "${{ARGS[@]}}"
+fi
+'''
+
+
+async def join_script(request: Any):  # noqa: ARG001, ANN201
+    from starlette.responses import PlainTextResponse
+
+    from .settings import get_settings
+
+    settings = get_settings()
+    server = (settings.public_base_url or f"http://{settings.host}:{settings.port}").rstrip("/")
+    return PlainTextResponse(_join_script(server), media_type="text/x-shellscript")
+
+
+def remote_routes() -> list[Any]:
+    from starlette.routing import Route
+
+    routes = []
+    for route in legacy_remote_routes():
+        if getattr(route, "path", None) == REMOTE_JOIN_PATH:
+            routes.append(Route(REMOTE_JOIN_PATH, join_script, methods=["GET"]))
+        else:
+            routes.append(route)
+    routes.append(Route(WORKER_MANIFEST_PATH, worker_manifest, methods=["GET"]))
+    return routes
+
+
+def _print_status(status: dict[str, Any]) -> None:
+    print(f"Installed: {'yes' if status['installed'] else 'no'}")
+    print(f"Running:   {'yes' if status['running'] else 'no'}")
+    if status["pid"]:
+        print(f"PID:       {status['pid']}")
+    if status["server"]:
+        print(f"Server:    {status['server']}")
+    if status["name"]:
+        print(f"Name:      {status['name']}")
+    print(f"State:     {status['state_dir']}")
+    print(f"Log:       {status['log']}")
+
+
+def run_worker_cli(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Manage the local-shell-mcp remote worker")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    enroll = subparsers.add_parser("enroll")
+    enroll.add_argument("--server", required=True)
+    enroll.add_argument("--invite", required=True)
+    enroll.add_argument("--name", default=None)
+    enroll.add_argument("--workdir", default=os.getcwd())
+
+    subparsers.add_parser("run")
+    subparsers.add_parser("start")
+    subparsers.add_parser("stop")
+    subparsers.add_parser("restart")
+    subparsers.add_parser("status")
+
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "enroll":
+            config = asyncio.run(enroll_worker(args.server, args.invite, args.name, args.workdir))
+            print(f"Enrolled worker {config['name']} for {config['server']}")
+        elif args.command == "run":
+            asyncio.run(run_installed_worker())
+        elif args.command == "start":
+            print(f"Worker started with PID {start_worker()}")
+        elif args.command == "stop":
+            print("Worker stopped" if stop_worker() else "Worker is not running")
+        elif args.command == "restart":
+            stop_worker()
+            print(f"Worker restarted with PID {start_worker()}")
+        elif args.command == "status":
+            _print_status(worker_status())
+    except KeyboardInterrupt:
+        raise SystemExit(130) from None
+    except Exception as exc:  # noqa: BLE001
+        print(f"Status: worker command failed: {exc}", file=sys.stderr)
+        raise SystemExit(1) from None
+
+
+__all__ = [
+    "WORKER_MANIFEST_PATH",
+    "enroll_worker",
+    "join_script",
+    "read_worker_config",
+    "remote_routes",
+    "run_worker_cli",
+    "start_worker",
+    "stop_worker",
+    "worker_manifest",
+    "worker_status",
+    "write_worker_config",
+]

--- a/src/local_shell_mcp/worker_lifecycle.py
+++ b/src/local_shell_mcp/worker_lifecycle.py
@@ -281,8 +281,8 @@ if [ "$PERSIST" = "1" ]; then
   mkdir -p "$BIN_DIR"
   cat > "$BIN_DIR/local-shell-mcp" <<'EOF'
 #!/bin/sh
-STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}/local-shell-mcp-worker"
-export PYTHONPATH="$STATE_HOME/runtime:$STATE_HOME/runtime/vendor${PYTHONPATH:+:$PYTHONPATH}"
+STATE_HOME="${{XDG_STATE_HOME:-$HOME/.local/state}}/local-shell-mcp-worker"
+export PYTHONPATH="$STATE_HOME/runtime:$STATE_HOME/runtime/vendor${{PYTHONPATH:+:$PYTHONPATH}}"
 exec python3 -m local_shell_mcp.main "$@"
 EOF
   chmod 755 "$BIN_DIR/local-shell-mcp"

--- a/src/local_shell_mcp/worker_lifecycle.py
+++ b/src/local_shell_mcp/worker_lifecycle.py
@@ -20,13 +20,13 @@ from .remote import (
     REMOTE_WORKER_BUNDLE_PATH,
     _worker_post_json_forever,
     _write_worker_identity,
-    remote_routes as legacy_remote_routes,
     run_worker,
-    run_worker_cli as legacy_run_worker_cli,
     worker_bundle,
     worker_capabilities,
     worker_info,
 )
+from .remote import remote_routes as legacy_remote_routes
+from .remote import run_worker_cli as legacy_run_worker_cli
 
 WORKER_MANIFEST_PATH = "/remote/worker-manifest.json"
 WORKER_CONFIG_FILE_NAME = "config.json"

--- a/tests/test_worker_lifecycle.py
+++ b/tests/test_worker_lifecycle.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import json
 from types import SimpleNamespace
 
@@ -215,6 +214,13 @@ def test_cli_enroll_and_run(monkeypatch, capsys):
     )
     lifecycle.run_worker_cli(["run"])
     assert "Enrolled worker n" in capsys.readouterr().out
+
+
+def test_cli_legacy_passthrough(monkeypatch):
+    calls = []
+    monkeypatch.setattr(lifecycle, "legacy_run_worker_cli", calls.append)
+    lifecycle.run_worker_cli(["--server", "https://s", "--invite", "i"])
+    assert calls == [["--server", "https://s", "--invite", "i"]]
 
 
 def test_cli_failure(monkeypatch, capsys):

--- a/tests/test_worker_lifecycle.py
+++ b/tests/test_worker_lifecycle.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from local_shell_mcp import worker_lifecycle as lifecycle
+
+
+@pytest.fixture
+def state_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKER_STATE_DIR", str(tmp_path))
+    return tmp_path
+
+
+def test_config_round_trip_and_status(state_dir):
+    config = {
+        "version": 1,
+        "server": "https://example.test",
+        "name": "node",
+        "workdir": str(state_dir),
+    }
+    lifecycle.write_worker_config(config)
+    assert lifecycle.read_worker_config() == config
+    status = lifecycle.worker_status()
+    assert status["installed"] is True
+    assert status["running"] is False
+    assert status["server"] == "https://example.test"
+
+
+def test_config_errors(state_dir):
+    with pytest.raises(RuntimeError, match="not installed"):
+        lifecycle.read_worker_config()
+    lifecycle.worker_config_path().write_text("{}", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="unsupported"):
+        lifecycle.read_worker_config()
+    lifecycle.worker_config_path().write_text(
+        json.dumps({"version": 1, "server": "x", "name": "", "workdir": "x"}),
+        encoding="utf-8",
+    )
+    with pytest.raises(RuntimeError, match="missing name"):
+        lifecycle.read_worker_config()
+
+
+def test_pid_helpers_remove_stale_pid(state_dir, monkeypatch):
+    lifecycle.worker_pid_path().write_text("123", encoding="utf-8")
+    monkeypatch.setattr(lifecycle, "_pid_is_running", lambda pid: False)
+    assert lifecycle.read_worker_pid() is None
+    assert not lifecycle.worker_pid_path().exists()
+
+
+def test_start_worker_is_idempotent(state_dir, monkeypatch):
+    lifecycle.write_worker_config(
+        {"version": 1, "server": "https://s", "name": "n", "workdir": str(state_dir)}
+    )
+    monkeypatch.setattr(lifecycle, "read_worker_pid", lambda: None)
+    process = SimpleNamespace(pid=321)
+    calls = []
+
+    def fake_popen(*args, **kwargs):
+        calls.append((args, kwargs))
+        return process
+
+    monkeypatch.setattr(lifecycle.subprocess, "Popen", fake_popen)
+    assert lifecycle.start_worker() == 321
+    assert lifecycle.worker_pid_path().read_text(encoding="utf-8") == "321"
+    assert calls[0][1]["start_new_session"] is True
+
+    monkeypatch.setattr(lifecycle, "read_worker_pid", lambda: 321)
+    assert lifecycle.start_worker() == 321
+    assert len(calls) == 1
+
+
+def test_stop_worker(state_dir, monkeypatch):
+    lifecycle.worker_pid_path().write_text("44", encoding="utf-8")
+    monkeypatch.setattr(lifecycle, "read_worker_pid", lambda: 44)
+    states = iter([True, False, False])
+    monkeypatch.setattr(lifecycle, "_pid_is_running", lambda pid: next(states, False))
+    signals = []
+    monkeypatch.setattr(lifecycle.os, "kill", lambda pid, sig: signals.append((pid, sig)))
+    assert lifecycle.stop_worker(timeout_s=0.1) is True
+    assert signals[0][0] == 44
+
+
+def test_stop_worker_when_not_running(monkeypatch):
+    monkeypatch.setattr(lifecycle, "read_worker_pid", lambda: None)
+    assert lifecycle.stop_worker() is False
+
+
+@pytest.mark.asyncio
+async def test_enroll_worker_persists_identity_and_config(state_dir, monkeypatch):
+    async def fake_post(*args, **kwargs):
+        return {"ok": True, "data": {"token": "secret", "name": "node"}}
+
+    identities = []
+    monkeypatch.setattr(lifecycle, "_worker_post_json_forever", fake_post)
+    monkeypatch.setattr(lifecycle, "worker_capabilities", lambda: ["shell"])
+    monkeypatch.setattr(lifecycle, "worker_info", lambda workdir: {"workdir": workdir})
+    monkeypatch.setattr(lifecycle, "_write_worker_identity", identities.append)
+    config = await lifecycle.enroll_worker("https://server/", "invite", None, str(state_dir))
+    assert config["server"] == "https://server"
+    assert config["name"] == "node"
+    assert identities[0]["access"] == "secret"
+    assert lifecycle.read_worker_config() == config
+
+
+@pytest.mark.asyncio
+async def test_enroll_worker_rejects_failed_response(state_dir, monkeypatch):
+    async def fake_post(*args, **kwargs):
+        return {"ok": False, "message": "denied"}
+
+    monkeypatch.setattr(lifecycle, "_worker_post_json_forever", fake_post)
+    monkeypatch.setattr(lifecycle, "worker_capabilities", lambda: [])
+    monkeypatch.setattr(lifecycle, "worker_info", lambda workdir: {})
+    with pytest.raises(RuntimeError, match="denied"):
+        await lifecycle.enroll_worker("https://server", "invite", None, str(state_dir))
+
+
+@pytest.mark.asyncio
+async def test_run_installed_worker(state_dir, monkeypatch):
+    lifecycle.write_worker_config(
+        {"version": 1, "server": "https://s", "name": "n", "workdir": str(state_dir)}
+    )
+    calls = []
+
+    async def fake_run_worker(*args):
+        calls.append(args)
+
+    monkeypatch.setattr(lifecycle, "run_worker", fake_run_worker)
+    await lifecycle.run_installed_worker()
+    assert calls == [("https://s", "", "n", str(state_dir), False)]
+
+
+@pytest.mark.asyncio
+async def test_manifest_uses_bundle_digest(monkeypatch):
+    class Response:
+        body = b"bundle"
+
+    async def fake_bundle(request):
+        return Response()
+
+    monkeypatch.setattr(lifecycle, "worker_bundle", fake_bundle)
+    response = await lifecycle.worker_manifest(object())
+    payload = json.loads(response.body)
+    assert payload["schema_version"] == 1
+    assert payload["size"] == 6
+    assert payload["url"].endswith("worker-bundle.tgz")
+
+
+def test_join_script_contains_cache_path_and_path_setup():
+    script = lifecycle._join_script("https://server")
+    assert "worker-manifest.json" in script
+    assert "runtime.sha256" in script
+    assert 'export PATH="$HOME/.local/bin:$PATH"' in script
+    assert "worker enroll" in script
+    assert "worker start" in script
+    assert "--invite \"$INVITE\"" in script
+    run_section = script.split("Persistent worker installed and started.", 1)[1]
+    assert "remote_worker" in run_section
+
+
+def test_remote_routes_replace_join_and_add_manifest():
+    routes = lifecycle.remote_routes()
+    paths = [route.path for route in routes]
+    assert paths.count(lifecycle.REMOTE_JOIN_PATH) == 1
+    assert lifecycle.WORKER_MANIFEST_PATH in paths
+
+
+def test_cli_status(monkeypatch, capsys):
+    monkeypatch.setattr(
+        lifecycle,
+        "worker_status",
+        lambda: {
+            "installed": True,
+            "running": True,
+            "pid": 7,
+            "server": "https://s",
+            "name": "n",
+            "workdir": "/tmp",
+            "state_dir": "/state",
+            "log": "/state/log",
+        },
+    )
+    lifecycle.run_worker_cli(["status"])
+    output = capsys.readouterr().out
+    assert "Installed: yes" in output
+    assert "PID:       7" in output
+
+
+def test_cli_start_stop_restart(monkeypatch, capsys):
+    monkeypatch.setattr(lifecycle, "start_worker", lambda: 9)
+    monkeypatch.setattr(lifecycle, "stop_worker", lambda: True)
+    lifecycle.run_worker_cli(["start"])
+    lifecycle.run_worker_cli(["stop"])
+    lifecycle.run_worker_cli(["restart"])
+    output = capsys.readouterr().out
+    assert "Worker started with PID 9" in output
+    assert "Worker stopped" in output
+    assert "Worker restarted with PID 9" in output
+
+
+def test_cli_enroll_and_run(monkeypatch, capsys):
+    async def fake_enroll(*args):
+        return {"name": "n", "server": "https://s"}
+
+    async def fake_run():
+        return None
+
+    monkeypatch.setattr(lifecycle, "enroll_worker", fake_enroll)
+    monkeypatch.setattr(lifecycle, "run_installed_worker", fake_run)
+    lifecycle.run_worker_cli(
+        ["enroll", "--server", "https://s", "--invite", "i", "--workdir", "/tmp"]
+    )
+    lifecycle.run_worker_cli(["run"])
+    assert "Enrolled worker n" in capsys.readouterr().out
+
+
+def test_cli_failure(monkeypatch, capsys):
+    monkeypatch.setattr(lifecycle, "start_worker", lambda: (_ for _ in ()).throw(RuntimeError("x")))
+    with pytest.raises(SystemExit) as exc:
+        lifecycle.run_worker_cli(["start"])
+    assert exc.value.code == 1
+    assert "worker command failed" in capsys.readouterr().err

--- a/tests/test_worker_lifecycle.py
+++ b/tests/test_worker_lifecycle.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import os
+import signal
 from types import SimpleNamespace
 
 import pytest
@@ -12,6 +14,21 @@ from local_shell_mcp import worker_lifecycle as lifecycle
 def state_dir(tmp_path, monkeypatch):
     monkeypatch.setenv("LOCAL_SHELL_MCP_WORKER_STATE_DIR", str(tmp_path))
     return tmp_path
+
+
+def test_worker_state_dir_precedence(tmp_path, monkeypatch):
+    configured = tmp_path / "configured"
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKER_STATE_DIR", str(configured))
+    assert lifecycle.worker_state_dir() == configured
+
+    monkeypatch.delenv("LOCAL_SHELL_MCP_WORKER_STATE_DIR")
+    xdg = tmp_path / "xdg"
+    monkeypatch.setenv("XDG_STATE_HOME", str(xdg))
+    assert lifecycle.worker_state_dir() == xdg / "local-shell-mcp-worker"
+
+    monkeypatch.delenv("XDG_STATE_HOME")
+    monkeypatch.setattr(lifecycle.Path, "home", lambda: tmp_path)
+    assert lifecycle.worker_state_dir() == tmp_path / ".local/state/local-shell-mcp-worker"
 
 
 def test_config_round_trip_and_status(state_dir):
@@ -29,11 +46,14 @@ def test_config_round_trip_and_status(state_dir):
     assert status["server"] == "https://example.test"
 
 
-def test_config_errors(state_dir):
+def test_config_errors(state_dir, monkeypatch):
     with pytest.raises(RuntimeError, match="not installed"):
         lifecycle.read_worker_config()
     lifecycle.worker_config_path().write_text("{}", encoding="utf-8")
     with pytest.raises(RuntimeError, match="unsupported"):
+        lifecycle.read_worker_config()
+    lifecycle.worker_config_path().write_text("not-json", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="unreadable"):
         lifecycle.read_worker_config()
     lifecycle.worker_config_path().write_text(
         json.dumps({"version": 1, "server": "x", "name": "", "workdir": "x"}),
@@ -42,12 +62,42 @@ def test_config_errors(state_dir):
     with pytest.raises(RuntimeError, match="missing name"):
         lifecycle.read_worker_config()
 
+    monkeypatch.setattr(lifecycle.Path, "read_text", lambda *args, **kwargs: (_ for _ in ()).throw(OSError("x")))
+    with pytest.raises(RuntimeError, match="unreadable"):
+        lifecycle.read_worker_config()
+
+
+def test_pid_is_running_branches(monkeypatch):
+    assert lifecycle._pid_is_running(0) is False
+
+    monkeypatch.setattr(lifecycle.os, "kill", lambda pid, sig: None)
+    assert lifecycle._pid_is_running(1) is True
+
+    def missing(pid, sig):
+        raise ProcessLookupError
+
+    monkeypatch.setattr(lifecycle.os, "kill", missing)
+    assert lifecycle._pid_is_running(1) is False
+
+    def denied(pid, sig):
+        raise PermissionError
+
+    monkeypatch.setattr(lifecycle.os, "kill", denied)
+    assert lifecycle._pid_is_running(1) is True
+
 
 def test_pid_helpers_remove_stale_pid(state_dir, monkeypatch):
+    assert lifecycle.read_worker_pid() is None
+    lifecycle.worker_pid_path().write_text("bad", encoding="utf-8")
+    assert lifecycle.read_worker_pid() is None
     lifecycle.worker_pid_path().write_text("123", encoding="utf-8")
     monkeypatch.setattr(lifecycle, "_pid_is_running", lambda pid: False)
     assert lifecycle.read_worker_pid() is None
     assert not lifecycle.worker_pid_path().exists()
+
+    lifecycle.worker_pid_path().write_text("123", encoding="utf-8")
+    monkeypatch.setattr(lifecycle, "_pid_is_running", lambda pid: True)
+    assert lifecycle.read_worker_pid() == 123
 
 
 def test_start_worker_is_idempotent(state_dir, monkeypatch):
@@ -66,10 +116,18 @@ def test_start_worker_is_idempotent(state_dir, monkeypatch):
     assert lifecycle.start_worker() == 321
     assert lifecycle.worker_pid_path().read_text(encoding="utf-8") == "321"
     assert calls[0][1]["start_new_session"] is True
+    assert "local_shell_mcp.remote_worker" in calls[0][0][0]
+    assert str(state_dir / "runtime") in calls[0][1]["env"]["PYTHONPATH"]
 
     monkeypatch.setattr(lifecycle, "read_worker_pid", lambda: 321)
     assert lifecycle.start_worker() == 321
     assert len(calls) == 1
+
+
+def test_start_worker_requires_install(state_dir, monkeypatch):
+    monkeypatch.setattr(lifecycle, "read_worker_pid", lambda: None)
+    with pytest.raises(RuntimeError, match="not installed"):
+        lifecycle.start_worker()
 
 
 def test_stop_worker(state_dir, monkeypatch):
@@ -80,12 +138,41 @@ def test_stop_worker(state_dir, monkeypatch):
     signals = []
     monkeypatch.setattr(lifecycle.os, "kill", lambda pid, sig: signals.append((pid, sig)))
     assert lifecycle.stop_worker(timeout_s=0.1) is True
-    assert signals[0][0] == 44
+    assert signals[0] == (44, signal.SIGTERM)
+
+
+def test_stop_worker_escalates_and_handles_missing_process(state_dir, monkeypatch):
+    lifecycle.worker_pid_path().write_text("44", encoding="utf-8")
+    monkeypatch.setattr(lifecycle, "read_worker_pid", lambda: 44)
+    monkeypatch.setattr(lifecycle, "_pid_is_running", lambda pid: True)
+    times = iter([0.0, 2.0])
+    monkeypatch.setattr(lifecycle.time, "monotonic", lambda: next(times, 2.0))
+    signals = []
+    monkeypatch.setattr(lifecycle.os, "kill", lambda pid, sig: signals.append(sig))
+    assert lifecycle.stop_worker(timeout_s=1.0) is True
+    assert signal.SIGTERM in signals
+    assert signal.SIGKILL in signals
+
+    monkeypatch.setattr(lifecycle, "read_worker_pid", lambda: 44)
+
+    def vanished(pid, sig):
+        raise ProcessLookupError
+
+    monkeypatch.setattr(lifecycle.os, "kill", vanished)
+    monkeypatch.setattr(lifecycle, "_pid_is_running", lambda pid: False)
+    assert lifecycle.stop_worker() is True
 
 
 def test_stop_worker_when_not_running(monkeypatch):
     monkeypatch.setattr(lifecycle, "read_worker_pid", lambda: None)
     assert lifecycle.stop_worker() is False
+
+
+def test_status_when_not_installed(state_dir):
+    status = lifecycle.worker_status()
+    assert status["installed"] is False
+    assert status["server"] is None
+    assert status["name"] is None
 
 
 @pytest.mark.asyncio
@@ -146,18 +233,34 @@ async def test_manifest_uses_bundle_digest(monkeypatch):
     assert payload["schema_version"] == 1
     assert payload["size"] == 6
     assert payload["url"].endswith("worker-bundle.tgz")
+    assert len(payload["sha256"]) == 64
 
 
 def test_join_script_contains_cache_path_and_path_setup():
-    script = lifecycle._join_script("https://server")
+    script = lifecycle._join_script("https://server/path with space")
     assert "worker-manifest.json" in script
     assert "runtime.sha256" in script
     assert 'export PATH="$HOME/.local/bin:$PATH"' in script
+    assert lifecycle.PATH_MARKER in script
     assert "worker enroll" in script
     assert "worker start" in script
     assert "--invite \"$INVITE\"" in script
+    assert "python3 -m local_shell_mcp.main" in script
     run_section = script.split("Persistent worker installed and started.", 1)[1]
     assert "remote_worker" in run_section
+
+
+@pytest.mark.asyncio
+async def test_join_script_response(monkeypatch):
+    settings = SimpleNamespace(public_base_url="https://public/", host="127.0.0.1", port=8000)
+    monkeypatch.setattr("local_shell_mcp.settings.get_settings", lambda: settings)
+    response = await lifecycle.join_script(object())
+    assert response.media_type == "text/x-shellscript"
+    assert "SERVER=https://public" in response.body.decode()
+
+    settings.public_base_url = None
+    response = await lifecycle.join_script(object())
+    assert "SERVER=http://127.0.0.1:8000" in response.body.decode()
 
 
 def test_remote_routes_replace_join_and_add_manifest():
@@ -165,6 +268,24 @@ def test_remote_routes_replace_join_and_add_manifest():
     paths = [route.path for route in routes]
     assert paths.count(lifecycle.REMOTE_JOIN_PATH) == 1
     assert lifecycle.WORKER_MANIFEST_PATH in paths
+
+
+def test_print_status_optional_fields(capsys):
+    lifecycle._print_status(
+        {
+            "installed": False,
+            "running": False,
+            "pid": None,
+            "server": None,
+            "name": None,
+            "state_dir": "/state",
+            "log": "/log",
+        }
+    )
+    output = capsys.readouterr().out
+    assert "Installed: no" in output
+    assert "PID:" not in output
+    assert "Server:" not in output
 
 
 def test_cli_status(monkeypatch, capsys):
@@ -199,6 +320,10 @@ def test_cli_start_stop_restart(monkeypatch, capsys):
     assert "Worker stopped" in output
     assert "Worker restarted with PID 9" in output
 
+    monkeypatch.setattr(lifecycle, "stop_worker", lambda: False)
+    lifecycle.run_worker_cli(["stop"])
+    assert "not running" in capsys.readouterr().out
+
 
 def test_cli_enroll_and_run(monkeypatch, capsys):
     async def fake_enroll(*args):
@@ -221,6 +346,13 @@ def test_cli_legacy_passthrough(monkeypatch):
     monkeypatch.setattr(lifecycle, "legacy_run_worker_cli", calls.append)
     lifecycle.run_worker_cli(["--server", "https://s", "--invite", "i"])
     assert calls == [["--server", "https://s", "--invite", "i"]]
+
+
+def test_cli_keyboard_interrupt(monkeypatch):
+    monkeypatch.setattr(lifecycle, "start_worker", lambda: (_ for _ in ()).throw(KeyboardInterrupt))
+    with pytest.raises(SystemExit) as exc:
+        lifecycle.run_worker_cli(["start"])
+    assert exc.value.code == 130
 
 
 def test_cli_failure(monkeypatch, capsys):


### PR DESCRIPTION
Superseded by #11, which implements the same Issue with the complete runtime installer, lifecycle commands, systemd/launchd support, update path, and platform fallback. Any useful compatibility and review findings from this branch are being addressed on #11.