### PR TITLE
Fix job store migration and startup durability

### DIFF
--- a/src/local_shell_mcp/jobs.py
+++ b/src/local_shell_mcp/jobs.py
@@ -30,6 +30,7 @@ from .shell_ops import (
 JOB_STORE_FILE_NAME = "jobs.json"
 JOB_STORE_BACKUP_FILE_NAME = "jobs.json.bak"
 JOB_STORE_VERSION = 2
+JOB_STORE_LEGACY_VERSIONS = {1}
 TERMINAL_STATUSES = {"succeeded", "failed", "exited", "stopped", "lost"}
 _JOB_STORE_THREAD_LOCK = threading.RLock()
 _ACTIVE_JOB_OPERATIONS: set[str] = set()
@@ -93,14 +94,26 @@ def _unlock_store_file(handle: BinaryIO) -> None:
 
 def _load_store_file(path: Path) -> dict[str, Any]:
     data = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(data, dict) or data.get("version") != JOB_STORE_VERSION:
+    if not isinstance(data, dict):
+        raise ValueError(f"unsupported or invalid job store: {path}")
+    version = data.get("version")
+    if version != JOB_STORE_VERSION and version not in JOB_STORE_LEGACY_VERSIONS:
         raise ValueError(f"unsupported or invalid job store: {path}")
     rows = data.get("jobs")
     if not isinstance(rows, list):
         raise ValueError(f"job store jobs field is invalid: {path}")
+    jobs = [job for job in rows if isinstance(job, dict)]
+    if version != JOB_STORE_VERSION:
+        audit(
+            "job_store_migrated",
+            path=str(path),
+            from_version=version,
+            to_version=JOB_STORE_VERSION,
+            jobs=len(jobs),
+        )
     return {
         "version": JOB_STORE_VERSION,
-        "jobs": [job for job in rows if isinstance(job, dict)],
+        "jobs": jobs,
     }
 
 
@@ -172,6 +185,7 @@ def _prune_store(store: dict[str, Any]) -> None:
 
 def _save_store(store: dict[str, Any]) -> None:
     _prune_store(store)
+    store["version"] = JOB_STORE_VERSION
     path = _job_store_path()
     backup_path = _job_store_backup_path()
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -380,13 +394,42 @@ def _refresh_job_status(
     job: dict[str, Any], active_sessions: set[str], now: float | None = None
 ) -> dict[str, Any]:
     status = str(job.get("status") or "unknown")
-    if status not in {"running", "stopping", "retrying"}:
+    if status not in {"starting", "running", "stopping", "retrying"}:
         return job
 
     updated = now or _utc()
+    if status == "starting" and _job_operation_is_active(job, "start"):
+        return job
     if status == "retrying" and _job_operation_is_active(job, "retry"):
         return job
     if status == "stopping" and _job_operation_is_active(job, "stop"):
+        return job
+    if status == "starting":
+        status_payload = _read_status(job)
+        session_id = str(job.get("session_id") or "")
+        _clear_job_operation(job)
+        if status_payload is not None:
+            return _apply_status_payload(job, status_payload, updated)
+        if session_id and session_id in active_sessions:
+            job.update(
+                {
+                    "status": "running",
+                    "updated_at": updated,
+                    "completed_at": None,
+                    "exit_code": None,
+                    "error": "recovered job start after an interrupted state commit",
+                }
+            )
+            return job
+        job.update(
+            {
+                "status": "failed",
+                "updated_at": updated,
+                "completed_at": updated,
+                "exit_code": None,
+                "error": "job start was interrupted before a recoverable shell session was created",
+            }
+        )
         return job
     if status == "retrying":
         pending_session = str(job.get("pending_session_name") or "")
@@ -516,36 +559,89 @@ async def start_job(command: str, cwd: str = ".", name: str | None = None) -> di
     display_name = name or job_id
     paths, runner_command = _prepare_attempt(job_id, 1, command, cwd)
     shell_name = _shell_safe_name(f"{display_name}-{job_id}")
-    shell = await start_shell(cwd, shell_name, runner_command)
     now = _utc()
     job = {
         "job_id": job_id,
         "name": display_name,
-        "status": "running",
+        "status": "starting",
         "command": command,
         "cwd": cwd,
-        "session_id": shell["session_id"],
-        "backend": shell.get("backend"),
+        "session_id": shell_name,
+        "backend": None,
         "command_path": str(paths["command"]),
         "log_path": str(paths["log"]),
         "status_path": str(paths["status"]),
         "created_at": now,
         "updated_at": now,
-        "last_started_at": now,
+        "last_started_at": None,
         "completed_at": None,
         "exit_code": None,
         "attempts": 1,
     }
+    operation_id = _begin_job_operation(job, "start")
     try:
         with _store_transaction() as store:
             store["jobs"].append(job)
-    except Exception:
-        with contextlib.suppress(Exception):
-            await kill_shell(str(shell["session_id"]))
+    except BaseException:
+        _ACTIVE_JOB_OPERATIONS.discard(operation_id)
         _remove_attempt_files(job_id)
         raise
-    audit("job_start", job_id=job_id, session=shell["session_id"], cwd=cwd)
-    return _public_job(job)
+
+    try:
+        try:
+            shell = await start_shell(cwd, shell_name, runner_command)
+        except Exception as exc:
+            _remove_attempt_files(job_id)
+            with _store_transaction() as store:
+                current = _find_job(store, job_id)
+                if (
+                    current.get("status") == "starting"
+                    and _job_operation_matches(current, operation_id)
+                ):
+                    _clear_job_operation(current)
+                    current["status"] = "failed"
+                    current["updated_at"] = _utc()
+                    current["completed_at"] = current["updated_at"]
+                    current["error"] = f"start failed: {type(exc).__name__}: {exc}"
+            raise
+
+        changed_while_starting = False
+        try:
+            with _store_transaction() as store:
+                current = _find_job(store, job_id)
+                if (
+                    current.get("status") != "starting"
+                    or not _job_operation_matches(current, operation_id)
+                ):
+                    changed_while_starting = True
+                else:
+                    started_at = _utc()
+                    _clear_job_operation(current)
+                    current.update(
+                        {
+                            "status": "running",
+                            "session_id": shell["session_id"],
+                            "backend": shell.get("backend"),
+                            "updated_at": started_at,
+                            "last_started_at": started_at,
+                            "error": None,
+                        }
+                    )
+                public_job = _public_job(current)
+        except Exception:
+            with contextlib.suppress(Exception):
+                await kill_shell(str(shell["session_id"]))
+            _remove_attempt_files(job_id)
+            raise
+        if changed_while_starting:
+            with contextlib.suppress(Exception):
+                await kill_shell(str(shell["session_id"]))
+            _remove_attempt_files(job_id)
+            raise RuntimeError(f"job changed while starting: {job_id}")
+        audit("job_start", job_id=job_id, session=shell["session_id"], cwd=cwd)
+        return public_job
+    finally:
+        _ACTIVE_JOB_OPERATIONS.discard(operation_id)
 
 
 async def list_jobs(include_finished: bool = True) -> dict[str, Any]:
@@ -675,7 +771,7 @@ async def retry_job(job_id: str) -> dict[str, Any]:
     try:
         with _store_transaction() as store:
             job = _refresh_job_status(_find_job(store, job_id), active)
-            if job.get("status") in {"running", "stopping", "retrying"}:
+            if job.get("status") in {"starting", "running", "stopping", "retrying"}:
                 raise RuntimeError(f"job is still active: {job_id}")
             attempts = int(job.get("attempts") or 1) + 1
             command = str(job["command"])

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -398,6 +398,149 @@ async def test_job_list_recovers_interrupted_stopping_and_retrying_states(tmp_pa
 
 
 @pytest.mark.asyncio
+async def test_job_store_migrates_v1_without_losing_history(tmp_path, monkeypatch):
+    state_dir = tmp_path / ".state"
+    state_dir.mkdir()
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(state_dir))
+    get_settings.cache_clear()
+    legacy_jobs = [
+        {
+            "job_id": "job_legacy_done",
+            "name": "legacy-done",
+            "status": "exited",
+            "command": "true",
+            "cwd": ".",
+            "session_id": "legacy-done-session",
+            "created_at": 1.0,
+            "updated_at": 2.0,
+            "attempts": 1,
+        },
+        {
+            "job_id": "job_legacy_live",
+            "name": "legacy-live",
+            "status": "running",
+            "command": "sleep 10",
+            "cwd": ".",
+            "session_id": "legacy-live-session",
+            "created_at": 3.0,
+            "updated_at": 3.0,
+            "attempts": 1,
+        },
+    ]
+    store_path = state_dir / jobs_module.JOB_STORE_FILE_NAME
+    store_path.write_text(
+        json.dumps({"version": 1, "jobs": legacy_jobs}), encoding="utf-8"
+    )
+
+    async def legacy_shells():
+        return {"sessions": [{"session_id": "legacy-live-session"}]}
+
+    monkeypatch.setattr(jobs_module, "list_shells", legacy_shells)
+    listed = await list_jobs()
+
+    assert {job["job_id"] for job in listed["jobs"]} == {
+        "job_legacy_done",
+        "job_legacy_live",
+    }
+    assert listed["counts"] == {"exited": 1, "running": 1}
+    for path in (store_path, state_dir / jobs_module.JOB_STORE_BACKUP_FILE_NAME):
+        migrated = json.loads(path.read_text(encoding="utf-8"))
+        assert migrated["version"] == jobs_module.JOB_STORE_VERSION
+        assert {job["job_id"] for job in migrated["jobs"]} == {
+            "job_legacy_done",
+            "job_legacy_live",
+        }
+
+
+@pytest.mark.asyncio
+async def test_job_start_does_not_launch_shell_when_store_is_invalid(
+    tmp_path, monkeypatch
+):
+    state_dir = tmp_path / ".state"
+    state_dir.mkdir()
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(state_dir))
+    get_settings.cache_clear()
+    (state_dir / jobs_module.JOB_STORE_FILE_NAME).write_text(
+        json.dumps({"version": 99, "jobs": []}), encoding="utf-8"
+    )
+    started = False
+
+    async def fake_start_shell(cwd=".", name=None, command=None):  # noqa: ARG001
+        nonlocal started
+        started = True
+        return {"session_id": str(name), "backend": "fake"}
+
+    monkeypatch.setattr(jobs_module, "start_shell", fake_start_shell)
+
+    with pytest.raises(RuntimeError, match="refusing to reset"):
+        await start_job("echo must-not-run")
+
+    assert started is False
+    runtime_dir = state_dir / "jobs"
+    assert not runtime_dir.exists() or not list(runtime_dir.iterdir())
+
+
+@pytest.mark.asyncio
+async def test_job_list_recovers_interrupted_start(tmp_path, monkeypatch):
+    state_dir = tmp_path / ".state"
+    state_dir.mkdir()
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(state_dir))
+    get_settings.cache_clear()
+    now = time.time()
+    rows = [
+        {
+            "job_id": "job_start_live",
+            "name": "start-live",
+            "status": "starting",
+            "command": "sleep 10",
+            "cwd": ".",
+            "session_id": "start-live-session",
+            "created_at": now,
+            "updated_at": now,
+            "attempts": 1,
+            "operation_id": "start_stale_live",
+            "operation_kind": "start",
+        },
+        {
+            "job_id": "job_start_missing",
+            "name": "start-missing",
+            "status": "starting",
+            "command": "sleep 10",
+            "cwd": ".",
+            "session_id": "start-missing-session",
+            "created_at": now - 1,
+            "updated_at": now,
+            "attempts": 1,
+            "operation_id": "start_stale_missing",
+            "operation_kind": "start",
+        },
+    ]
+    (state_dir / jobs_module.JOB_STORE_FILE_NAME).write_text(
+        json.dumps({"version": jobs_module.JOB_STORE_VERSION, "jobs": rows}),
+        encoding="utf-8",
+    )
+
+    async def active_shells():
+        return {"sessions": [{"session_id": "start-live-session"}]}
+
+    monkeypatch.setattr(jobs_module, "list_shells", active_shells)
+    listed = await list_jobs()
+    recovered = {job["job_id"]: job for job in listed["jobs"]}
+
+    assert recovered["job_start_live"]["status"] == "running"
+    assert "recovered job start" in recovered["job_start_live"]["error"]
+    assert recovered["job_start_missing"]["status"] == "failed"
+    assert "start was interrupted" in recovered["job_start_missing"]["error"]
+    stored = json.loads(
+        (state_dir / jobs_module.JOB_STORE_FILE_NAME).read_text(encoding="utf-8")
+    )
+    assert all("operation_id" not in job for job in stored["jobs"])
+
+
+@pytest.mark.asyncio
 async def test_job_store_recovers_from_atomic_backup(tmp_path, monkeypatch):
     state_dir = tmp_path / ".state"
     monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
@@ -451,6 +594,44 @@ async def test_job_store_refuses_to_overwrite_unrecoverable_corruption(tmp_path,
         await list_jobs()
     assert store_path.read_text(encoding="utf-8") == "{broken"
     assert not (state_dir / jobs_module.JOB_STORE_BACKUP_FILE_NAME).exists()
+
+
+@pytest.mark.asyncio
+async def test_job_list_does_not_interrupt_active_start(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(tmp_path / ".state"))
+    get_settings.cache_clear()
+    active: set[str] = set()
+    start_entered = asyncio.Event()
+    allow_start = asyncio.Event()
+
+    async def fake_start_shell(cwd=".", name=None, command=None):
+        start_entered.set()
+        await allow_start.wait()
+        active.add(str(name))
+        return {
+            "session_id": str(name),
+            "cwd": cwd,
+            "command": command,
+            "backend": "fake",
+        }
+
+    async def fake_list_shells():
+        return {"sessions": [{"session_id": item} for item in sorted(active)]}
+
+    monkeypatch.setattr(jobs_module, "start_shell", fake_start_shell)
+    monkeypatch.setattr(jobs_module, "list_shells", fake_list_shells)
+
+    start_task = asyncio.create_task(start_job("sleep 10"))
+    await start_entered.wait()
+
+    during = await list_jobs()
+    assert during["jobs"][0]["status"] == "starting"
+
+    allow_start.set()
+    started = await start_task
+    assert started["status"] == "running"
+    assert (await list_jobs())["jobs"][0]["status"] == "running"
 
 
 @pytest.mark.asyncio

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -483,6 +483,96 @@ async def test_job_start_does_not_launch_shell_when_store_is_invalid(
 
 
 @pytest.mark.asyncio
+async def test_job_start_records_shell_launch_failure(tmp_path, monkeypatch):
+    state_dir = tmp_path / ".state"
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(state_dir))
+    get_settings.cache_clear()
+
+    async def failing_start_shell(cwd=".", name=None, command=None):  # noqa: ARG001
+        raise RuntimeError("shell launch failed")
+
+    monkeypatch.setattr(jobs_module, "start_shell", failing_start_shell)
+
+    with pytest.raises(RuntimeError, match="shell launch failed"):
+        await start_job("echo never-ran")
+
+    stored = json.loads(
+        (state_dir / jobs_module.JOB_STORE_FILE_NAME).read_text(encoding="utf-8")
+    )
+    assert len(stored["jobs"]) == 1
+    job = stored["jobs"][0]
+    assert job["status"] == "failed"
+    assert job["completed_at"] is not None
+    assert job["error"] == "start failed: RuntimeError: shell launch failed"
+    assert "operation_id" not in job
+    runtime_dir = state_dir / "jobs"
+    assert not list(runtime_dir.iterdir())
+
+
+@pytest.mark.asyncio
+async def test_job_start_kills_shell_when_running_state_cannot_be_committed(
+    tmp_path, monkeypatch
+):
+    state_dir = tmp_path / ".state"
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(state_dir))
+    get_settings.cache_clear()
+    killed: list[str] = []
+
+    async def corrupt_store_after_start(cwd=".", name=None, command=None):  # noqa: ARG001
+        invalid = json.dumps({"version": 99, "jobs": []})
+        for path in (
+            state_dir / jobs_module.JOB_STORE_FILE_NAME,
+            state_dir / jobs_module.JOB_STORE_BACKUP_FILE_NAME,
+        ):
+            path.write_text(invalid, encoding="utf-8")
+        return {"session_id": str(name), "backend": "fake"}
+
+    async def fake_kill_shell(session_id):
+        killed.append(session_id)
+        return {"session_id": session_id, "killed": True, "stderr": ""}
+
+    monkeypatch.setattr(jobs_module, "start_shell", corrupt_store_after_start)
+    monkeypatch.setattr(jobs_module, "kill_shell", fake_kill_shell)
+
+    with pytest.raises(RuntimeError, match="refusing to reset"):
+        await start_job("echo started")
+
+    assert len(killed) == 1
+    runtime_dir = state_dir / "jobs"
+    assert not list(runtime_dir.iterdir())
+
+
+@pytest.mark.asyncio
+async def test_job_start_kills_shell_if_reserved_job_changes(tmp_path, monkeypatch):
+    state_dir = tmp_path / ".state"
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(state_dir))
+    get_settings.cache_clear()
+    killed: list[str] = []
+
+    async def change_reserved_job(cwd=".", name=None, command=None):  # noqa: ARG001
+        with jobs_module._store_transaction() as store:
+            store["jobs"][0]["status"] = "stopped"
+        return {"session_id": str(name), "backend": "fake"}
+
+    async def fake_kill_shell(session_id):
+        killed.append(session_id)
+        return {"session_id": session_id, "killed": True, "stderr": ""}
+
+    monkeypatch.setattr(jobs_module, "start_shell", change_reserved_job)
+    monkeypatch.setattr(jobs_module, "kill_shell", fake_kill_shell)
+
+    with pytest.raises(RuntimeError, match="job changed while starting"):
+        await start_job("echo changed")
+
+    assert len(killed) == 1
+    runtime_dir = state_dir / "jobs"
+    assert not list(runtime_dir.iterdir())
+
+
+@pytest.mark.asyncio
 async def test_job_list_recovers_interrupted_start(tmp_path, monkeypatch):
     state_dir = tmp_path / ".state"
     state_dir.mkdir()

--- a/tests/test_runtime_edge_complete.py
+++ b/tests/test_runtime_edge_complete.py
@@ -54,10 +54,19 @@ def test_job_store_helpers_recovery_pruning_and_attempt_files(tmp_path, monkeypa
     assert jobs._load_store() == jobs._empty_store()
 
     invalid = tmp_path / "invalid.json"
-    for payload in ({"version": 1, "jobs": []}, {"version": 2, "jobs": {}}, []):
+    for payload in ({"version": 3, "jobs": []}, {"version": 2, "jobs": {}}, []):
         invalid.write_text(json.dumps(payload), encoding="utf-8")
         with pytest.raises(ValueError):
             jobs._load_store_file(invalid)
+
+    invalid.write_text(
+        json.dumps({"version": 1, "jobs": [{"job_id": "legacy"}, 1]}),
+        encoding="utf-8",
+    )
+    assert jobs._load_store_file(invalid) == {
+        "version": jobs.JOB_STORE_VERSION,
+        "jobs": [{"job_id": "legacy"}],
+    }
 
     main = jobs._job_store_path()
     backup = jobs._job_store_backup_path()


### PR DESCRIPTION
## Summary

- migrate legacy `jobs.json` schema v1 stores to v2 without dropping job history
- persist a `starting` job record before launching its shell, preventing untracked commands when state persistence fails
- recover interrupted starts from the persisted session or completion status
- add regression coverage for migration, invalid stores, interrupted starts, and concurrent job listing

## Validation

- `PYTHONPATH=src python -m pytest -q`: 443 passed
- focused job tests: 27 passed
- `ruff check .`
- branch coverage: 93.6%
- verified migration against a copy of the live 259-record v1 store with all IDs and ordering preserved
