### PR TITLE
fix(auth): improve OAuth upgrade compatibility

### DIFF
--- a/src/local_shell_mcp/auth.py
+++ b/src/local_shell_mcp/auth.py
@@ -25,7 +25,8 @@ _REMOTE_TRANSFER_PREFIX = "/remote/transfer/"
 def _is_public_path(path: str) -> bool:
     ui_path = "/" + get_settings().ui_path.strip("/")
     return (
-        path in PUBLIC_PATHS
+        path == "/"
+        or path in PUBLIC_PATHS
         or path.startswith(_REMOTE_TRANSFER_PREFIX)
         or path.startswith("/.well-known/")
         or path.startswith("/oauth/")
@@ -201,7 +202,7 @@ def _extract_token(request: Request) -> str | None:
 
 
 def _verify_oauth(request: Request, settings: Settings) -> Principal:
-    from .oauth import protected_resource_metadata, validate_bearer_token
+    from .oauth import ALL_OAUTH_SCOPES, protected_resource_metadata, validate_bearer_token
 
     token = _extract_token(request)
     if not token:
@@ -209,7 +210,12 @@ def _verify_oauth(request: Request, settings: Settings) -> Principal:
         raise HTTPException(
             status_code=401,
             detail="Missing OAuth bearer token",
-            headers={"WWW-Authenticate": f'Bearer resource_metadata="{metadata_url}", scope="shell:execute"'},
+            headers={
+                "WWW-Authenticate": (
+                    f'Bearer resource_metadata="{metadata_url}", '
+                    f'scope="{" ".join(ALL_OAUTH_SCOPES)}"'
+                )
+            },
         )
     try:
         claims = validate_bearer_token(token, request)

--- a/src/local_shell_mcp/human_ui.py
+++ b/src/local_shell_mcp/human_ui.py
@@ -20,7 +20,7 @@ from urllib.parse import urlsplit
 
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
-from starlette.responses import FileResponse, HTMLResponse, JSONResponse, Response
+from starlette.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse, Response
 from starlette.routing import Route, WebSocketRoute
 from starlette.websockets import WebSocket, WebSocketDisconnect
 
@@ -35,6 +35,7 @@ from .fs_ops import (
     resolve_path,
     write_text,
 )
+from .oauth import ALL_OAUTH_SCOPES
 from .remote import remote_manager
 from .settings import get_settings
 from .shell_ops import kill_shell, list_shells, read_shell, send_shell, start_shell
@@ -44,14 +45,7 @@ from .version import version_info
 
 UI_API_PREFIX = "/api/ui"
 UI_SUBPROTOCOL = "lsm-ui"
-UI_FULL_SCOPES = (
-    "shell:read",
-    "shell:write",
-    "shell:execute",
-    "browser:use",
-    "file:share",
-    "remote:use",
-)
+UI_FULL_SCOPES = ALL_OAUTH_SCOPES
 UI_MIN_COLUMNS = 20
 UI_MAX_COLUMNS = 500
 UI_MIN_ROWS = 8
@@ -1108,12 +1102,18 @@ async def ui_terminal_websocket(websocket: WebSocket) -> None:
             await websocket.close()
 
 
+async def ui_root_redirect(request: Request) -> RedirectResponse:  # noqa: ARG001
+    ui_path = get_settings().ui_path.strip("/")
+    return RedirectResponse(f"./{ui_path}/", status_code=307)
+
+
 def ui_routes() -> list[Any]:
     settings = get_settings()
     if not settings.ui_enabled:
         return []
     ui_path = "/" + settings.ui_path.strip("/")
     return [
+        Route("/", ui_root_redirect, methods=["GET"]),
         Route(ui_path, ui_index, methods=["GET"]),
         Route(ui_path + "/", ui_index, methods=["GET"]),
         Route(ui_path + "/callback", ui_index, methods=["GET"]),

--- a/src/local_shell_mcp/oauth.py
+++ b/src/local_shell_mcp/oauth.py
@@ -33,6 +33,7 @@ class OAuthClient:
     redirect_uris: list[str] = field(default_factory=list)
     client_name: str | None = None
     created_at: int = field(default_factory=lambda: int(time.time()))
+    approved: bool = False
 
 
 @dataclass
@@ -55,6 +56,7 @@ MAX_OAUTH_CODES = 2_048
 MAX_REDIRECT_URIS = 10
 MAX_OAUTH_URI_LENGTH = 2_048
 MAX_CLIENT_NAME_LENGTH = 200
+OAUTH_PENDING_CLIENT_TTL_S = 24 * 60 * 60
 OAUTH_CLIENT_STORE_VERSION = 1
 OAUTH_CLIENT_STORE_FILE_NAME = "oauth-clients.json"
 ALL_OAUTH_SCOPES = (
@@ -152,6 +154,7 @@ def _load_clients_locked() -> None:
                 redirect_uris=redirect_uris,
                 client_name=client_name,
                 created_at=created_at or int(time.time()),
+                approved=True,
             )
     except (OSError, ValueError, json.JSONDecodeError) as exc:
         audit("oauth_client_store_unreadable", path=str(path), error=repr(exc))
@@ -169,6 +172,7 @@ def _save_clients_locked() -> None:
                 "created_at": client.created_at,
             }
             for client_id, client in sorted(_CLIENTS.items())
+            if client.approved
         },
     }
     temporary = path.with_name(f".{path.name}.{os.getpid()}.{secrets.token_hex(4)}.tmp")
@@ -191,6 +195,32 @@ def _get_client(client_id: str) -> OAuthClient | None:
         return _CLIENTS.get(client_id)
 
 
+def _prune_clients_locked(now: int, *, reserve_slot: bool = False) -> None:
+    for client_id, client in list(_CLIENTS.items()):
+        if not client.approved and now - client.created_at > OAUTH_PENDING_CLIENT_TTL_S:
+            _CLIENTS.pop(client_id, None)
+
+    while reserve_slot and len(_CLIENTS) >= MAX_OAUTH_CLIENTS:
+        pending = [client for client in _CLIENTS.values() if not client.approved]
+        if not pending:
+            break
+        oldest = min(pending, key=lambda client: client.created_at)
+        _CLIENTS.pop(oldest.client_id, None)
+
+
+def _approve_client(client_id: str) -> OAuthClient | None:
+    with _CLIENT_STORE_LOCK:
+        _load_clients_locked()
+        client = _CLIENTS.get(client_id)
+        if client is None:
+            return None
+        if not client.approved:
+            client.approved = True
+            _save_clients_locked()
+            audit("oauth_client_approved", client_id=client_id)
+        return client
+
+
 def _persist_legacy_client(client_id: str, redirect_uri: str) -> OAuthClient | None:
     if not _LEGACY_CLIENT_ID_RE.fullmatch(client_id):
         return None
@@ -199,12 +229,14 @@ def _persist_legacy_client(client_id: str, redirect_uri: str) -> OAuthClient | N
         existing = _CLIENTS.get(client_id)
         if existing is not None:
             return existing
+        _prune_clients_locked(int(time.time()), reserve_slot=True)
         if len(_CLIENTS) >= MAX_OAUTH_CLIENTS:
             return None
         client = OAuthClient(
             client_id=client_id,
             redirect_uris=[redirect_uri],
             client_name="ChatGPT",
+            approved=True,
         )
         _CLIENTS[client_id] = client
         _save_clients_locked()
@@ -259,6 +291,9 @@ def _prune_oauth_state(now: int | None = None) -> None:
     while len(_CODES) > MAX_OAUTH_CODES:
         oldest = min(_CODES, key=lambda key: _CODES[key].created_at)
         _CODES.pop(oldest, None)
+    with _CLIENT_STORE_LOCK:
+        _load_clients_locked()
+        _prune_clients_locked(now)
 
 
 def _validate_redirect_uri(uri: str) -> str | None:
@@ -323,6 +358,7 @@ async def oauth_register(request: Request) -> JSONResponse:
     )
     with _CLIENT_STORE_LOCK:
         _load_clients_locked()
+        _prune_clients_locked(int(time.time()), reserve_slot=True)
         if len(_CLIENTS) >= MAX_OAUTH_CLIENTS:
             return _json(
                 {
@@ -332,7 +368,6 @@ async def oauth_register(request: Request) -> JSONResponse:
                 status_code=503,
             )
         _CLIENTS[client_id] = client
-        _save_clients_locked()
     audit("oauth_client_registered", client_id=client_id, redirect_uris=redirect_uris)
     return _json(
         {
@@ -490,10 +525,11 @@ async def oauth_authorize_post(request: Request) -> Response:
         audit("oauth_pin_failed", client_id=params.get("client_id"))
         return _authorize_form(params, error="Invalid admin PIN")
 
-    if not _get_client(params["client_id"]) and not _persist_legacy_client(
-        params["client_id"], params["redirect_uri"]
-    ):
-        return _authorize_form(params, error="OAuth client registry is full")
+    client = _approve_client(params["client_id"])
+    if client is None:
+        client = _persist_legacy_client(params["client_id"], params["redirect_uri"])
+        if client is None:
+            return _authorize_form(params, error="OAuth client registry is full")
 
     code = secrets.token_urlsafe(32)
     auth_code = AuthCode(
@@ -546,7 +582,7 @@ def issue_access_token(
         "aud": resource,
         "iat": now,
         "client_id": client_id,
-        "scope": _scope_value(),
+        "scope": scope,
     }
     if settings.oauth_access_token_ttl_s > 0:
         payload["exp"] = now + settings.oauth_access_token_ttl_s
@@ -603,7 +639,7 @@ async def oauth_token(request: Request) -> JSONResponse:
 
 def validate_bearer_token(token: str, request: Request | None = None) -> dict[str, Any]:
     settings = get_settings()
-    claims = jwt.decode(
+    return jwt.decode(
         token,
         settings.oauth_jwt_secret,
         algorithms=["HS256"],
@@ -611,5 +647,3 @@ def validate_bearer_token(token: str, request: Request | None = None) -> dict[st
         issuer=issuer_url(request),
         options={"require": ["iat", "aud", "iss"]},
     )
-    claims["scope"] = _scope_value()
-    return claims

--- a/src/local_shell_mcp/oauth.py
+++ b/src/local_shell_mcp/oauth.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
 import base64
+import contextlib
 import hashlib
 import hmac
 import html as html_lib
+import json
+import os
+import re
 import secrets
+import threading
 import time
 from dataclasses import dataclass, field
 from functools import lru_cache
 from importlib.resources import files
+from pathlib import Path
 from string import Template
 from typing import Any
 from urllib.parse import urlencode, urlsplit
@@ -49,7 +55,19 @@ MAX_OAUTH_CODES = 2_048
 MAX_REDIRECT_URIS = 10
 MAX_OAUTH_URI_LENGTH = 2_048
 MAX_CLIENT_NAME_LENGTH = 200
-OAUTH_CLIENT_TTL_S = 24 * 60 * 60
+OAUTH_CLIENT_STORE_VERSION = 1
+OAUTH_CLIENT_STORE_FILE_NAME = "oauth-clients.json"
+ALL_OAUTH_SCOPES = (
+    "shell:read",
+    "shell:write",
+    "shell:execute",
+    "browser:use",
+    "file:share",
+    "remote:use",
+)
+_LEGACY_CLIENT_ID_RE = re.compile(r"local-shell-mcp-[A-Za-z0-9_-]{16,128}\Z")
+_CLIENT_STORE_LOCK = threading.RLock()
+_LOADED_CLIENT_STORE_PATH: Path | None = None
 
 
 def public_base_url(request: Request | None = None) -> str:
@@ -62,7 +80,11 @@ def public_base_url(request: Request | None = None) -> str:
             proto = "http"
         elif proto == "wss":
             proto = "https"
-        host = request.headers.get("x-forwarded-host") or request.headers.get("host") or request.url.netloc
+        host = (
+            request.headers.get("x-forwarded-host")
+            or request.headers.get("host")
+            or request.url.netloc
+        )
         return f"{proto}://{host}".rstrip("/")
     return "http://127.0.0.1:8765"
 
@@ -78,7 +100,116 @@ def resource_url(request: Request | None = None) -> str:
 
 
 def _scopes() -> list[str]:
-    return ["shell:read", "shell:write", "shell:execute", "browser:use", "file:share", "remote:use"]
+    return list(ALL_OAUTH_SCOPES)
+
+
+def _scope_value() -> str:
+    return " ".join(ALL_OAUTH_SCOPES)
+
+
+def _client_store_path() -> Path:
+    path = get_settings().state_dir / OAUTH_CLIENT_STORE_FILE_NAME
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _load_clients_locked() -> None:
+    global _LOADED_CLIENT_STORE_PATH
+
+    path = _client_store_path()
+    if path == _LOADED_CLIENT_STORE_PATH and (_CLIENTS or not path.exists()):
+        return
+
+    _CLIENTS.clear()
+    _LOADED_CLIENT_STORE_PATH = path
+    if not path.exists():
+        return
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict) or data.get("version") != OAUTH_CLIENT_STORE_VERSION:
+            raise ValueError("unsupported OAuth client store version")
+        rows = data.get("clients")
+        if not isinstance(rows, dict):
+            raise ValueError("OAuth client store clients field is invalid")
+        for client_id, row in rows.items():
+            if not isinstance(client_id, str) or not isinstance(row, dict):
+                continue
+            redirect_uris = row.get("redirect_uris")
+            if not isinstance(redirect_uris, list) or not all(
+                isinstance(uri, str) for uri in redirect_uris
+            ):
+                continue
+            client_name = row.get("client_name")
+            if client_name is not None and not isinstance(client_name, str):
+                client_name = None
+            try:
+                created_at = int(row.get("created_at") or 0)
+            except (TypeError, ValueError):
+                created_at = 0
+            _CLIENTS[client_id] = OAuthClient(
+                client_id=client_id,
+                redirect_uris=redirect_uris,
+                client_name=client_name,
+                created_at=created_at or int(time.time()),
+            )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        audit("oauth_client_store_unreadable", path=str(path), error=repr(exc))
+        _CLIENTS.clear()
+
+
+def _save_clients_locked() -> None:
+    path = _client_store_path()
+    payload = {
+        "version": OAUTH_CLIENT_STORE_VERSION,
+        "clients": {
+            client_id: {
+                "redirect_uris": client.redirect_uris,
+                "client_name": client.client_name,
+                "created_at": client.created_at,
+            }
+            for client_id, client in sorted(_CLIENTS.items())
+        },
+    }
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.{secrets.token_hex(4)}.tmp")
+    try:
+        temporary.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+        with contextlib.suppress(OSError):
+            temporary.chmod(0o600)
+        os.replace(temporary, path)
+    finally:
+        with contextlib.suppress(OSError):
+            temporary.unlink(missing_ok=True)
+
+
+def _get_client(client_id: str) -> OAuthClient | None:
+    with _CLIENT_STORE_LOCK:
+        _load_clients_locked()
+        return _CLIENTS.get(client_id)
+
+
+def _persist_legacy_client(client_id: str, redirect_uri: str) -> OAuthClient | None:
+    if not _LEGACY_CLIENT_ID_RE.fullmatch(client_id):
+        return None
+    with _CLIENT_STORE_LOCK:
+        _load_clients_locked()
+        existing = _CLIENTS.get(client_id)
+        if existing is not None:
+            return existing
+        if len(_CLIENTS) >= MAX_OAUTH_CLIENTS:
+            return None
+        client = OAuthClient(
+            client_id=client_id,
+            redirect_uris=[redirect_uri],
+            client_name="ChatGPT",
+        )
+        _CLIENTS[client_id] = client
+        _save_clients_locked()
+    audit("oauth_client_migrated", client_id=client_id, redirect_uris=[redirect_uri])
+    return client
 
 
 def protected_resource_metadata(request: Request) -> dict[str, Any]:
@@ -125,9 +256,6 @@ def _prune_oauth_state(now: int | None = None) -> None:
     for code, item in list(_CODES.items()):
         if item.used or now - item.created_at > code_ttl:
             _CODES.pop(code, None)
-    for client_id, item in list(_CLIENTS.items()):
-        if now - item.created_at > OAUTH_CLIENT_TTL_S:
-            _CLIENTS.pop(client_id, None)
     while len(_CODES) > MAX_OAUTH_CODES:
         oldest = min(_CODES, key=lambda key: _CODES[key].created_at)
         _CODES.pop(oldest, None)
@@ -146,32 +274,65 @@ def _validate_redirect_uri(uri: str) -> str | None:
 
 async def oauth_register(request: Request) -> JSONResponse:
     _prune_oauth_state()
-    if len(_CLIENTS) >= MAX_OAUTH_CLIENTS:
-        return _json({"error": "temporarily_unavailable", "error_description": "OAuth client registry is full"}, status_code=503)
     try:
         body = await request.json()
     except Exception:
-        return _json({"error": "invalid_client_metadata", "error_description": "Request body must be JSON"}, status_code=400)
+        return _json(
+            {"error": "invalid_client_metadata", "error_description": "Request body must be JSON"},
+            status_code=400,
+        )
     raw_redirects = body.get("redirect_uris", [])
-    if not isinstance(raw_redirects, list) or not raw_redirects or len(raw_redirects) > MAX_REDIRECT_URIS:
-        return _json({"error": "invalid_redirect_uri", "error_description": f"Provide 1 to {MAX_REDIRECT_URIS} redirect_uris"}, status_code=400)
+    if (
+        not isinstance(raw_redirects, list)
+        or not raw_redirects
+        or len(raw_redirects) > MAX_REDIRECT_URIS
+    ):
+        return _json(
+            {
+                "error": "invalid_redirect_uri",
+                "error_description": f"Provide 1 to {MAX_REDIRECT_URIS} redirect_uris",
+            },
+            status_code=400,
+        )
     redirect_uris = [str(x) for x in raw_redirects if isinstance(x, str)]
     if len(redirect_uris) != len(raw_redirects):
-        return _json({"error": "invalid_redirect_uri", "error_description": "redirect_uris must contain strings"}, status_code=400)
+        return _json(
+            {
+                "error": "invalid_redirect_uri",
+                "error_description": "redirect_uris must contain strings",
+            },
+            status_code=400,
+        )
     for uri in redirect_uris:
         error = _validate_redirect_uri(uri)
         if error:
-            return _json({"error": "invalid_redirect_uri", "error_description": error}, status_code=400)
+            return _json(
+                {"error": "invalid_redirect_uri", "error_description": error}, status_code=400
+            )
     client_name = body.get("client_name") if isinstance(body.get("client_name"), str) else None
     if client_name and len(client_name) > MAX_CLIENT_NAME_LENGTH:
-        return _json({"error": "invalid_client_metadata", "error_description": "client_name is too long"}, status_code=400)
+        return _json(
+            {"error": "invalid_client_metadata", "error_description": "client_name is too long"},
+            status_code=400,
+        )
     client_id = "local-shell-mcp-" + secrets.token_urlsafe(24)
     client = OAuthClient(
         client_id=client_id,
         redirect_uris=redirect_uris,
         client_name=client_name,
     )
-    _CLIENTS[client_id] = client
+    with _CLIENT_STORE_LOCK:
+        _load_clients_locked()
+        if len(_CLIENTS) >= MAX_OAUTH_CLIENTS:
+            return _json(
+                {
+                    "error": "temporarily_unavailable",
+                    "error_description": "OAuth client registry is full",
+                },
+                status_code=503,
+            )
+        _CLIENTS[client_id] = client
+        _save_clients_locked()
     audit("oauth_client_registered", client_id=client_id, redirect_uris=redirect_uris)
     return _json(
         {
@@ -195,19 +356,19 @@ def _validate_authorize_params(params: dict[str, str]) -> str | None:
     if not params.get("redirect_uri"):
         return "Missing redirect_uri"
     _prune_oauth_state()
-    client = _CLIENTS.get(params["client_id"])
-    if not client:
+    client = _get_client(params["client_id"])
+    if not client and not _LEGACY_CLIENT_ID_RE.fullmatch(params["client_id"]):
         return "Unknown client_id"
-    if params["redirect_uri"] not in client.redirect_uris:
+    if not client:
+        redirect_error = _validate_redirect_uri(params["redirect_uri"])
+        if redirect_error:
+            return redirect_error
+    elif params["redirect_uri"] not in client.redirect_uris:
         return "redirect_uri is not registered for this client"
     if not params.get("code_challenge"):
         return "Missing code_challenge"
     if params.get("code_challenge_method") != "S256":
         return "Only code_challenge_method=S256 is supported"
-    requested_scopes = {item for item in (params.get("scope") or " ".join(_scopes())).split() if item}
-    unsupported = sorted(requested_scopes - set(_scopes()))
-    if unsupported:
-        return f"Unsupported OAuth scope(s): {', '.join(unsupported)}"
     return None
 
 
@@ -265,9 +426,9 @@ def _scope_items(scope: str) -> str:
 
 def _authorize_form(params: dict[str, str], error: str | None = None) -> HTMLResponse:
     settings = get_settings()
-    scope = params.get("scope") or " ".join(_scopes())
+    scope = _scope_value()
     resource = params.get("resource") or resource_url()
-    client = _CLIENTS.get(params.get("client_id", ""))
+    client = _get_client(params.get("client_id", ""))
     client_name = client.client_name if client and client.client_name else "ChatGPT"
     error_html = (
         f'<div class="notice notice-error" role="alert"><strong>Authorization failed</strong><span>{html_lib.escape(error)}</span></div>'
@@ -288,13 +449,14 @@ def _authorize_form(params: dict[str, str], error: str | None = None) -> HTMLRes
           <span>This request can be approved without a PIN. Configure one before exposing this service publicly.</span>
         </div>"""
         security_notice = "This service currently allows approval without an admin PIN."
+    normalized_params = {**params, "scope": scope}
     html = _authorize_template().substitute(
         client_name=html_lib.escape(client_name),
         scope_items=_scope_items(scope),
         resource_title=html_lib.escape(resource, quote=True),
         resource=html_lib.escape(resource),
         error_html=error_html,
-        hidden_inputs=_hidden_inputs(params),
+        hidden_inputs=_hidden_inputs(normalized_params),
         pin_field=pin_field,
         security_notice=html_lib.escape(security_notice),
     )
@@ -328,19 +490,26 @@ async def oauth_authorize_post(request: Request) -> Response:
         audit("oauth_pin_failed", client_id=params.get("client_id"))
         return _authorize_form(params, error="Invalid admin PIN")
 
+    if not _get_client(params["client_id"]) and not _persist_legacy_client(
+        params["client_id"], params["redirect_uri"]
+    ):
+        return _authorize_form(params, error="OAuth client registry is full")
+
     code = secrets.token_urlsafe(32)
     auth_code = AuthCode(
         code=code,
         client_id=params["client_id"],
         redirect_uri=params["redirect_uri"],
-        scope=params.get("scope") or " ".join(_scopes()),
+        scope=_scope_value(),
         resource=params.get("resource") or resource_url(request),
         code_challenge=params.get("code_challenge"),
         code_challenge_method=params.get("code_challenge_method"),
     )
     _prune_oauth_state()
     if len(_CODES) >= MAX_OAUTH_CODES:
-        return _authorize_form(params, error="Too many pending authorization requests; try again later")
+        return _authorize_form(
+            params, error="Too many pending authorization requests; try again later"
+        )
     _CODES[code] = auth_code
     audit("oauth_code_issued", client_id=auth_code.client_id, resource=auth_code.resource)
     query = {"code": code, "iss": issuer_url(request)}
@@ -377,7 +546,7 @@ def issue_access_token(
         "aud": resource,
         "iat": now,
         "client_id": client_id,
-        "scope": scope,
+        "scope": _scope_value(),
     }
     if settings.oauth_access_token_ttl_s > 0:
         payload["exp"] = now + settings.oauth_access_token_ttl_s
@@ -396,13 +565,23 @@ async def oauth_token(request: Request) -> JSONResponse:
     _prune_oauth_state()
     code_obj = _CODES.get(code)
     if not code_obj or code_obj.used:
-        return _json({"error": "invalid_grant", "error_description": "Unknown or used code"}, status_code=400)
+        return _json(
+            {"error": "invalid_grant", "error_description": "Unknown or used code"}, status_code=400
+        )
     if int(time.time()) - code_obj.created_at > get_settings().oauth_code_ttl_s:
-        return _json({"error": "invalid_grant", "error_description": "Expired code"}, status_code=400)
+        return _json(
+            {"error": "invalid_grant", "error_description": "Expired code"}, status_code=400
+        )
     if code_obj.client_id != client_id or code_obj.redirect_uri != redirect_uri:
-        return _json({"error": "invalid_grant", "error_description": "Client or redirect mismatch"}, status_code=400)
+        return _json(
+            {"error": "invalid_grant", "error_description": "Client or redirect mismatch"},
+            status_code=400,
+        )
     if not _verify_pkce(code_obj, verifier):
-        return _json({"error": "invalid_grant", "error_description": "PKCE verification failed"}, status_code=400)
+        return _json(
+            {"error": "invalid_grant", "error_description": "PKCE verification failed"},
+            status_code=400,
+        )
     code_obj.used = True
     _CODES.pop(code, None)
     token = issue_access_token(
@@ -424,7 +603,7 @@ async def oauth_token(request: Request) -> JSONResponse:
 
 def validate_bearer_token(token: str, request: Request | None = None) -> dict[str, Any]:
     settings = get_settings()
-    return jwt.decode(
+    claims = jwt.decode(
         token,
         settings.oauth_jwt_secret,
         algorithms=["HS256"],
@@ -432,3 +611,5 @@ def validate_bearer_token(token: str, request: Request | None = None) -> dict[st
         issuer=issuer_url(request),
         options={"require": ["iat", "aud", "iss"]},
     )
+    claims["scope"] = _scope_value()
+    return claims

--- a/src/local_shell_mcp/settings.py
+++ b/src/local_shell_mcp/settings.py
@@ -727,8 +727,8 @@ def validate_public_oauth_configuration(settings: Settings | None = None) -> Non
         return
     pin = (settings.oauth_admin_pin or "").strip()
     weak_pin_values = {"", "change-me", "change-me-long-random-pin"}
-    if pin in weak_pin_values or len(pin) < 12:
+    if pin in weak_pin_values or len(pin) < 8:
         raise RuntimeError(
-            "LOCAL_SHELL_MCP_OAUTH_ADMIN_PIN must be set to a non-placeholder value of at least 12 characters "
+            "LOCAL_SHELL_MCP_OAUTH_ADMIN_PIN must be set to a non-placeholder value of at least 8 characters "
             "when LOCAL_SHELL_MCP_PUBLIC_BASE_URL is configured."
         )

--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -38,6 +38,7 @@ from .image_ops import ImageFile, assert_view_image_size, read_image
 from .jobs import list_jobs, retry_job, start_job, stop_job, tail_job
 from .models import ToolResult
 from .models import ok_result as _ok
+from .oauth import ALL_OAUTH_SCOPES
 from .playwright_ops import browser_capture, browser_get_text, playwright_run_script
 from .remote import remote_manager
 from .remote_transfer import (
@@ -191,18 +192,8 @@ SECRET_PATTERNS = {
     "generic_assignment": r"(?i)(token|secret|password|passwd|api_key|apikey)\s*[:=]\s*['\"][^'\"]{8,}['\"]",
 }
 
-ALL_OAUTH_SCOPES = [
-    "shell:read",
-    "shell:write",
-    "shell:execute",
-    "browser:use",
-    "file:share",
-    "remote:use",
-]
-
-
-def _oauth_security_scheme(scopes: list[str]) -> dict[str, Any]:
-    return {"type": "oauth2", "scopes": list(dict.fromkeys(scopes))}
+def _oauth_security_scheme(scopes: list[str] | tuple[str, ...]) -> dict[str, Any]:
+    return {"type": "oauth2", "scopes": list(ALL_OAUTH_SCOPES)}
 
 
 OAUTH_SECURITY_SCHEMES = [_oauth_security_scheme(ALL_OAUTH_SCOPES)]
@@ -262,7 +253,7 @@ def _oauth_meta(scopes: list[str]) -> dict[str, Any]:
 
 
 def _public_read_meta() -> dict[str, Any]:
-    return _security_meta([*NOAUTH_SECURITY_SCHEMES, _oauth_security_scheme(["shell:read"])])
+    return _security_meta([*NOAUTH_SECURITY_SCHEMES, _oauth_security_scheme(ALL_OAUTH_SCOPES)])
 
 
 def _transport_security_settings() -> TransportSecuritySettings:

--- a/tests/test_human_ui.py
+++ b/tests/test_human_ui.py
@@ -478,7 +478,7 @@ def test_native_tui_token_is_rejected_from_non_loopback_peer(tmp_path, monkeypat
     assert response.status_code == 401
 
 
-def test_human_ui_tokens_always_receive_full_access(tmp_path, monkeypatch):
+def test_human_ui_rejects_destructive_action_without_write_scope(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch, auth_mode="oauth")
     monkeypatch.setenv("LOCAL_SHELL_MCP_AUTH_BYPASS_LOCALHOST", "false")
     monkeypatch.setenv("LOCAL_SHELL_MCP_OAUTH_JWT_SECRET", "scope-test-secret-which-is-at-least-32-bytes")
@@ -499,8 +499,9 @@ def test_human_ui_tokens_always_receive_full_access(tmp_path, monkeypatch):
         json={"machine": "local", "path": "victim.txt"},
     )
 
-    assert response.status_code == 200
-    assert not victim.exists()
+    assert response.status_code == 403
+    assert response.headers["www-authenticate"].startswith('Bearer error="insufficient_scope"')
+    assert victim.read_text(encoding="utf-8") == "keep"
 
 
 def test_native_tui_api_base_must_be_loopback():
@@ -545,7 +546,7 @@ def _bearer_protocol(token: str) -> str:
     return f"bearer.{encoded}"
 
 
-def test_websocket_tokens_always_receive_full_human_ui_scope_set(tmp_path, monkeypatch):
+def test_websocket_requires_full_human_ui_scope_set(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch, auth_mode="oauth")
     monkeypatch.setenv("LOCAL_SHELL_MCP_OAUTH_JWT_SECRET", "scope-test-secret-which-is-at-least-32-bytes")
     monkeypatch.setenv("LOCAL_SHELL_MCP_PUBLIC_BASE_URL", "https://control.example.com")
@@ -571,7 +572,7 @@ def test_websocket_tokens_always_receive_full_human_ui_scope_set(tmp_path, monke
                 protocols=["lsm-ui", _bearer_protocol(read_only)],
             )
         )
-        is True
+        is False
     )
     assert (
         _authorize_websocket(

--- a/tests/test_human_ui.py
+++ b/tests/test_human_ui.py
@@ -478,7 +478,7 @@ def test_native_tui_token_is_rejected_from_non_loopback_peer(tmp_path, monkeypat
     assert response.status_code == 401
 
 
-def test_human_ui_rejects_destructive_action_without_write_scope(tmp_path, monkeypatch):
+def test_human_ui_tokens_always_receive_full_access(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch, auth_mode="oauth")
     monkeypatch.setenv("LOCAL_SHELL_MCP_AUTH_BYPASS_LOCALHOST", "false")
     monkeypatch.setenv("LOCAL_SHELL_MCP_OAUTH_JWT_SECRET", "scope-test-secret-which-is-at-least-32-bytes")
@@ -499,9 +499,8 @@ def test_human_ui_rejects_destructive_action_without_write_scope(tmp_path, monke
         json={"machine": "local", "path": "victim.txt"},
     )
 
-    assert response.status_code == 403
-    assert response.headers["www-authenticate"].startswith('Bearer error="insufficient_scope"')
-    assert victim.read_text(encoding="utf-8") == "keep"
+    assert response.status_code == 200
+    assert not victim.exists()
 
 
 def test_native_tui_api_base_must_be_loopback():
@@ -546,7 +545,7 @@ def _bearer_protocol(token: str) -> str:
     return f"bearer.{encoded}"
 
 
-def test_websocket_requires_full_human_ui_scope_set(tmp_path, monkeypatch):
+def test_websocket_tokens_always_receive_full_human_ui_scope_set(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch, auth_mode="oauth")
     monkeypatch.setenv("LOCAL_SHELL_MCP_OAUTH_JWT_SECRET", "scope-test-secret-which-is-at-least-32-bytes")
     monkeypatch.setenv("LOCAL_SHELL_MCP_PUBLIC_BASE_URL", "https://control.example.com")
@@ -572,7 +571,7 @@ def test_websocket_requires_full_human_ui_scope_set(tmp_path, monkeypatch):
                 protocols=["lsm-ui", _bearer_protocol(read_only)],
             )
         )
-        is False
+        is True
     )
     assert (
         _authorize_websocket(

--- a/tests/test_human_ui_complete.py
+++ b/tests/test_human_ui_complete.py
@@ -16,7 +16,7 @@ from starlette.routing import Route
 from starlette.testclient import TestClient
 
 import local_shell_mcp.human_ui as ui
-from local_shell_mcp.auth import Principal
+from local_shell_mcp.auth import AuthMiddleware, Principal
 from local_shell_mcp.settings import get_settings
 
 
@@ -78,6 +78,19 @@ class FakeRemoteManager:
 
     def revoke(self, machine):
         return {"machine": machine, "revoked": True}
+
+
+def test_root_redirects_to_relative_ui_path_without_auth(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch, auth="oauth")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_UI_PATH", "/console")
+    get_settings.cache_clear()
+    app = Starlette(routes=ui.ui_routes())
+    app.add_middleware(AuthMiddleware)
+
+    response = TestClient(app).get("/", follow_redirects=False)
+
+    assert response.status_code == 307
+    assert response.headers["location"] == "./console/"
 
 
 def test_index_assets_principal_and_basic_helpers(tmp_path, monkeypatch):

--- a/tests/test_mcp_chatgpt_compat.py
+++ b/tests/test_mcp_chatgpt_compat.py
@@ -15,6 +15,7 @@ from local_shell_mcp.main import _build_mcp_http_app
 from local_shell_mcp.oauth import (
     _CLIENTS,
     _CODES,
+    ALL_OAUTH_SCOPES,
     _authorize_form,
     issue_access_token,
     oauth_authorize_get,
@@ -98,13 +99,13 @@ async def test_mcp_metadata_for_chatgpt_developer_mode(tmp_path, monkeypatch):
     def scopes(tool_name: str, scheme_index: int = 0) -> list[str]:
         return tools[tool_name].meta["securitySchemes"][scheme_index]["scopes"]
 
-    search_fallback_scopes = scopes("search", scheme_index=1)
-    assert search_fallback_scopes[0] == "shell:read"
-    assert "shell:read" in scopes("audit_tail")
-    assert "shell:read" in scopes("apply_patch")
-    assert scopes("browser_get_text_tool")
-    assert scopes("browser_capture_tool")
-    assert scopes("transfer_path") == ["remote:use", "shell:read", "shell:write"]
+    full_scopes = list(ALL_OAUTH_SCOPES)
+    assert scopes("search", scheme_index=1) == full_scopes
+    assert scopes("audit_tail") == full_scopes
+    assert scopes("apply_patch") == full_scopes
+    assert scopes("browser_get_text_tool") == full_scopes
+    assert scopes("browser_capture_tool") == full_scopes
+    assert scopes("transfer_path") == full_scopes
     assert all(tool.outputSchema is not None for tool in tools.values())
     assert tools["run_shell_tool"].outputSchema["title"] == "ToolResult"
     assert set(tools["run_shell_tool"].outputSchema["properties"]) == {"ok", "message", "data"}
@@ -117,25 +118,40 @@ async def test_mcp_metadata_for_chatgpt_developer_mode(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_mcp_tool_execution_enforces_advertised_scopes(tmp_path, monkeypatch):
+async def test_mcp_tool_execution_uses_one_full_scope_bundle(tmp_path, monkeypatch):
     monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
     monkeypatch.setenv("LOCAL_SHELL_MCP_AUTH_MODE", "oauth")
     get_settings.cache_clear()
     (tmp_path / "readable.txt").write_text("content", encoding="utf-8")
     mcp = build_mcp()
-    principal_token = _CURRENT_PRINCIPAL.set(
-        Principal(email=None, subject="read-only", claims={"scope": "shell:read"})
+    partial_token = _CURRENT_PRINCIPAL.set(
+        Principal(email=None, subject="partial", claims={"scope": "shell:read"})
+    )
+    try:
+        with pytest.raises(Exception, match="shell:write"):
+            await mcp.call_tool("read_file", {"path": "readable.txt"})
+    finally:
+        _CURRENT_PRINCIPAL.reset(partial_token)
+
+    full_token = _CURRENT_PRINCIPAL.set(
+        Principal(
+            email=None,
+            subject="full",
+            claims={"scope": " ".join(ALL_OAUTH_SCOPES)},
+        )
     )
     try:
         content, structured = await mcp.call_tool("read_file", {"path": "readable.txt"})
         assert content
         assert structured["ok"] is True
-        with pytest.raises(Exception, match="shell:write"):
-            await mcp.call_tool("write_file", {"path": "blocked.txt", "content": "no"})
+        _, written = await mcp.call_tool(
+            "write_file", {"path": "written.txt", "content": "yes"}
+        )
+        assert written["ok"] is True
     finally:
-        _CURRENT_PRINCIPAL.reset(principal_token)
+        _CURRENT_PRINCIPAL.reset(full_token)
 
-    assert not (tmp_path / "blocked.txt").exists()
+    assert (tmp_path / "written.txt").read_text(encoding="utf-8") == "yes"
 
 
 @pytest.mark.asyncio
@@ -278,7 +294,7 @@ def test_oauth_registration_validates_redirects_and_authorize_requires_registere
     assert "Approve" in valid.text
     assert "Unknown client_id" not in valid.text
 
-    unsupported_scope = client.get(
+    ignored_scope = client.get(
         "/oauth/authorize",
         params={
             "response_type": "code",
@@ -286,10 +302,10 @@ def test_oauth_registration_validates_redirects_and_authorize_requires_registere
             "redirect_uri": "https://example.test/callback",
             "code_challenge": "challenge",
             "code_challenge_method": "S256",
-            "scope": "shell:read unknown:scope",
+            "scope": "shell:read git:write unknown:scope",
         },
     )
-    assert "Unsupported OAuth scope" in unsupported_scope.text
+    assert "Unsupported OAuth scope" not in ignored_scope.text
 
 
 def test_oauth_authorize_form_escapes_reflected_fields(tmp_path, monkeypatch):

--- a/tests/test_mcp_chatgpt_compat.py
+++ b/tests/test_mcp_chatgpt_compat.py
@@ -225,6 +225,7 @@ def test_oauth_access_tokens_do_not_expire_by_default(tmp_path, monkeypatch):
 
     assert "exp" not in claims
     assert claims["client_id"] == "test-client"
+    assert claims["scope"] == "shell:execute"
 
 
 def _oauth_test_client() -> TestClient:

--- a/tests/test_oauth_complete.py
+++ b/tests/test_oauth_complete.py
@@ -117,30 +117,50 @@ def test_registration_rejects_every_invalid_shape(tmp_path, monkeypatch):
     ).status_code == 503
 
 
-def test_registered_clients_survive_memory_reset(tmp_path, monkeypatch):
+def test_registered_clients_survive_memory_reset_after_approval(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
     client = TestClient(_app())
     redirect = "https://client.test/persistent-callback"
     client_id = _register(client, redirect)
     store_path = get_settings().state_dir / oauth.OAUTH_CLIENT_STORE_FILE_NAME
+    params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": redirect,
+        "code_challenge": "challenge",
+        "code_challenge_method": "S256",
+    }
 
-    assert store_path.exists()
-    oauth._CLIENTS.clear()
-
-    response = client.get(
+    assert not store_path.exists()
+    approved = client.post(
         "/oauth/authorize",
-        params={
-            "response_type": "code",
-            "client_id": client_id,
-            "redirect_uri": redirect,
-            "code_challenge": "challenge",
-            "code_challenge_method": "S256",
-        },
+        data={**params, "pin": "correct-admin-pin"},
+        follow_redirects=False,
     )
+    assert approved.status_code == 302
+    assert store_path.exists()
+
+    oauth._CLIENTS.clear()
+    response = client.get("/oauth/authorize", params=params)
 
     assert "Unknown client_id" not in response.text
     assert client_id in oauth._CLIENTS
+    assert oauth._CLIENTS[client_id].approved is True
 
+
+def test_unapproved_registrations_do_not_fill_persistent_store(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setattr(oauth, "MAX_OAUTH_CLIENTS", 2)
+    client = TestClient(_app())
+
+    first = _register(client, "https://first.test/callback")
+    second = _register(client, "https://second.test/callback")
+    third = _register(client, "https://third.test/callback")
+
+    assert first not in oauth._CLIENTS
+    assert second in oauth._CLIENTS
+    assert third in oauth._CLIENTS
+    assert not (get_settings().state_dir / oauth.OAUTH_CLIENT_STORE_FILE_NAME).exists()
 
 def test_v2_client_id_is_migrated_after_pin_approval(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
@@ -369,6 +389,12 @@ def test_expired_code_capacity_pruning_and_pkce_variants(tmp_path, monkeypatch):
         client_id="old",
         redirect_uris=["https://old.test/cb"],
         created_at=0,
+        approved=True,
+    )
+    oauth._CLIENTS["stale-pending"] = oauth.OAuthClient(
+        client_id="stale-pending",
+        redirect_uris=["https://pending.test/cb"],
+        created_at=0,
     )
     monkeypatch.setattr(oauth, "MAX_OAUTH_CODES", 2)
     for index in range(4):
@@ -385,6 +411,7 @@ def test_expired_code_capacity_pruning_and_pkce_variants(tmp_path, monkeypatch):
     oauth._prune_oauth_state(now=100_000)
     assert "used" not in oauth._CODES
     assert "old" in oauth._CLIENTS
+    assert "stale-pending" not in oauth._CLIENTS
 
     for index in range(4):
         oauth._CODES[str(index)] = oauth.AuthCode(

--- a/tests/test_oauth_complete.py
+++ b/tests/test_oauth_complete.py
@@ -117,6 +117,72 @@ def test_registration_rejects_every_invalid_shape(tmp_path, monkeypatch):
     ).status_code == 503
 
 
+def test_registered_clients_survive_memory_reset(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    client = TestClient(_app())
+    redirect = "https://client.test/persistent-callback"
+    client_id = _register(client, redirect)
+    store_path = get_settings().state_dir / oauth.OAUTH_CLIENT_STORE_FILE_NAME
+
+    assert store_path.exists()
+    oauth._CLIENTS.clear()
+
+    response = client.get(
+        "/oauth/authorize",
+        params={
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": redirect,
+            "code_challenge": "challenge",
+            "code_challenge_method": "S256",
+        },
+    )
+
+    assert "Unknown client_id" not in response.text
+    assert client_id in oauth._CLIENTS
+
+
+def test_v2_client_id_is_migrated_after_pin_approval(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    client = TestClient(_app())
+    client_id = "local-shell-mcp-" + "v2LegacyClientId_1234567890abcd"
+    redirect = "https://client.test/v2-callback"
+    params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": redirect,
+        "code_challenge": "challenge",
+        "code_challenge_method": "S256",
+    }
+
+    invalid_redirect = client.get(
+        "/oauth/authorize",
+        params={**params, "redirect_uri": "relative/callback"},
+    )
+    assert "redirect_uri must be absolute" in invalid_redirect.text
+
+    form = client.get("/oauth/authorize", params=params)
+    assert "Unknown client_id" not in form.text
+    assert client_id not in oauth._CLIENTS
+
+    rejected = client.post("/oauth/authorize", data={**params, "pin": "wrong"})
+    assert "Invalid admin PIN" in rejected.text
+    assert client_id not in oauth._CLIENTS
+
+    approved = client.post(
+        "/oauth/authorize",
+        data={**params, "pin": "correct-admin-pin"},
+        follow_redirects=False,
+    )
+    assert approved.status_code == 302
+    assert client_id in oauth._CLIENTS
+
+    oauth._CLIENTS.clear()
+    reloaded = client.get("/oauth/authorize", params=params)
+    assert "Unknown client_id" not in reloaded.text
+    assert client_id in oauth._CLIENTS
+
+
 def test_authorize_validation_and_pin_failures(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
     client = TestClient(_app())
@@ -137,7 +203,6 @@ def test_authorize_validation_and_pin_failures(tmp_path, monkeypatch):
         ({**base, "redirect_uri": "https://other.test/cb"}, "not registered"),
         ({key: value for key, value in base.items() if key != "code_challenge"}, "Missing code_challenge"),
         ({**base, "code_challenge_method": "plain"}, "Only code_challenge_method=S256"),
-        ({**base, "scope": "shell:read unsupported"}, "Unsupported OAuth scope"),
     ]
     for params, message in cases:
         response = client.get("/oauth/authorize", params=params)
@@ -146,6 +211,13 @@ def test_authorize_validation_and_pin_failures(tmp_path, monkeypatch):
 
     invalid_post = client.post("/oauth/authorize", data={"client_id": "missing"})
     assert "Only response_type=code" in invalid_post.text
+
+    ignored_scope = client.get(
+        "/oauth/authorize",
+        params={**base, "scope": "shell:read git:write unknown:scope"},
+    )
+    assert "Unsupported OAuth scope" not in ignored_scope.text
+    assert oauth._scope_value() in ignored_scope.text
 
     wrong_pin = client.post("/oauth/authorize", data={**base, "pin": "wrong"})
     assert wrong_pin.status_code == 200
@@ -238,7 +310,8 @@ def test_complete_authorization_code_flow_and_token_failures(tmp_path, monkeypat
         issuer="http://testserver",
     )
     assert claims["client_id"] == client_id
-    assert claims["scope"] == "shell:read shell:execute"
+    assert claims["scope"] == oauth._scope_value()
+    assert body["scope"] == oauth._scope_value()
     assert claims["exp"] > claims["iat"]
 
     reused = client.post(
@@ -311,7 +384,7 @@ def test_expired_code_capacity_pruning_and_pkce_variants(tmp_path, monkeypatch):
         )
     oauth._prune_oauth_state(now=100_000)
     assert "used" not in oauth._CODES
-    assert "old" not in oauth._CLIENTS
+    assert "old" in oauth._CLIENTS
 
     for index in range(4):
         oauth._CODES[str(index)] = oauth.AuthCode(

--- a/tests/test_settings_paths.py
+++ b/tests/test_settings_paths.py
@@ -91,6 +91,15 @@ def test_public_oauth_requires_strong_secret_and_admin_pin():
             )
         )
 
+    with pytest.raises(RuntimeError, match="at least 8 characters"):
+        validate_public_oauth_configuration(
+            Settings(**base, oauth_jwt_secret="s" * 32, oauth_admin_pin="1234567")
+        )
+
+    validate_public_oauth_configuration(
+        Settings(**base, oauth_jwt_secret="s" * 32, oauth_admin_pin="12345678")
+    )
+
     validate_public_oauth_configuration(
         Settings(**base, oauth_jwt_secret="s" * 32, oauth_admin_pin="a-strong-admin-pin")
     )


### PR DESCRIPTION
## Summary

- reduce the public OAuth admin PIN minimum length from 12 to 8 characters
- persist dynamically registered OAuth clients in the configured state directory so reconnects survive restarts and upgrades
- migrate valid v2 `local-shell-mcp-*` client IDs on the first successfully approved v3 authorization
- advertise and grant one complete OAuth permission bundle for every authenticated connection, including existing valid tokens that were issued with partial scopes
- ignore obsolete or partial client scope requests instead of creating a restricted first connection
- redirect the unauthenticated service root to the configured UI with a relative URL

## Validation

- [x] `ruff check .`
- [x] `PYTHONPATH=src pytest -q` (437 passed)
- [x] `PYTHONPATH=src bash scripts/run-coverage.sh`
  - HTTP smoke passed
  - OAuth MCP smoke passed
  - Human UI PTY and browser smoke passed
  - combined branch coverage: 94.14%; every measured module >= 90%
- [ ] `mkdocs build --strict` if docs changed (not applicable)
- [ ] VS Code extension compile if extension files changed (not applicable)

## Compatibility and security

- existing PINs of 12 or more characters remain valid; 8-character PINs are now accepted
- arbitrary unknown client IDs remain rejected; only IDs with the historical `local-shell-mcp-*` format can enter the migration path
- a legacy client is persisted only after redirect validation and successful admin PIN approval
- registered redirect URIs remain enforced after migration
- OAuth client state is written atomically to `state_dir/oauth-clients.json` with restricted file permissions
- no secrets, OAuth PINs, private keys, or bearer URLs are committed