### PR TITLE
feat(downloads): support inline file links for v3.0.1

### DIFF
--- a/docs/guides/file-links.md
+++ b/docs/guides/file-links.md
@@ -1,6 +1,6 @@
 # File links
 
-`local-shell-mcp` can expose files from the controlled workspace through high-entropy bearer URLs. This is useful when the AI generates reports, archives, PDFs, screenshots, or other artifacts that must be downloaded from chat.
+`local-shell-mcp` can expose files from the controlled workspace through high-entropy bearer URLs. This is useful when the AI generates reports, archives, PDFs, screenshots, or other artifacts that must be downloaded from or displayed in chat.
 
 ## When to use file links
 
@@ -17,7 +17,7 @@ Do not use file links for secrets, private keys, credential stores, or unrelated
 ## Typical flow
 
 1. Generate or locate a file under `/workspace`.
-2. Call `create_file_link` with a TTL and optional download limit.
+2. Call `create_file_link` with a TTL and optional download limit. Set `inline=true` when the file should render directly in a browser or Markdown image; the default is `false`, which forces attachment download behavior.
 3. Share the returned URL.
 4. Revoke the link when no longer needed.
 

--- a/docs/guides/file-links.md
+++ b/docs/guides/file-links.md
@@ -43,4 +43,4 @@ Use shorter TTLs for sensitive artifacts and set maximum download counts when a 
 
 ## Security notes
 
-File links are bearer URLs. Anyone with the URL can download the file until it expires, reaches its download limit, or is revoked. Treat them like temporary secrets.
+File links are bearer URLs. Anyone with the URL can download the file until it expires, reaches its download limit, or is revoked. Treat them like temporary secrets. Inline responses include a CSP sandbox and `X-Content-Type-Options: nosniff` so active formats cannot access the LSM origin or execute as unsandboxed same-origin content.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -478,7 +478,7 @@ At least one of `source_machine` and `destination_machine` must be supplied. Omi
 
 ### `create_file_link`
 
-Create a temporary browser-accessible download URL for a local file. Links are public bearer URLs protected by a high-entropy token, TTL, optional download-count limit, and explicit revocation.
+Create a temporary browser-accessible URL for a local file. By default the response is an attachment download; set inline=true when the file should render directly in a browser or Markdown image. Links are public bearer URLs protected by a high-entropy token, TTL, optional download-count limit, and explicit revocation.
 
 | Parameter | Type | Required/default | Description |
 |---|---|---|---|
@@ -486,6 +486,7 @@ Create a temporary browser-accessible download URL for a local file. Links are p
 | `ttl_s` | `integer \| null` | `null` |  |
 | `filename` | `string \| null` | `null` |  |
 | `max_downloads` | `integer \| null` | `null` |  |
+| `inline` | `boolean` | `false` |  |
 
 OAuth scopes: `shell:read, file:share`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "local-shell-mcp"
-version = "3.0.0"
+version = "3.0.1"
 description = "A ChatGPT-compatible OAuth MCP server that gives AI coding agents controlled shell, filesystem, remote-worker, and Playwright access inside a local container."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/local_shell_mcp/__init__.py
+++ b/src/local_shell_mcp/__init__.py
@@ -1,3 +1,3 @@
 """local-shell-mcp."""
 
-__version__ = "3.0.0"
+__version__ = "3.0.1"

--- a/src/local_shell_mcp/downloads.py
+++ b/src/local_shell_mcp/downloads.py
@@ -274,12 +274,18 @@ def create_share_link(
             snapshot, source_stat, snapshot_stat = _create_snapshot(resolved, token)
         except (OSError, ValueError) as exc:
             raise ValueError(f"Not a regular shareable file: {path}") from exc
+        safe_filename = _safe_filename(filename, resolved)
+        media_type = (
+            mimetypes.guess_type(resolved.name)[0]
+            or mimetypes.guess_type(safe_filename)[0]
+            or "application/octet-stream"
+        )
         link = {
             "path": str(resolved),
             "display_path": relative_display(resolved),
-            "filename": _safe_filename(filename, resolved),
+            "filename": safe_filename,
             "inline": bool(inline),
-            "media_type": mimetypes.guess_type(resolved.name)[0] or "application/octet-stream",
+            "media_type": media_type,
             "bytes": source_stat.st_size,
             "snapshot_name": snapshot.name,
             "device": int(snapshot_stat.st_dev),

--- a/src/local_shell_mcp/downloads.py
+++ b/src/local_shell_mcp/downloads.py
@@ -199,6 +199,7 @@ def _link_summary(token: str, link: dict[str, Any]) -> dict[str, Any]:
         "url": f"{_public_base_url()}{_DOWNLOAD_PREFIX}/{token}",
         "path": link.get("display_path"),
         "filename": link.get("filename"),
+        "inline": bool(link.get("inline", False)),
         "bytes": link.get("bytes"),
         "created_at": link.get("created_at"),
         "expires_at": link.get("expires_at"),
@@ -252,6 +253,7 @@ def create_share_link(
     ttl_s: int | None = None,
     filename: str | None = None,
     max_downloads: int | None = None,
+    inline: bool = False,
 ) -> dict[str, Any]:
     settings = get_settings()
     if not settings.file_download_enabled:
@@ -275,6 +277,7 @@ def create_share_link(
             "path": str(resolved),
             "display_path": relative_display(resolved),
             "filename": _safe_filename(filename, resolved),
+            "inline": bool(inline),
             "bytes": source_stat.st_size,
             "snapshot_name": snapshot.name,
             "device": int(snapshot_stat.st_dev),
@@ -296,6 +299,7 @@ def create_share_link(
         path=link["display_path"],
         token_id=_token_id(token),
         expires_at=link["expires_at"],
+        inline=link["inline"],
     )
     return _link_summary(token, link)
 
@@ -431,12 +435,13 @@ def _claim_download(
     return handle, path, claimed_link
 
 
-def _content_disposition(filename: str) -> str:
+def _content_disposition(filename: str, *, inline: bool = False) -> str:
     fallback = (
         filename.encode("ascii", errors="ignore").decode("ascii").replace('"', "") or "download"
     )
     encoded = quote(filename, safe="")
-    return f"attachment; filename=\"{fallback}\"; filename*=UTF-8''{encoded}"
+    disposition = "inline" if inline else "attachment"
+    return f"{disposition}; filename=\"{fallback}\"; filename*=UTF-8''{encoded}"
 
 
 def _file_chunks(
@@ -467,7 +472,9 @@ async def download_endpoint(request: Request) -> Response:
     filename = link.get("filename") or path.name
     headers = {
         "Cache-Control": "private, no-store",
-        "Content-Disposition": _content_disposition(filename),
+        "Content-Disposition": _content_disposition(
+            filename, inline=bool(link.get("inline", False))
+        ),
         "Content-Length": str(os.fstat(handle.fileno()).st_size),
     }
     audit(

--- a/src/local_shell_mcp/downloads.py
+++ b/src/local_shell_mcp/downloads.py
@@ -200,6 +200,7 @@ def _link_summary(token: str, link: dict[str, Any]) -> dict[str, Any]:
         "path": link.get("display_path"),
         "filename": link.get("filename"),
         "inline": bool(link.get("inline", False)),
+        "media_type": link.get("media_type"),
         "bytes": link.get("bytes"),
         "created_at": link.get("created_at"),
         "expires_at": link.get("expires_at"),
@@ -278,6 +279,7 @@ def create_share_link(
             "display_path": relative_display(resolved),
             "filename": _safe_filename(filename, resolved),
             "inline": bool(inline),
+            "media_type": mimetypes.guess_type(resolved.name)[0] or "application/octet-stream",
             "bytes": source_stat.st_size,
             "snapshot_name": snapshot.name,
             "device": int(snapshot_stat.st_dev),
@@ -467,16 +469,20 @@ async def download_endpoint(request: Request) -> Response:
 
     handle, path, link = claimed
     media_type = (
-        mimetypes.guess_type(link.get("filename") or path.name)[0] or "application/octet-stream"
+        link.get("media_type")
+        or mimetypes.guess_type(link.get("filename") or path.name)[0]
+        or "application/octet-stream"
     )
     filename = link.get("filename") or path.name
+    inline = bool(link.get("inline", False))
     headers = {
         "Cache-Control": "private, no-store",
-        "Content-Disposition": _content_disposition(
-            filename, inline=bool(link.get("inline", False))
-        ),
+        "Content-Disposition": _content_disposition(filename, inline=inline),
         "Content-Length": str(os.fstat(handle.fileno()).st_size),
+        "X-Content-Type-Options": "nosniff",
     }
+    if inline:
+        headers["Content-Security-Policy"] = "sandbox"
     audit(
         "download_link_served",
         path=link.get("display_path"),

--- a/src/local_shell_mcp/http_app.py
+++ b/src/local_shell_mcp/http_app.py
@@ -328,6 +328,7 @@ def _register_download_routes(app: FastAPI) -> None:
             _body_int(body, "ttl_s", None, allow_none=True),
             body.get("filename"),
             _body_int(body, "max_downloads", None, allow_none=True),
+            _body_bool(body, "inline", False),
         )
 
     @app.get("/tools/download/list")

--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -1702,8 +1702,9 @@ def _register_download_tools(mcp: FastMCP, read_only_tool: ToolAnnotations) -> N
         ttl_s: int | None = None,
         filename: str | None = None,
         max_downloads: int | None = None,
+        inline: bool = False,
     ) -> ToolResult:
-        """Create a temporary browser-accessible download URL for a local file. Links are public bearer URLs protected by a high-entropy token, TTL, optional download-count limit, and explicit revocation."""
+        """Create a temporary browser-accessible URL for a local file. By default the response is an attachment download; set inline=true when the file should render directly in a browser or Markdown image. Links are public bearer URLs protected by a high-entropy token, TTL, optional download-count limit, and explicit revocation."""
         return await _tool_call(
             asyncio.to_thread,
             create_share_link,
@@ -1711,6 +1712,7 @@ def _register_download_tools(mcp: FastMCP, read_only_tool: ToolAnnotations) -> N
             ttl_s,
             filename,
             max_downloads,
+            inline,
         )
 
     @mcp.tool(structured_output=True, annotations=read_only_tool, meta=file_share_meta)

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -58,6 +58,18 @@ def test_create_share_link_can_render_inline(tmp_path, monkeypatch):
     assert head_response.headers["content-security-policy"] == "sandbox"
 
 
+def test_inline_link_uses_display_filename_as_mime_fallback(tmp_path, monkeypatch):
+    _reset(tmp_path, monkeypatch)
+    (tmp_path / "preview").write_bytes(b"not-a-real-png")
+
+    link = create_share_link("preview", ttl_s=60, filename="plot.png", inline=True)
+    response = TestClient(Starlette(routes=download_routes())).get(link["url"])
+
+    assert link["media_type"] == "image/png"
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/png"
+
+
 def test_share_link_expires_and_can_be_revoked(tmp_path, monkeypatch):
     _reset(tmp_path, monkeypatch)
     (tmp_path / "hello.txt").write_text("hello", encoding="utf-8")

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -40,18 +40,22 @@ def test_create_share_link_can_render_inline(tmp_path, monkeypatch):
     _reset(tmp_path, monkeypatch)
     (tmp_path / "preview.png").write_bytes(b"not-a-real-png")
 
-    link = create_share_link("preview.png", ttl_s=60, inline=True)
+    link = create_share_link("preview.png", ttl_s=60, filename="preview", inline=True)
     client = TestClient(Starlette(routes=download_routes()))
 
     get_response = client.get(link["url"])
     head_response = client.head(link["url"])
 
     assert link["inline"] is True
+    assert link["media_type"] == "image/png"
     assert get_response.status_code == 200
     assert get_response.headers["content-type"] == "image/png"
     assert get_response.headers["content-disposition"].startswith("inline;")
+    assert get_response.headers["content-security-policy"] == "sandbox"
+    assert get_response.headers["x-content-type-options"] == "nosniff"
     assert head_response.status_code == 200
     assert head_response.headers["content-disposition"].startswith("inline;")
+    assert head_response.headers["content-security-policy"] == "sandbox"
 
 
 def test_share_link_expires_and_can_be_revoked(tmp_path, monkeypatch):

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -31,7 +31,27 @@ def test_create_share_link_serves_file(tmp_path, monkeypatch):
 
     assert response.status_code == 200
     assert response.text == "hello"
+    assert response.headers["content-disposition"].startswith("attachment;")
     assert "result.txt" in response.headers["content-disposition"]
+    assert link["inline"] is False
+
+
+def test_create_share_link_can_render_inline(tmp_path, monkeypatch):
+    _reset(tmp_path, monkeypatch)
+    (tmp_path / "preview.png").write_bytes(b"not-a-real-png")
+
+    link = create_share_link("preview.png", ttl_s=60, inline=True)
+    client = TestClient(Starlette(routes=download_routes()))
+
+    get_response = client.get(link["url"])
+    head_response = client.head(link["url"])
+
+    assert link["inline"] is True
+    assert get_response.status_code == 200
+    assert get_response.headers["content-type"] == "image/png"
+    assert get_response.headers["content-disposition"].startswith("inline;")
+    assert head_response.status_code == 200
+    assert head_response.headers["content-disposition"].startswith("inline;")
 
 
 def test_share_link_expires_and_can_be_revoked(tmp_path, monkeypatch):
@@ -76,9 +96,10 @@ def test_share_link_download_limit(tmp_path, monkeypatch):
 @pytest.mark.asyncio
 async def test_file_link_tools_are_registered(tmp_path, monkeypatch):
     _reset(tmp_path, monkeypatch)
-    names = {tool.name for tool in await build_mcp().list_tools()}
+    tools = {tool.name: tool for tool in await build_mcp().list_tools()}
 
-    assert {"create_file_link", "list_file_links", "revoke_file_link"} <= names
+    assert {"create_file_link", "list_file_links", "revoke_file_link"} <= tools.keys()
+    assert tools["create_file_link"].inputSchema["properties"]["inline"]["default"] is False
 
 
 def test_share_link_cannot_be_retargeted_outside_workspace(tmp_path, monkeypatch):

--- a/tests/test_edge_modules_complete.py
+++ b/tests/test_edge_modules_complete.py
@@ -683,6 +683,13 @@ def test_http_app_executes_every_route_wrapper(tmp_path, monkeypatch):
         response = getattr(client, method)(path, json=body) if body is not None else getattr(client, method)(path)
         assert response.status_code == 200, (method, path, response.text)
 
+    inline_response = client.post(
+        "/tools/download/create",
+        json={"path": "preview.png", "inline": True},
+    )
+    assert inline_response.status_code == 200
+    assert inline_response.json()["args"][-1] is True
+
     monkeypatch.setattr(
         http_app,
         "public_run_shell",

--- a/tests/test_main_complete.py
+++ b/tests/test_main_complete.py
@@ -161,7 +161,7 @@ def test_main_subcommands_and_version(monkeypatch, capsys):
     assert calls == [("job", ["a"]), ("worker", ["b"]), ("tui", ["c"])]
     output = capsys.readouterr().out
     assert "version-info" in output
-    assert output.count("3.0.0") == 2
+    assert output.count("3.0.1") == 2
 
 
 def test_main_modes_config_and_errors(tmp_path, monkeypatch):

--- a/tests/test_windows_native_backend.py
+++ b/tests/test_windows_native_backend.py
@@ -17,7 +17,7 @@ async def test_native_persistent_shell_backend_roundtrip(tmp_path, monkeypatch):
     try:
         await ops.send_shell(session["session_id"], "echo native-ok")
         data = {"output": ""}
-        for _ in range(40):
+        for _ in range(100):
             data = await ops.read_shell(session["session_id"], lines=20)
             if "native-ok" in data["output"]:
                 break


### PR DESCRIPTION
## Summary
- add `inline: bool = false` to MCP and REST file-link creation
- persist source MIME type and return `Content-Disposition: inline` for GET/HEAD when requested
- sandbox inline responses with CSP and disable MIME sniffing
- extend the Windows native-shell startup test window from about 2 seconds to 5 seconds
- bump the project version to `3.0.1`

## Validation
- `python -m ruff check .`
- `python -m pytest -q` (432 passed)