### PR TITLE
fix(audit): preserve tool inputs without redaction

### DIFF
--- a/src/local_shell_mcp/audit.py
+++ b/src/local_shell_mcp/audit.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import contextlib
 import json
 import os
-import re
 import threading
 import time
 from collections.abc import Iterator
@@ -16,84 +15,28 @@ from .settings import get_settings
 
 _AUDIT_ENABLED: ContextVar[bool] = ContextVar("local_shell_mcp_audit_enabled", default=True)
 _AUDIT_LOCK = threading.Lock()
-_AUDIT_REDACTED = "<redacted>"
-_AUDIT_OPAQUE_FIELDS = {
-    "code",
-    "command",
-    "content",
-    "data_b64",
-    "explanation",
-    "input_text",
-    "javascript",
-    "patch",
-    "purpose",
-    "repo_url",
-    "script",
-}
-_AUDIT_SECRET_FIELDS = {
-    "access",
-    "authorization",
-    "client_secret",
-    "cookie",
-    "oauth_admin_pin",
-    "oauth_jwt_secret",
-    "password",
-    "passwd",
-    "pin",
-    "secret",
-    "set-cookie",
-    "token",
-}
-_AUDIT_TOKEN_PATTERN = re.compile(
-    r"(?i)(?:bearer\s+)[A-Za-z0-9._~+/=-]+|gh[pousr]_[A-Za-z0-9_]{20,}"
-)
 _AUDIT_MAX_STRING = 2_000
 
 
-def _audit_configured_secrets(settings: Any) -> tuple[str, ...]:
-    values = []
-    for name in ("oauth_admin_pin", "oauth_jwt_secret"):
-        value = getattr(settings, name, None)
-        if isinstance(value, str) and len(value) >= 8:
-            values.append(value)
-    return tuple(values)
+def _format_audit_text(value: str) -> str:
+    if len(value) > _AUDIT_MAX_STRING:
+        return value[:_AUDIT_MAX_STRING] + "…<truncated>"
+    return value
 
 
-def _redact_audit_text(value: str, configured_secrets: tuple[str, ...]) -> str:
-    redacted = value
-    for secret in configured_secrets:
-        redacted = redacted.replace(secret, _AUDIT_REDACTED)
-    redacted = _AUDIT_TOKEN_PATTERN.sub(_AUDIT_REDACTED, redacted)
-    if len(redacted) > _AUDIT_MAX_STRING:
-        redacted = redacted[:_AUDIT_MAX_STRING] + "…<truncated>"
-    return redacted
-
-
-def _sanitize_audit_value(
-    value: Any, configured_secrets: tuple[str, ...], field_name: str | None = None
-) -> Any:
-    normalized = (field_name or "").casefold()
-    if normalized in _AUDIT_OPAQUE_FIELDS or normalized in _AUDIT_SECRET_FIELDS:
-        return _AUDIT_REDACTED
-    if normalized.endswith(("_password", "_passwd", "_secret", "_authorization")):
-        return _AUDIT_REDACTED
-    if normalized.endswith("_token") and normalized != "token_id":
-        return _AUDIT_REDACTED
+def _serialize_audit_value(value: Any) -> Any:
     if isinstance(value, str):
-        return _redact_audit_text(value, configured_secrets)
+        return _format_audit_text(value)
     if isinstance(value, dict):
         return {
-            str(name): _sanitize_audit_value(item, configured_secrets, str(name))
+            str(name): _serialize_audit_value(item)
             for name, item in list(value.items())[:100]
         }
     if isinstance(value, (list, tuple)):
-        return [
-            _sanitize_audit_value(item, configured_secrets)
-            for item in list(value)[:100]
-        ]
+        return [_serialize_audit_value(item) for item in list(value)[:100]]
     if isinstance(value, (int, float, bool)) or value is None:
         return value
-    return _redact_audit_text(repr(value), configured_secrets)
+    return _format_audit_text(repr(value))
 
 
 def _trim_audit_log(path: Path, max_bytes: int) -> None:
@@ -136,14 +79,10 @@ def audit(event: str, **fields: Any) -> None:
     if not _AUDIT_ENABLED.get():
         return
     settings = get_settings()
-    configured_secrets = _audit_configured_secrets(settings)
     record = {
         "ts": time.time(),
-        "event": _redact_audit_text(event, configured_secrets),
-        **{
-            name: _sanitize_audit_value(value, configured_secrets, name)
-            for name, value in fields.items()
-        },
+        "event": _format_audit_text(event),
+        **{name: _serialize_audit_value(value) for name, value in fields.items()},
     }
     path: Path = settings.audit_log_path
     encoded = json.dumps(record, ensure_ascii=False, default=str) + "\n"

--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -199,20 +199,6 @@ def _oauth_security_scheme(scopes: list[str] | tuple[str, ...]) -> dict[str, Any
 OAUTH_SECURITY_SCHEMES = [_oauth_security_scheme(ALL_OAUTH_SCOPES)]
 NOAUTH_SECURITY_SCHEMES = [{"type": "noauth"}]
 PUBLIC_TOOL_TIMEOUT_S = PUBLIC_TOOL_WATCHDOG_TIMEOUT_S
-SENSITIVE_TOOL_ARG_FRAGMENTS = ("token", "secret", "password", "passwd", "pin", "jwt", "key")
-OPAQUE_AUDIT_TOOL_ARGS = {
-    "code",
-    "command",
-    "content",
-    "data_b64",
-    "explanation",
-    "input_text",
-    "javascript",
-    "patch",
-    "purpose",
-    "repo_url",
-    "script",
-}
 MAX_AUDIT_TOOL_ARG_STRING = 500
 MCP_INSTRUCTIONS = (
     "When a task may benefit from an installed Agent Skill, call skills_list first "
@@ -288,7 +274,7 @@ def _transport_security_settings() -> TransportSecuritySettings:
     )
 
 
-def _redact_audit_value(value: Any) -> Any:
+def _serialize_audit_value(value: Any) -> Any:
     if isinstance(value, str):
         if len(value) > MAX_AUDIT_TOOL_ARG_STRING:
             return value[:MAX_AUDIT_TOOL_ARG_STRING] + "…<truncated>"
@@ -296,28 +282,21 @@ def _redact_audit_value(value: Any) -> Any:
     if isinstance(value, (int, float, bool)) or value is None:
         return value
     if isinstance(value, list):
-        return [_redact_audit_value(item) for item in value[:20]]
+        return [_serialize_audit_value(item) for item in value[:20]]
     if isinstance(value, tuple):
-        return [_redact_audit_value(item) for item in value[:20]]
+        return [_serialize_audit_value(item) for item in value[:20]]
     if isinstance(value, dict):
-        out: dict[str, Any] = {}
-        for name, item in list(value.items())[:50]:
-            name_s = str(name)
-            name_lower = name_s.lower()
-            if name_lower in OPAQUE_AUDIT_TOOL_ARGS or any(
-                fragment in name_lower for fragment in SENSITIVE_TOOL_ARG_FRAGMENTS
-            ):
-                out[name_s] = "<redacted>"
-            else:
-                out[name_s] = _redact_audit_value(item)
-        return out
+        return {
+            str(name): _serialize_audit_value(item)
+            for name, item in list(value.items())[:50]
+        }
     return repr(value)
 
 
 def _audit_tool_arguments(args: tuple[Any, ...], kwargs: dict[str, Any]) -> dict[str, Any]:
     return {
         "positional_count": len(args),
-        "keyword_args": _redact_audit_value(kwargs),
+        "keyword_args": _serialize_audit_value(kwargs),
     }
 
 
@@ -389,7 +368,7 @@ def _install_mcp_tool_watchdogs(mcp: FastMCP) -> None:
                 require_current_scopes(("remote:use",))
             arguments = {
                 "positional_count": len(args),
-                "keyword_args": _redact_audit_value(call_arguments),
+                "keyword_args": _serialize_audit_value(call_arguments),
             }
             audit_context = {
                 name: call_arguments[name]

--- a/tests/test_audit_tool_calls.py
+++ b/tests/test_audit_tool_calls.py
@@ -27,14 +27,14 @@ async def test_mcp_tool_calls_are_audited(tmp_path, monkeypatch):
     assert ends[-1]["ok"] is True
 
 
-def test_audit_tool_arguments_redacts_sensitive_keys():
+def test_audit_tool_arguments_preserves_sensitive_keys():
     payload = _audit_tool_arguments((), {"token": "abc", "normal": "value"})
 
-    assert payload["keyword_args"]["token"] == "<redacted>"
+    assert payload["keyword_args"]["token"] == "abc"
     assert payload["keyword_args"]["normal"] == "value"
 
 
-def test_audit_tool_arguments_redacts_opaque_payloads():
+def test_audit_tool_arguments_preserves_payloads():
     payload = _audit_tool_arguments(
         (),
         {
@@ -44,8 +44,10 @@ def test_audit_tool_arguments_redacts_opaque_payloads():
         },
     )
 
-    assert payload["keyword_args"]["command"] == "<redacted>"
-    assert payload["keyword_args"]["content"] == "<redacted>"
+    assert payload["keyword_args"]["command"] == (
+        "curl -H 'Authorization: Bearer secret-value' example.test"
+    )
+    assert payload["keyword_args"]["content"] == "API_TOKEN=secret-value"
     assert payload["keyword_args"]["path"] == "safe.txt"
 
 
@@ -64,7 +66,7 @@ async def test_mcp_audit_extracts_session_context(tmp_path, monkeypatch):
     assert starts[-1]["session"] == "missing-session"
 
 
-def test_audit_redacts_lower_level_commands_and_embedded_tokens(tmp_path, monkeypatch):
+def test_audit_preserves_lower_level_commands_and_embedded_tokens(tmp_path, monkeypatch):
     from local_shell_mcp.audit import audit
 
     audit_path = tmp_path / "audit.jsonl"
@@ -83,10 +85,11 @@ def test_audit_redacts_lower_level_commands_and_embedded_tokens(tmp_path, monkey
     )
     record = json.loads(audit_path.read_text(encoding="utf-8"))
 
-    assert record["command"] == "<redacted>"
-    assert "bearer-value" not in json.dumps(record)
-    assert "ghp_" not in json.dumps(record)
-    assert secret not in json.dumps(record)
+    assert record["command"] == (
+        "curl -H 'Authorization: Bearer bearer-value' example.test"
+    )
+    assert f"ghp_{'A' * 36}" in record["error"]
+    assert secret in record["error"]
     assert record["token_id"] == "safe-identifier"
-    assert record["nested"]["access_token"] == "<redacted>"
+    assert record["nested"]["access_token"] == "nested-secret"
     assert record["nested"]["path"] == "safe.txt"

--- a/tests/test_edge_modules_complete.py
+++ b/tests/test_edge_modules_complete.py
@@ -66,7 +66,7 @@ def _request(
     )
 
 
-def test_audit_sanitization_trimming_and_all_filters(tmp_path, monkeypatch):
+def test_audit_serialization_trimming_and_all_filters(tmp_path, monkeypatch):
     _configure(
         tmp_path,
         monkeypatch,
@@ -77,17 +77,11 @@ def test_audit_sanitization_trimming_and_all_filters(tmp_path, monkeypatch):
         LOCAL_SHELL_MCP_MAX_AUDIT_TAIL_BYTES=40,
     )
     settings = get_settings()
-    secrets = audit_module._audit_configured_secrets(settings)
-    assert "configured-secret-pin" in secrets
-    redacted = audit_module._redact_audit_text(
-        "Bearer abc.def configured-secret-pin ghp_" + "x" * 30 + "z" * 3000,
-        secrets,
-    )
-    assert "configured-secret-pin" not in redacted
-    assert "Bearer" not in redacted
-    assert audit_module._redact_audit_text("z" * 3000, ()).endswith("…<truncated>")
+    sensitive_text = "Bearer abc.def configured-secret-pin ghp_" + "x" * 30
+    assert audit_module._format_audit_text(sensitive_text) == sensitive_text
+    assert audit_module._format_audit_text("z" * 3000).endswith("…<truncated>")
 
-    value = audit_module._sanitize_audit_value(
+    value = audit_module._serialize_audit_value(
         {
             "token": "hidden",
             "api_token": "hidden",
@@ -96,13 +90,12 @@ def test_audit_sanitization_trimming_and_all_filters(tmp_path, monkeypatch):
             "items": list(range(110)),
             "tuple": (1, 2),
             "object": object(),
-        },
-        secrets,
+        }
     )
-    assert value["token"] == "<redacted>"
-    assert value["api_token"] == "<redacted>"
+    assert value["token"] == "hidden"
+    assert value["api_token"] == "hidden"
     assert value["token_id"] == "visible"
-    assert value["db_password"] == "<redacted>"
+    assert value["db_password"] == "hidden"
     assert len(value["items"]) == 100
     assert value["tuple"] == [1, 2]
     assert "object at" in value["object"]

--- a/tests/test_tools_complete.py
+++ b/tests/test_tools_complete.py
@@ -319,11 +319,11 @@ async def test_tool_wrapper_error_paths_and_remote_disabled(tmp_path, monkeypatc
     )
 
 
-def test_tool_helpers_redaction_audit_timeout_and_tail(tmp_path, monkeypatch):
+def test_tool_helpers_audit_serialization_timeout_and_tail(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
-    assert tools._redact_audit_value("x" * 501).endswith("…<truncated>")
-    assert tools._redact_audit_value((1, 2)) == [1, 2]
-    redacted = tools._redact_audit_value(
+    assert tools._serialize_audit_value("x" * 501).endswith("…<truncated>")
+    assert tools._serialize_audit_value((1, 2)) == [1, 2]
+    serialized = tools._serialize_audit_value(
         {
             "token": "secret",
             "content": "body",
@@ -332,10 +332,10 @@ def test_tool_helpers_redaction_audit_timeout_and_tail(tmp_path, monkeypatch):
             "object": object(),
         }
     )
-    assert redacted["token"] == "<redacted>"
-    assert redacted["content"] == "<redacted>"
-    assert len(redacted["items"]) == 20
-    assert "object at" in redacted["object"]
+    assert serialized["token"] == "secret"
+    assert serialized["content"] == "body"
+    assert len(serialized["items"]) == 20
+    assert "object at" in serialized["object"]
     assert tools._audit_tool_arguments((1, 2), {"password": "x"})["positional_count"] == 2
 
     assert tools._audit_tool_purpose("x", "  purpose ", " explanation ") == {


### PR DESCRIPTION
## Summary
- remove audit-field and token redaction
- preserve commands, content, patches, purpose, explanations, and credential-like fields
- retain bounded string/list sizes and audit-log rotation
- keep settings-page secret redaction unchanged

## Verification
- `ruff check` on changed files
- `PYTHONPATH=src pytest -q` (439 passed)