### PR TITLE
feat: add native image viewing tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ See the [Agent Skills guide](https://fwerkor.github.io/local-shell-mcp/guides/sk
 The public MCP surface includes:
 
 - Shell and jobs: `run_shell_tool`, `run_python_tool`, persistent `shell_*`, and tracked `job_*` tools. Use `run_shell_tool` for Git CLI operations.
-- Filesystem: `list_files`, `tree_view`, `glob_search`, `grep_search`, unified `read_file`, `write_file`, unified `edit_file`, `delete_file_or_dir`, and `apply_patch`.
+- Filesystem: `list_files`, `tree_view`, `glob_search`, `grep_search`, unified `read_file`, native-vision `view_image`, `write_file`, unified `edit_file`, `delete_file_or_dir`, and `apply_patch`.
 - Transfer: `transfer_path` for files or directories across controller and worker endpoints.
 - Browser: `browser_get_text_tool`, unified `browser_capture_tool`, and `playwright_run_script_tool`.
 - File links: `create_file_link`, `list_file_links`, `revoke_file_link`.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -379,6 +379,19 @@ OAuth scopes: `shell:read`.
 
 When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
 
+### `view_image`
+
+View a PNG, JPEG, GIF, or WebP file as native MCP image content locally or on a remote machine. Use this instead of read_file when visual inspection is needed. Remote images reuse the existing file-transfer protocol, so the worker does not need a new image-specific RPC.
+
+| Parameter | Type | Required/default | Description |
+|---|---|---|---|
+| `path` | `string` | required |  |
+| `machine` | `string \| null` | `null` |  |
+
+OAuth scopes: `shell:read`.
+
+When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
+
 ### `write_file`
 
 Write a UTF-8 text file locally or on a remote machine.

--- a/scripts/generate-tools-reference.py
+++ b/scripts/generate-tools-reference.py
@@ -54,6 +54,7 @@ GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "glob_search",
             "grep_search",
             "read_file",
+            "view_image",
             "write_file",
             "edit_file",
             "delete_file_or_dir",

--- a/src/local_shell_mcp/image_ops.py
+++ b/src/local_shell_mcp/image_ops.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .fs_ops import relative_display, resolve_path
+
+MAX_VIEW_IMAGE_BYTES = 20 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class ImageFile:
+    path: str
+    data: bytes
+    format: str
+    mime_type: str
+    size: int
+
+
+def assert_view_image_size(size: int) -> None:
+    if size <= 0:
+        raise ValueError("Image file is empty")
+    if size > MAX_VIEW_IMAGE_BYTES:
+        raise ValueError(
+            f"Refusing image of {size} bytes; max is {MAX_VIEW_IMAGE_BYTES}"
+        )
+
+
+def detect_image_type(header: bytes) -> tuple[str, str]:
+    if header.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "png", "image/png"
+    if header.startswith(b"\xff\xd8\xff"):
+        return "jpeg", "image/jpeg"
+    if header.startswith((b"GIF87a", b"GIF89a")):
+        return "gif", "image/gif"
+    if len(header) >= 12 and header.startswith(b"RIFF") and header[8:12] == b"WEBP":
+        return "webp", "image/webp"
+    raise ValueError("Unsupported image format; expected PNG, JPEG, GIF, or WebP")
+
+
+def read_image(path: str) -> ImageFile:
+    resolved = resolve_path(path, must_exist=True)
+    if not resolved.is_file():
+        raise IsADirectoryError(str(resolved))
+
+    expected_size = resolved.stat().st_size
+    assert_view_image_size(expected_size)
+    with resolved.open("rb") as handle:
+        data = handle.read(MAX_VIEW_IMAGE_BYTES + 1)
+    assert_view_image_size(len(data))
+    image_format, mime_type = detect_image_type(data[:16])
+
+    return ImageFile(
+        path=relative_display(resolved),
+        data=data,
+        format=image_format,
+        mime_type=mime_type,
+        size=len(data),
+    )

--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -1,18 +1,19 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import inspect
 import json
 import subprocess
 import uuid
 from contextlib import suppress
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from urllib.parse import urlparse
 
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
-from mcp.types import ToolAnnotations
+from mcp.types import CallToolResult, ImageContent, TextContent, ToolAnnotations
 from pathspec.gitignore import GitIgnoreSpec
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -32,6 +33,7 @@ from .fs_ops import (
     temp_dir,
     write_text,
 )
+from .image_ops import ImageFile, assert_view_image_size, read_image
 from .jobs import list_jobs, retry_job, start_job, stop_job, tail_job
 from .models import ToolResult
 from .playwright_ops import browser_capture, browser_get_text, playwright_run_script
@@ -85,6 +87,20 @@ class TextEdit(BaseModel):
     old: str = Field(min_length=1)
     new: str
     replace_all: bool = False
+
+
+class ViewImageResult(BaseModel):
+    """Structured metadata accompanying native MCP image content."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    ok: bool
+    path: str
+    machine: str | None = None
+    mime_type: str | None = None
+    bytes: int | None = None
+    message: str = ""
+    error_type: str | None = None
 
 
 def _ok(data: Any = None, message: str = "") -> dict:
@@ -213,6 +229,7 @@ NON_CANCELLABLE_TOOL_NAMES = frozenset(
     {
         "create_file_link",
         "revoke_file_link",
+        "view_image",
         "write_file",
         "edit_file",
         "delete_file_or_dir",
@@ -451,6 +468,7 @@ MACHINE_CAPABLE_TOOL_NAMES = {
     "glob_search",
     "grep_search",
     "read_file",
+    "view_image",
     "write_file",
     "edit_file",
     "delete_file_or_dir",
@@ -1029,6 +1047,91 @@ async def _transfer_path(
     return {"type": source_type, **result}
 
 
+def _view_image_success_result(
+    image: ImageFile,
+    path: str,
+    machine: str | None,
+) -> CallToolResult:
+    metadata = ViewImageResult(
+        ok=True,
+        path=path,
+        machine=machine,
+        mime_type=image.mime_type,
+        bytes=image.size,
+    )
+    return CallToolResult(
+        content=[
+            ImageContent(
+                type="image",
+                data=base64.b64encode(image.data).decode("ascii"),
+                mimeType=image.mime_type,
+            ),
+            TextContent(
+                type="text",
+                text=f"{path} ({image.mime_type}, {image.size} bytes)",
+            ),
+        ],
+        structuredContent=metadata.model_dump(mode="json"),
+    )
+
+
+def _view_image_error_result(
+    path: str,
+    machine: str | None,
+    exc: Exception,
+) -> CallToolResult:
+    audit("tool_error", error=repr(exc))
+    message = f"{type(exc).__name__}: {exc}"
+    metadata = ViewImageResult(
+        ok=False,
+        path=path,
+        machine=machine,
+        message=message,
+        error_type=type(exc).__name__,
+    )
+    return CallToolResult(
+        content=[TextContent(type="text", text=f"Unable to view image: {message}")],
+        structuredContent=metadata.model_dump(mode="json"),
+        isError=True,
+    )
+
+
+async def _view_image_result(path: str, machine: str | None = None) -> CallToolResult:
+    try:
+        display_path = path
+        if machine:
+            if not get_settings().remote_enabled:
+                raise RuntimeError("Remote workers are disabled")
+            stat = await _remote_transfer_data(
+                machine,
+                "transfer_stat",
+                {"path": path, "sha256": False},
+            )
+            if not isinstance(stat, dict) or stat.get("type") != "file":
+                raise ValueError(f"source is not a file: {path}")
+            assert_view_image_size(int(stat.get("size") or 0))
+            temporary = await _to_thread(transfer_alloc_temp_path, ".bin")
+            temporary_path = temporary["path"]
+            try:
+                await _copy_remote_file_to_local(
+                    machine,
+                    path,
+                    temporary_path,
+                    True,
+                )
+                image = await _to_thread(read_image, temporary_path)
+            finally:
+                with suppress(Exception):
+                    await _to_thread(delete_path, temporary_path, False)
+            display_path = str(stat.get("path") or path)
+        else:
+            image = await _to_thread(read_image, path)
+            display_path = image.path
+        return _view_image_success_result(image, display_path, machine)
+    except Exception as exc:
+        return _view_image_error_result(path, machine, exc)
+
+
 def _read_audit_tail_entries(lines: int = 100) -> dict:
     settings = get_settings()
     path = settings.audit_log_path
@@ -1582,6 +1685,14 @@ def build_mcp() -> FastMCP:
             )
         except Exception as exc:
             return _handled_error(exc)
+
+    @mcp.tool(structured_output=True, annotations=read_only_tool, meta=shell_read_meta)
+    async def view_image(
+        path: str,
+        machine: str | None = None,
+    ) -> ViewImageResult:
+        """View a PNG, JPEG, GIF, or WebP file as native MCP image content locally or on a remote machine. Use this instead of read_file when visual inspection is needed. Remote images reuse the existing file-transfer protocol, so the worker does not need a new image-specific RPC."""
+        return cast(ViewImageResult, await _view_image_result(path, machine))
 
     @mcp.tool(structured_output=True, meta=file_share_meta)
     async def create_file_link(

--- a/tests/test_mcp_chatgpt_compat.py
+++ b/tests/test_mcp_chatgpt_compat.py
@@ -180,6 +180,8 @@ async def test_tool_annotations_are_conservative_and_mode_independent(
     assert tools["browser_get_text_tool"].annotations.openWorldHint is True
     assert tools["read_file"].annotations.readOnlyHint is True
     assert tools["read_file"].annotations.openWorldHint is True
+    assert tools["view_image"].annotations.readOnlyHint is True
+    assert tools["view_image"].annotations.openWorldHint is True
     assert tools["search"].annotations.readOnlyHint is True
     assert tools["search"].annotations.openWorldHint is False
     assert all(tool.annotations is not None for tool in tools.values())
@@ -328,6 +330,7 @@ async def test_read_only_tools_have_read_only_hint(tmp_path, monkeypatch):
         "glob_search",
         "grep_search",
         "read_file",
+        "view_image",
         "list_file_links",
         "secret_scan",
         "todo_read_tool",

--- a/tests/test_tool_surface.py
+++ b/tests/test_tool_surface.py
@@ -27,6 +27,7 @@ CORE_TOOL_NAMES = {
     "glob_search",
     "grep_search",
     "read_file",
+    "view_image",
     "create_file_link",
     "list_file_links",
     "revoke_file_link",
@@ -121,6 +122,7 @@ async def test_machine_capable_tools_use_optional_machine_arguments(tmp_path, mo
         "glob_search",
         "grep_search",
         "read_file",
+        "view_image",
         "write_file",
         "edit_file",
         "delete_file_or_dir",
@@ -158,6 +160,8 @@ async def test_key_tool_descriptions_guide_tool_choice(tmp_path, monkeypatch):
     assert "old must match exactly" in tools["edit_file"].description
     assert "recursive=true is required" in tools["delete_file_or_dir"].description
     assert "high-entropy token" in tools["create_file_link"].description
+    assert "native MCP image content" in tools["view_image"].description
+    assert "existing file-transfer protocol" in tools["view_image"].description
     assert "tool surface stays fixed" in tools["skills_list"].description
     assert "exact name returned from skills_list" in tools["skill_load"].description
 

--- a/tests/test_tools_complete.py
+++ b/tests/test_tools_complete.py
@@ -72,6 +72,9 @@ async def test_all_public_tool_wrappers_local_and_remote(tmp_path, monkeypatch):
     async def async_value(*args, **kwargs):
         return {"args": list(args), "kwargs": kwargs}
 
+    async def image_value(*args, **kwargs):
+        return {"ok": True, "args": list(args), "kwargs": kwargs}
+
     def sync_value(*args, **kwargs):
         return {"args": list(args), "kwargs": kwargs}
 
@@ -125,6 +128,7 @@ async def test_all_public_tool_wrappers_local_and_remote(tmp_path, monkeypatch):
     ):
         monkeypatch.setattr(tools, name, sync_value)
 
+    monkeypatch.setattr(tools, "_view_image_result", image_value)
     monkeypatch.setattr(downloads, "create_share_link", sync_value)
     monkeypatch.setattr(downloads, "list_share_links", sync_value)
     monkeypatch.setattr(downloads, "revoke_share_link", sync_value)
@@ -154,6 +158,7 @@ async def test_all_public_tool_wrappers_local_and_remote(tmp_path, monkeypatch):
         "glob_search": {"pattern": "*.py"},
         "grep_search": {"query": "x"},
         "read_file": {"path": "x"},
+        "view_image": {"path": "found.png"},
         "create_file_link": {"path": "found.txt"},
         "list_file_links": {},
         "revoke_file_link": {"token": "t"},
@@ -202,6 +207,7 @@ async def test_all_public_tool_wrappers_local_and_remote(tmp_path, monkeypatch):
         "glob_search": {"pattern": "*"},
         "grep_search": {"query": "x"},
         "read_file": {"path": "x"},
+        "view_image": {"path": "x"},
         "write_file": {"path": "x", "content": "y"},
         "edit_file": {"path": "x", "edits": []},
         "delete_file_or_dir": {"path": "x"},
@@ -213,7 +219,8 @@ async def test_all_public_tool_wrappers_local_and_remote(tmp_path, monkeypatch):
     for name, kwargs in remote_cases.items():
         result = await _raw_tool(mcp, name)(**kwargs, machine="node")
         assert result["ok"] is True, name
-    assert len(fake_remote.calls) == len(remote_cases)
+    assert len(fake_remote.calls) == len(remote_cases) - 1
+    assert all(tool != "view_image" for _, tool, _, _ in fake_remote.calls)
 
 
 @pytest.mark.asyncio

--- a/tests/test_view_image.py
+++ b/tests/test_view_image.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+import pytest
+from mcp.types import CallToolResult, ImageContent, TextContent
+
+import local_shell_mcp.tools as tools
+from local_shell_mcp.image_ops import (
+    MAX_VIEW_IMAGE_BYTES,
+    assert_view_image_size,
+    detect_image_type,
+    read_image,
+)
+from local_shell_mcp.settings import get_settings
+
+PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+)
+
+
+def _configure(tmp_path: Path, monkeypatch, *, remote_enabled: bool = True) -> None:
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(tmp_path / ".state"))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_AUDIT_LOG_PATH", str(tmp_path / "audit.jsonl"))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_AUTH_MODE", "none")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_REMOTE_ENABLED", str(remote_enabled).lower())
+    get_settings.cache_clear()
+
+
+@pytest.mark.parametrize(
+    ("header", "expected"),
+    [
+        (b"\x89PNG\r\n\x1a\nrest", ("png", "image/png")),
+        (b"\xff\xd8\xffrest", ("jpeg", "image/jpeg")),
+        (b"GIF87arest", ("gif", "image/gif")),
+        (b"GIF89arest", ("gif", "image/gif")),
+        (b"RIFF\x00\x00\x00\x00WEBPrest", ("webp", "image/webp")),
+    ],
+)
+def test_detect_image_type(header, expected):
+    assert detect_image_type(header) == expected
+
+
+def test_image_validation_errors(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    with pytest.raises(ValueError, match="empty"):
+        assert_view_image_size(0)
+    with pytest.raises(ValueError, match="max"):
+        assert_view_image_size(MAX_VIEW_IMAGE_BYTES + 1)
+    with pytest.raises(ValueError, match="Unsupported"):
+        detect_image_type(b"not an image")
+
+    (tmp_path / "folder").mkdir()
+    with pytest.raises(IsADirectoryError):
+        read_image("folder")
+
+    oversized = tmp_path / "oversized.png"
+    oversized.write_bytes(b"\x89PNG\r\n\x1a\n")
+    with oversized.open("r+b") as handle:
+        handle.truncate(MAX_VIEW_IMAGE_BYTES + 1)
+    with pytest.raises(ValueError, match="max"):
+        read_image("oversized.png")
+
+
+@pytest.mark.asyncio
+async def test_view_image_returns_native_mcp_image_content(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    (tmp_path / "pixel.png").write_bytes(PNG)
+
+    result = await tools.build_mcp().call_tool("view_image", {"path": "pixel.png"})
+
+    assert isinstance(result, CallToolResult)
+    assert result.isError is False
+    assert result.structuredContent == {
+        "ok": True,
+        "path": "pixel.png",
+        "machine": None,
+        "mime_type": "image/png",
+        "bytes": len(PNG),
+        "message": "",
+        "error_type": None,
+    }
+    image = next(item for item in result.content if isinstance(item, ImageContent))
+    text = next(item for item in result.content if isinstance(item, TextContent))
+    assert image.mimeType == "image/png"
+    assert base64.b64decode(image.data) == PNG
+    assert "pixel.png" in text.text
+
+
+@pytest.mark.asyncio
+async def test_view_image_reuses_remote_transfer_protocol(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    remote_calls = []
+    staged_paths = []
+
+    async def fake_remote_transfer_data(machine, tool, args, timeout_s=None):
+        remote_calls.append((machine, tool, args, timeout_s))
+        assert tool == "transfer_stat"
+        return {
+            "path": "images/remote.png",
+            "type": "file",
+            "size": len(PNG),
+        }
+
+    async def fake_copy_remote_file_to_local(
+        machine,
+        source_path,
+        destination_path,
+        overwrite=True,
+        chunk_size=None,
+    ):
+        assert machine == "node"
+        assert source_path == "images/remote.png"
+        assert overwrite is True
+        assert chunk_size is None
+        destination = tools.resolve_path(destination_path)
+        destination.write_bytes(PNG)
+        staged_paths.append(destination)
+        return {"bytes": len(PNG)}
+
+    monkeypatch.setattr(tools, "_remote_transfer_data", fake_remote_transfer_data)
+    monkeypatch.setattr(
+        tools,
+        "_copy_remote_file_to_local",
+        fake_copy_remote_file_to_local,
+    )
+
+    result = await tools.build_mcp().call_tool(
+        "view_image",
+        {"path": "images/remote.png", "machine": "node"},
+    )
+
+    assert isinstance(result, CallToolResult)
+    assert result.isError is False
+    assert result.structuredContent["machine"] == "node"
+    assert result.structuredContent["path"] == "images/remote.png"
+    assert [call[1] for call in remote_calls] == ["transfer_stat"]
+    assert staged_paths and all(not path.exists() for path in staged_paths)
+
+
+@pytest.mark.asyncio
+async def test_view_image_returns_structured_errors(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    (tmp_path / "plain.txt").write_text("not an image", encoding="utf-8")
+
+    invalid = await tools.build_mcp().call_tool("view_image", {"path": "plain.txt"})
+    assert isinstance(invalid, CallToolResult)
+    assert invalid.isError is True
+    assert invalid.structuredContent["ok"] is False
+    assert invalid.structuredContent["error_type"] == "ValueError"
+
+    _configure(tmp_path, monkeypatch, remote_enabled=False)
+    disabled = await tools.build_mcp().call_tool(
+        "view_image",
+        {"path": "remote.png", "machine": "node"},
+    )
+    assert isinstance(disabled, CallToolResult)
+    assert disabled.isError is True
+    assert "disabled" in disabled.structuredContent["message"]


### PR DESCRIPTION
## Summary

- add `view_image(path, machine=None)` with native MCP `ImageContent` output
- support PNG, JPEG, GIF, and WebP files up to 20 MiB
- reuse the existing remote file-transfer protocol instead of adding a worker RPC, preserving compatibility with currently connected workers
- return structured metadata and structured errors alongside the visual content
- add focused local/remote tests and regenerate the tool reference

## Validation

- `ruff check .`
- `431 passed`
- coverage: `93.9%`
- `python scripts/check-doc-i18n.py`
- `mkdocs build --strict`