### PR TITLE
fix(ui): consolidate audit tool calls

### DIFF
--- a/scripts/ui-smoke.py
+++ b/scripts/ui-smoke.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import socket
 import subprocess
@@ -322,14 +323,44 @@ def main() -> int:
         (workspace / "mouse-second.txt").write_text("second", encoding="utf-8")
         state_dir.mkdir()
         now = time.time()
+        audit_records = [
+            {
+                "ts": now - 21,
+                "event": "mcp_tool_call_start",
+                "call_id": "audit-old-call",
+                "tool": "audit-old-tool",
+                "machine": "local",
+                "arguments": {"keyword_args": {"command": "audit-old-input"}},
+            },
+            {
+                "ts": now - 20,
+                "event": "mcp_tool_call_end",
+                "call_id": "audit-old-call",
+                "tool": "audit-old-tool",
+                "machine": "local",
+                "ok": True,
+                "result": {"detail": "audit-old-detail"},
+            },
+            {
+                "ts": now - 11,
+                "event": "mcp_tool_call_start",
+                "call_id": "audit-new-call",
+                "tool": "audit-new-tool",
+                "machine": "local",
+                "arguments": {"keyword_args": {"command": "audit-new-input"}},
+            },
+            {
+                "ts": now - 10,
+                "event": "mcp_tool_call_end",
+                "call_id": "audit-new-call",
+                "tool": "audit-new-tool",
+                "machine": "local",
+                "ok": True,
+                "result": {"detail": "audit-new-detail"},
+            },
+        ]
         (state_dir / "audit.jsonl").write_text(
-            "\n".join(
-                [
-                    f'{{"ts": {now - 20}, "event": "mcp_tool_call_end", "tool": "audit-old-tool", "machine": "local", "operation": "read", "command": "audit-old-detail", "ok": true}}',
-                    f'{{"ts": {now - 10}, "event": "mcp_tool_call_end", "tool": "audit-new-tool", "machine": "local", "operation": "run", "command": "audit-new-detail", "ok": true}}',
-                ]
-            )
-            + "\n",
+            "\n".join(json.dumps(record) for record in audit_records) + "\n",
             encoding="utf-8",
         )
         env = os.environ.copy()

--- a/src/local_shell_mcp/audit.py
+++ b/src/local_shell_mcp/audit.py
@@ -97,15 +97,220 @@ def audit(event: str, **fields: Any) -> None:
             path.chmod(0o600)
 
 
+_TOOL_OPERATION_GROUPS: dict[str, frozenset[str]] = {
+    "files": frozenset(
+        {
+            "search",
+            "fetch",
+            "list_files",
+            "tree_view",
+            "glob_search",
+            "grep_search",
+            "read_file",
+            "view_image",
+            "write_file",
+            "edit_file",
+            "delete_file_or_dir",
+            "apply_patch",
+            "secret_scan",
+        }
+    ),
+    "shell": frozenset(
+        {
+            "run_shell_tool",
+            "run_python_tool",
+            "shell_start",
+            "shell_send",
+            "shell_read",
+            "shell_kill",
+            "shell_list",
+        }
+    ),
+    "jobs": frozenset({"job_start", "job_list", "job_tail", "job_stop", "job_retry"}),
+    "transfer": frozenset(
+        {"create_file_link", "list_file_links", "revoke_file_link", "transfer_path"}
+    ),
+    "browser": frozenset(
+        {"browser_capture_tool", "browser_get_text_tool", "playwright_run_script_tool"}
+    ),
+    "remote": frozenset(
+        {
+            "remote_invite",
+            "remote_list_machines",
+            "remote_revoke_machine",
+            "remote_rename_machine",
+        }
+    ),
+    "agent": frozenset(
+        {
+            "environment_info",
+            "skills_list",
+            "skill_load",
+            "skill_read_file",
+            "todo_read_tool",
+            "todo_write_tool",
+            "audit_tail",
+        }
+    ),
+}
+_TOOL_OPERATION_BY_NAME = {
+    tool: operation
+    for operation, tools in _TOOL_OPERATION_GROUPS.items()
+    for tool in tools
+}
+
+
 def _operation_type(record: dict[str, Any]) -> str:
-    event = str(record.get("event") or "")
     tool = str(record.get("tool") or "")
-    value = tool or event
-    for prefix in ("remote_", "mcp_tool_call_", "tool_", "oauth_", "shell_", "git_"):
-        if value.startswith(prefix):
-            value = value[len(prefix) :]
-            break
-    return value.split("_", 1)[0] if value else "other"
+    if tool in _TOOL_OPERATION_BY_NAME:
+        return _TOOL_OPERATION_BY_NAME[tool]
+
+    event = str(record.get("event") or "")
+    if event.startswith(("run_shell_", "shell_")):
+        return "shell"
+    if event.startswith("job_"):
+        return "jobs"
+    if event.startswith(("browser_", "playwright_")):
+        return "browser"
+    if event.startswith("remote_"):
+        return "remote"
+    if event.startswith(("download_", "file_link_", "transfer_")):
+        return "transfer"
+    return "other"
+
+
+def _record_node(record: dict[str, Any]) -> str:
+    return str(record.get("machine") or record.get("node") or "local")
+
+
+def _record_session(record: dict[str, Any]) -> str:
+    return str(record.get("session") or "")
+
+
+def _call_input(record: dict[str, Any]) -> Any:
+    arguments = record.get("arguments")
+    if not isinstance(arguments, dict):
+        return None
+    keyword_args = arguments.get("keyword_args")
+    return keyword_args if keyword_args is not None else arguments
+
+
+def _call_match_key(record: dict[str, Any]) -> tuple[str, str, str]:
+    return (
+        str(record.get("tool") or ""),
+        _record_node(record),
+        _record_session(record),
+    )
+
+
+def _new_call_entry(record: dict[str, Any], index: int) -> dict[str, Any]:
+    call_id = str(record.get("call_id") or "")
+    entry: dict[str, Any] = {
+        "id": f"call:{call_id}" if call_id else f"legacy-call:{record.get('ts', 0)}:{index}",
+        "ts": float(record.get("ts") or 0),
+        "event": "mcp_tool_call",
+        "tool": str(record.get("tool") or "unknown"),
+        "node": _record_node(record),
+        "operation": _operation_type(record),
+        "paired": False,
+        "status": "running",
+        "source_events": ["mcp_tool_call_start"],
+    }
+    if call_id:
+        entry["call_id"] = call_id
+    session = _record_session(record)
+    if session:
+        entry["session"] = session
+    call_input = _call_input(record)
+    if call_input is not None:
+        entry["input"] = call_input
+    return entry
+
+
+def _finish_call_entry(entry: dict[str, Any], record: dict[str, Any]) -> None:
+    ok = record.get("ok")
+    entry["paired"] = True
+    entry["ok"] = ok
+    entry["status"] = "success" if ok is True else "failed" if ok is False else "completed"
+    entry["source_events"] = ["mcp_tool_call_start", "mcp_tool_call_end"]
+    if "duration_ms" in record:
+        entry["duration_ms"] = record["duration_ms"]
+    if "result" in record:
+        entry["output"] = record["result"]
+    for name in ("error", "error_type"):
+        if record.get(name):
+            entry[name] = record[name]
+
+
+def _unpaired_end_entry(record: dict[str, Any], index: int) -> dict[str, Any]:
+    call_id = str(record.get("call_id") or "")
+    entry: dict[str, Any] = {
+        "id": f"call:{call_id}" if call_id else f"legacy-end:{record.get('ts', 0)}:{index}",
+        "ts": float(record.get("ts") or 0),
+        "event": "mcp_tool_call",
+        "tool": str(record.get("tool") or "unknown"),
+        "node": _record_node(record),
+        "operation": _operation_type(record),
+        "paired": False,
+        "status": "unpaired",
+        "source_events": ["mcp_tool_call_end"],
+    }
+    if call_id:
+        entry["call_id"] = call_id
+    session = _record_session(record)
+    if session:
+        entry["session"] = session
+    if "duration_ms" in record:
+        entry["duration_ms"] = record["duration_ms"]
+    if "result" in record:
+        entry["output"] = record["result"]
+    for name in ("ok", "error", "error_type"):
+        if name in record:
+            entry[name] = record[name]
+    return entry
+
+
+def _coalesce_audit_records(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    pending_by_id: dict[str, dict[str, Any]] = {}
+    pending_legacy: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+
+    for index, record in enumerate(records):
+        event = str(record.get("event") or "")
+        if event == "auth_ok":
+            continue
+        if event == "mcp_tool_call_start":
+            entry = _new_call_entry(record, index)
+            rows.append(entry)
+            call_id = str(record.get("call_id") or "")
+            if call_id:
+                pending_by_id[call_id] = entry
+            else:
+                pending_legacy.setdefault(_call_match_key(record), []).append(entry)
+            continue
+        if event == "mcp_tool_call_end":
+            call_id = str(record.get("call_id") or "")
+            entry = pending_by_id.pop(call_id, None) if call_id else None
+            if entry is None and not call_id:
+                pending = pending_legacy.get(_call_match_key(record), [])
+                if pending:
+                    entry = pending.pop(0)
+            if entry is None:
+                rows.append(_unpaired_end_entry(record, index))
+            else:
+                _finish_call_entry(entry, record)
+            continue
+
+        rows.append(
+            {
+                **record,
+                "id": str(record.get("id") or f"record:{record.get('ts', 0)}:{index}"),
+                "node": _record_node(record),
+                "operation": _operation_type(record),
+            }
+        )
+
+    return rows
 
 
 def query_audit(
@@ -120,7 +325,7 @@ def query_audit(
     end_ts: float | None = None,
     sort: str = "desc",
 ) -> dict[str, Any]:
-    """Read, filter, and sort the bounded JSONL audit log for the human UI."""
+    """Read, pair, filter, and sort the bounded JSONL audit log for the human UI."""
 
     settings = get_settings()
     path = settings.audit_log_path
@@ -136,52 +341,49 @@ def query_audit(
             handle.readline()
         raw = handle.read(max_bytes)
 
-    rows: list[dict[str, Any]] = []
-    needle = (search or "").casefold().strip()
-    node_filter = (node or "").casefold().strip()
-    event_filter = (event or "").casefold().strip()
-    operation_filter = (operation or "").casefold().strip()
-    session_filter = (session or "").casefold().strip()
-
+    records: list[dict[str, Any]] = []
     for line in raw.splitlines():
         try:
             record = json.loads(line)
         except (json.JSONDecodeError, UnicodeDecodeError):
             continue
-        if not isinstance(record, dict):
-            continue
-        ts = float(record.get("ts") or 0)
+        if isinstance(record, dict):
+            records.append(record)
+
+    rows = _coalesce_audit_records(records)
+    needle = (search or "").casefold().strip()
+    node_filter = (node or "").casefold().strip()
+    event_filter = (event or "").casefold().strip()
+    operation_filter = (operation or "").casefold().strip()
+    session_filter = (session or "").casefold().strip()
+    matched: list[dict[str, Any]] = []
+
+    for row in rows:
+        ts = float(row.get("ts") or 0)
         if start_ts is not None and ts < start_ts:
             continue
         if end_ts is not None and ts > end_ts:
             continue
-        record_node = str(record.get("machine") or record.get("node") or "local")
-        if node_filter and node_filter != record_node.casefold():
+        if node_filter and node_filter != str(row.get("node") or "local").casefold():
             continue
-        record_event = str(record.get("event") or "")
-        if event_filter and event_filter not in record_event.casefold():
-            continue
-        record_operation = _operation_type(record)
-        if operation_filter and operation_filter not in record_operation.casefold():
-            continue
-        record_session = str(record.get("session") or "")
-        if session_filter and session_filter != record_session.casefold():
-            continue
-        if needle and needle not in json.dumps(record, ensure_ascii=False, default=str).casefold():
-            continue
-        rows.append(
-            {
-                **record,
-                "node": record_node,
-                "operation": record_operation,
-            }
+        event_text = " ".join(
+            [str(row.get("event") or ""), *map(str, row.get("source_events") or [])]
         )
+        if event_filter and event_filter not in event_text.casefold():
+            continue
+        if operation_filter and operation_filter != str(row.get("operation") or "").casefold():
+            continue
+        if session_filter and session_filter != str(row.get("session") or "").casefold():
+            continue
+        if needle and needle not in json.dumps(row, ensure_ascii=False, default=str).casefold():
+            continue
+        matched.append(row)
 
     reverse = sort.lower() != "asc"
-    rows.sort(key=lambda item: float(item.get("ts") or 0), reverse=reverse)
-    total = len(rows)
+    matched.sort(key=lambda item: float(item.get("ts") or 0), reverse=reverse)
+    total = len(matched)
     return {
-        "entries": rows[:bounded_limit],
+        "entries": matched[:bounded_limit],
         "count": min(total, bounded_limit),
         "total_matched": total,
     }

--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -5,6 +5,7 @@ import base64
 import inspect
 import json
 import subprocess
+import time
 import uuid
 from contextlib import suppress
 from pathlib import Path
@@ -275,6 +276,8 @@ def _transport_security_settings() -> TransportSecuritySettings:
 
 
 def _serialize_audit_value(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        return _serialize_audit_value(value.model_dump(mode="json"))
     if isinstance(value, str):
         if len(value) > MAX_AUDIT_TOOL_ARG_STRING:
             return value[:MAX_AUDIT_TOOL_ARG_STRING] + "…<truncated>"
@@ -377,8 +380,11 @@ def _install_mcp_tool_watchdogs(mcp: FastMCP) -> None:
             }
             if call_arguments.get("session_id"):
                 audit_context["session"] = call_arguments["session_id"]
+            call_id = uuid.uuid4().hex
+            started_at = time.monotonic()
             audit(
                 "mcp_tool_call_start",
+                call_id=call_id,
                 tool=__tool_name,
                 arguments=arguments,
                 **audit_context,
@@ -390,27 +396,48 @@ def _install_mcp_tool_watchdogs(mcp: FastMCP) -> None:
                     result = await asyncio.wait_for(
                         __original(*args, **kwargs), timeout=PUBLIC_TOOL_TIMEOUT_S
                     )
-                audit("mcp_tool_call_end", tool=__tool_name, ok=True, **audit_context)
+                audit(
+                    "mcp_tool_call_end",
+                    call_id=call_id,
+                    tool=__tool_name,
+                    ok=True,
+                    duration_ms=round((time.monotonic() - started_at) * 1000),
+                    result=_serialize_audit_value(result),
+                    **audit_context,
+                )
                 return result
             except TimeoutError:
                 exc = PublicToolTimeoutError(
                     f"{__tool_name} exceeded {PUBLIC_TOOL_TIMEOUT_S} second public tool timeout"
                 )
-                audit("tool_timeout", tool=__tool_name, timeout_s=PUBLIC_TOOL_TIMEOUT_S)
+                result = _timeout_payload_for_tool(__tool_name, exc)
+                audit(
+                    "tool_timeout",
+                    call_id=call_id,
+                    tool=__tool_name,
+                    timeout_s=PUBLIC_TOOL_TIMEOUT_S,
+                )
                 audit(
                     "mcp_tool_call_end",
+                    call_id=call_id,
                     tool=__tool_name,
                     ok=False,
-                    error=type(exc).__name__,
+                    duration_ms=round((time.monotonic() - started_at) * 1000),
+                    error=str(exc),
+                    error_type=type(exc).__name__,
+                    result=_serialize_audit_value(result),
                     **audit_context,
                 )
-                return _timeout_payload_for_tool(__tool_name, exc)
+                return result
             except Exception as exc:
                 audit(
                     "mcp_tool_call_end",
+                    call_id=call_id,
                     tool=__tool_name,
                     ok=False,
-                    error=type(exc).__name__,
+                    duration_ms=round((time.monotonic() - started_at) * 1000),
+                    error=str(exc) or type(exc).__name__,
+                    error_type=type(exc).__name__,
                     **audit_context,
                 )
                 raise

--- a/tests/test_audit_tool_calls.py
+++ b/tests/test_audit_tool_calls.py
@@ -22,9 +22,11 @@ async def test_mcp_tool_calls_are_audited(tmp_path, monkeypatch):
 
     assert starts[-1]["tool"] == "list_files"
     assert starts[-1]["arguments"]["keyword_args"]["path"] == "."
-    assert ends[-1] == {k: ends[-1][k] for k in ends[-1]}
+    assert starts[-1]["call_id"] == ends[-1]["call_id"]
     assert ends[-1]["tool"] == "list_files"
     assert ends[-1]["ok"] is True
+    assert ends[-1]["duration_ms"] >= 0
+    assert ends[-1]["result"]["ok"] is True
 
 
 def test_audit_tool_arguments_preserves_sensitive_keys():

--- a/tests/test_audit_ui_complete.py
+++ b/tests/test_audit_ui_complete.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import json
+
+import local_shell_mcp.audit as audit_module
+from local_shell_mcp.settings import get_settings
+
+
+def _configure(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_AUDIT_LOG_PATH", str(tmp_path / "audit.jsonl"))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_TAIL_BYTES", "100")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_LOG_BYTES", "400")
+    get_settings.cache_clear()
+
+
+def test_audit_call_helpers_cover_legacy_unpaired_and_optional_fields():
+    assert audit_module._operation_type({"event": "run_shell_start"}) == "shell"
+    assert audit_module._operation_type({"event": "job_started"}) == "jobs"
+    assert audit_module._operation_type({"event": "browser_capture"}) == "browser"
+    assert audit_module._operation_type({"event": "download_created"}) == "transfer"
+    assert audit_module._call_input({"arguments": "invalid"}) is None
+    assert audit_module._call_input({"arguments": {"positional_count": 2}}) == {
+        "positional_count": 2
+    }
+
+    legacy_start = {
+        "ts": 1,
+        "event": "mcp_tool_call_start",
+        "tool": "read_file",
+        "machine": "worker-a",
+        "session": "term-a",
+        "arguments": {"path": "legacy.txt"},
+    }
+    entry = audit_module._new_call_entry(legacy_start, 4)
+    assert entry["id"] == "legacy-call:1:4"
+    assert entry["session"] == "term-a"
+    assert entry["input"] == {"path": "legacy.txt"}
+
+    audit_module._finish_call_entry(
+        entry,
+        {
+            "ok": None,
+            "duration_ms": 9,
+            "result": {"value": 1},
+            "error": "unknown status",
+            "error_type": "RuntimeError",
+        },
+    )
+    assert entry["status"] == "completed"
+    assert entry["duration_ms"] == 9
+    assert entry["output"] == {"value": 1}
+    assert entry["error_type"] == "RuntimeError"
+
+    unpaired = audit_module._unpaired_end_entry(
+        {
+            "ts": 2,
+            "event": "mcp_tool_call_end",
+            "call_id": "orphan",
+            "tool": "job_tail",
+            "node": "worker-b",
+            "session": "term-b",
+            "duration_ms": 4,
+            "result": {"lines": []},
+            "ok": False,
+            "error": "missing start",
+            "error_type": "LookupError",
+        },
+        5,
+    )
+    assert unpaired == {
+        "id": "call:orphan",
+        "ts": 2.0,
+        "event": "mcp_tool_call",
+        "tool": "job_tail",
+        "node": "worker-b",
+        "operation": "jobs",
+        "paired": False,
+        "status": "unpaired",
+        "source_events": ["mcp_tool_call_end"],
+        "call_id": "orphan",
+        "session": "term-b",
+        "duration_ms": 4,
+        "output": {"lines": []},
+        "ok": False,
+        "error": "missing start",
+        "error_type": "LookupError",
+    }
+
+    rows = audit_module._coalesce_audit_records(
+        [
+            {"ts": 0, "event": "auth_ok"},
+            legacy_start,
+            {
+                "ts": 3,
+                "event": "mcp_tool_call_end",
+                "tool": "read_file",
+                "machine": "worker-a",
+                "session": "term-a",
+                "ok": False,
+            },
+            {"ts": 4, "event": "mcp_tool_call_end", "tool": "job_tail", "ok": True},
+            {"id": "kept", "ts": 5, "event": "remote_worker_registered", "node": "worker-c"},
+        ]
+    )
+    assert len(rows) == 3
+    assert rows[0]["paired"] is True
+    assert rows[0]["status"] == "failed"
+    assert rows[1]["status"] == "unpaired"
+    assert rows[2]["id"] == "kept"
+    assert rows[2]["operation"] == "remote"
+
+
+def test_query_audit_covers_tail_reading_and_filter_rejections(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    assert audit_module.query_audit() == {"entries": [], "count": 0, "total_matched": 0}
+
+    path = get_settings().audit_log_path
+    records = [
+        {"ts": 1, "event": "shell_send", "machine": "worker-a", "session": "one", "detail": "alpha"},
+        {"ts": 2, "event": "job_started", "machine": "worker-b", "session": "two", "detail": "beta"},
+        {"ts": 3, "event": "browser_capture", "machine": "worker-c", "session": "three", "detail": "gamma"},
+    ]
+    payload = b"prefix-without-json\n" + b"x" * 500 + b"\n\xff\n"
+    payload += ("\n".join(json.dumps(record) for record in records) + "\n").encode()
+    path.write_bytes(payload)
+
+    all_rows = audit_module.query_audit(sort="asc")
+    assert [row["ts"] for row in all_rows["entries"]] == [1, 2, 3]
+    assert audit_module.query_audit(start_ts=2.5)["entries"][0]["ts"] == 3
+    assert audit_module.query_audit(end_ts=1.5)["entries"][0]["ts"] == 1
+    assert audit_module.query_audit(node="missing")["total_matched"] == 0
+    assert audit_module.query_audit(event="missing")["total_matched"] == 0
+    assert audit_module.query_audit(operation="transfer")["total_matched"] == 0
+    assert audit_module.query_audit(session="missing")["total_matched"] == 0
+    assert audit_module.query_audit(search="missing")["total_matched"] == 0
+
+
+def test_trim_audit_log_without_newline_keeps_bounded_tail(tmp_path):
+    path = tmp_path / "audit.jsonl"
+    path.write_bytes(b"x" * 200)
+
+    audit_module._trim_audit_log(path, 100)
+
+    assert path.read_bytes() == b"x" * 50

--- a/tests/test_edge_modules_complete.py
+++ b/tests/test_edge_modules_complete.py
@@ -111,7 +111,7 @@ def test_audit_serialization_trimming_and_all_filters(tmp_path, monkeypatch):
     settings.max_audit_tail_bytes = 10_000
     settings.max_audit_log_bytes = 10_000
     rows = [
-        {"ts": 1, "event": "mcp_tool_call_start", "tool": "read_file", "machine": "a", "session": "s", "detail": "needle"},
+        {"ts": 1, "event": "mcp_tool_call_start", "tool": "read_file", "machine": "a", "session": "s", "arguments": {"keyword_args": {"path": "needle"}}},
         {"ts": 2, "event": "oauth_auth_failed", "node": "b", "session": "x"},
         ["not", "dict"],
     ]
@@ -120,7 +120,7 @@ def test_audit_serialization_trimming_and_all_filters(tmp_path, monkeypatch):
         limit=9999,
         node="a",
         event="call",
-        operation="read",
+        operation="files",
         session="s",
         search="needle",
         start_ts=0,
@@ -128,9 +128,11 @@ def test_audit_serialization_trimming_and_all_filters(tmp_path, monkeypatch):
         sort="asc",
     )
     assert matched["total_matched"] == 1
-    assert matched["entries"][0]["operation"] == "read"
+    assert matched["entries"][0]["operation"] == "files"
     assert audit_module._operation_type({}) == "other"
-    assert audit_module._operation_type({"event": "remote_worker_registered"}) == "worker"
+    assert audit_module._operation_type({"event": "remote_worker_registered"}) == "remote"
+    assert audit_module._operation_type({"tool": "job_tail"}) == "jobs"
+    assert audit_module._operation_type({"tool": "create_file_link"}) == "transfer"
 
 
 def test_auth_scopes_hosts_tokens_and_metadata(tmp_path, monkeypatch):

--- a/tests/test_human_ui.py
+++ b/tests/test_human_ui.py
@@ -407,27 +407,59 @@ def test_audit_storage_remains_valid_under_concurrent_trim_and_append(tmp_path, 
     assert not list(tmp_path.glob(".audit.jsonl.*.tmp"))
 
 
-def test_query_audit_filters_node_operation_and_order(tmp_path, monkeypatch):
+def test_query_audit_pairs_calls_filters_compact_operations_and_hides_auth(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
     path = tmp_path / "audit.jsonl"
     path.write_text(
         "\n".join(
             json.dumps(record)
             for record in [
-                {"ts": 10, "event": "mcp_tool_call_start", "tool": "read_file", "machine": "worker-a"},
-                {"ts": 20, "event": "mcp_tool_call_start", "tool": "run_shell_tool", "machine": "worker-b"},
-                {"ts": 30, "event": "mcp_tool_call_end", "tool": "run_shell_tool", "machine": "worker-b", "ok": True},
+                {"ts": 5, "event": "auth_ok", "subject": "local-user"},
+                {
+                    "ts": 10,
+                    "event": "mcp_tool_call_start",
+                    "call_id": "files-call",
+                    "tool": "read_file",
+                    "machine": "worker-a",
+                    "arguments": {"keyword_args": {"path": "a.txt"}},
+                },
+                {
+                    "ts": 20,
+                    "event": "mcp_tool_call_start",
+                    "call_id": "shell-call",
+                    "tool": "run_shell_tool",
+                    "machine": "worker-b",
+                    "arguments": {"keyword_args": {"command": "true"}},
+                },
+                {
+                    "ts": 30,
+                    "event": "mcp_tool_call_end",
+                    "call_id": "shell-call",
+                    "tool": "run_shell_tool",
+                    "machine": "worker-b",
+                    "ok": True,
+                    "duration_ms": 12,
+                    "result": {"ok": True, "message": "", "data": {"exit_code": 0}},
+                },
             ]
         )
         + "\n",
         encoding="utf-8",
     )
 
-    result = query_audit(node="worker-b", operation="run", sort="asc")
+    result = query_audit(node="worker-b", operation="shell", sort="asc")
 
-    assert result["total_matched"] == 2
-    assert [entry["ts"] for entry in result["entries"]] == [20, 30]
-    assert all(entry["node"] == "worker-b" for entry in result["entries"])
+    assert result["total_matched"] == 1
+    entry = result["entries"][0]
+    assert entry["id"] == "call:shell-call"
+    assert entry["node"] == "worker-b"
+    assert entry["operation"] == "shell"
+    assert entry["paired"] is True
+    assert entry["status"] == "success"
+    assert entry["input"] == {"command": "true"}
+    assert entry["output"]["data"]["exit_code"] == 0
+    assert entry["duration_ms"] == 12
+    assert all(item["event"] != "auth_ok" for item in query_audit()["entries"])
 
 
 

--- a/ui/src/audit-screen.tsx
+++ b/ui/src/audit-screen.tsx
@@ -1,6 +1,13 @@
 import { useKeyboard } from "@opentui/react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { api, formatError } from "./api"
+import {
+  AUDIT_OPERATIONS,
+  auditInput,
+  auditOutput,
+  formatAuditValue,
+  selectionAfterRefresh,
+} from "./audit-utils"
 import { EmptyState, KeyHint, Modal, Panel, useVisibleRows } from "./components"
 import { clampIndex } from "./state-utils"
 import { screenTheme, theme } from "./theme"
@@ -17,22 +24,26 @@ const TIME_RANGES = [
   { label: "7d", seconds: 7 * 24 * 60 * 60 },
   { label: "All", seconds: 0 },
 ]
-const OPERATIONS = ["", "run", "read", "write", "shell", "git", "remote", "browser", "download", "auth"]
 
 function entryColor(entry: AuditEntry): string {
-  if (entry.ok === false || entry.error) return theme.red
-  if (entry.ok === true) return theme.green
-  if (entry.event.includes("start")) return colors.accent
+  if (entry.paired === false) return theme.yellow
+  if (entry.ok === false || entry.error || entry.status === "failed") return theme.red
+  if (entry.ok === true || entry.status === "success") return theme.green
+  if (entry.event.endsWith("_start")) return theme.yellow
   return theme.muted
 }
 
-function detail(entry: AuditEntry): string {
-  if (entry.command) return String(entry.command)
-  if (entry.cwd) return String(entry.cwd)
-  if (entry.error) return String(entry.error)
-  const args = entry.arguments as Record<string, unknown> | undefined
-  if (args) return JSON.stringify(args)
-  return JSON.stringify(entry)
+function statusLabel(entry: AuditEntry): string {
+  if (entry.paired === false) return entry.status === "running" ? "RUNNING" : "UNPAIRED"
+  if (entry.ok === false || entry.error || entry.status === "failed") return "FAILED"
+  if (entry.ok === true || entry.status === "success") return "SUCCESS"
+  return entry.status?.toUpperCase() || "EVENT"
+}
+
+function durationLabel(entry: AuditEntry): string {
+  if (typeof entry.duration_ms !== "number") return ""
+  if (entry.duration_ms < 1000) return `${entry.duration_ms} ms`
+  return `${(entry.duration_ms / 1000).toFixed(2)} s`
 }
 
 export function AuditScreen({
@@ -63,18 +74,26 @@ export function AuditScreen({
   const [loading, setLoading] = useState(false)
   const refreshRequest = useRef(0)
   const refreshController = useRef<AbortController | null>(null)
+  const entriesRef = useRef<AuditEntry[]>([])
+  const selectedRef = useRef(0)
 
   const nodes = useMemo(() => ["", ...machines.map((machine) => machine.name)], [machines])
   const selectedNode = nodes[nodeIndex] || ""
-  const selectedOperation = OPERATIONS[operationIndex] || ""
+  const selectedOperation = AUDIT_OPERATIONS[operationIndex] || ""
   const timeRange = TIME_RANGES[timeIndex] || TIME_RANGES[2]!
   const current = entries[selected]
   const narrow = width < 70
   const tableHeight = Math.max(6, height - 15)
   const { rows, start } = useVisibleRows(entries, selected, tableHeight)
 
+  const selectIndex = useCallback((next: number | ((value: number) => number)) => {
+    const resolved = typeof next === "function" ? next(selectedRef.current) : next
+    selectedRef.current = resolved
+    setSelected(resolved)
+  }, [])
+
   const cycleNode = () => setNodeIndex((value) => (value + 1) % nodes.length)
-  const cycleOperation = () => setOperationIndex((value) => (value + 1) % OPERATIONS.length)
+  const cycleOperation = () => setOperationIndex((value) => (value + 1) % AUDIT_OPERATIONS.length)
   const cycleTime = () => setTimeIndex((value) => (value + 1) % TIME_RANGES.length)
   const toggleSort = () => setSort((value) => (value === "desc" ? "asc" : "desc"))
 
@@ -101,9 +120,12 @@ export function AuditScreen({
         controller.signal,
       )
       if (requestId !== refreshRequest.current || controller.signal.aborted) return
+      const nextSelected = selectionAfterRefresh(entriesRef.current, selectedRef.current, payload.entries)
+      entriesRef.current = payload.entries
+      selectedRef.current = nextSelected
       setEntries(payload.entries)
-      setSelected((value) => clampIndex(value, payload.entries.length))
-      setStatus(`Audit: ${payload.total_matched} matching records`)
+      setSelected(nextSelected)
+      setStatus(`Audit: ${payload.total_matched} matching calls and events`)
     } catch (error) {
       if (requestId === refreshRequest.current && !controller.signal.aborted) {
         setStatus(`Audit: ${formatError(error)}`)
@@ -141,10 +163,10 @@ export function AuditScreen({
       return
     }
     if (key.name === "j" || key.name === "down") {
-      setSelected((value) => clampIndex(value + 1, entries.length))
-    }
-    else if (key.name === "k" || key.name === "up") setSelected((value) => Math.max(0, value - 1))
-    else if (key.name === "n") cycleNode()
+      selectIndex((value) => clampIndex(value + 1, entries.length))
+    } else if (key.name === "k" || key.name === "up") {
+      selectIndex((value) => Math.max(0, value - 1))
+    } else if (key.name === "n") cycleNode()
     else if (key.name === "o") cycleOperation()
     else if (key.name === "t") cycleTime()
     else if (key.name === "s") toggleSort()
@@ -168,6 +190,13 @@ export function AuditScreen({
     else if (dialog.type === "session") setSession(submitted.trim())
     setDialog({ type: "none" })
   }
+
+  const outputText = current
+    ? formatAuditValue(auditOutput(current), "No return value recorded")
+    : ""
+  const inputText = current ? formatAuditValue(auditInput(current), "No input recorded") : ""
+  const duration = current ? durationLabel(current) : ""
+  const detailHeight = width >= 110 ? "100%" : Math.max(14, Math.floor(height * 0.42))
 
   return (
     <box style={{ flexGrow: 1, flexDirection: "column", gap: 1 }}>
@@ -211,7 +240,7 @@ export function AuditScreen({
               <box style={{ height: 2, flexDirection: "row", paddingLeft: 1, paddingRight: 1 }}>
                 <text fg={theme.faint} content="TIME       " />
                 {!narrow && <text fg={theme.faint} content="NODE              " />}
-                {!narrow && <text fg={theme.faint} content="OPERATION     " />}
+                {!narrow && <text fg={theme.faint} content="OPERATION  " />}
                 <text fg={theme.faint} content="EVENT / TOOL" />
               </box>
               {rows.map((entry, offset) => {
@@ -219,8 +248,8 @@ export function AuditScreen({
                 const active = index === selected
                 return (
                   <box
-                    key={`${entry.ts}-${entry.event}-${index}`}
-                    onMouseDown={() => setSelected(index)}
+                    key={entry.id || `${entry.ts}-${entry.event}-${index}`}
+                    onMouseDown={() => selectIndex(index)}
                     style={{
                       height: 1,
                       flexDirection: "row",
@@ -231,7 +260,7 @@ export function AuditScreen({
                   >
                     <text fg={theme.faint} content={`${new Date(entry.ts * 1000).toLocaleTimeString().padEnd(11)} `} />
                     {!narrow && <text fg={active ? theme.text : theme.muted} content={`${entry.node.slice(0, 16).padEnd(17)} `} />}
-                    {!narrow && <text fg={entryColor(entry)} content={`${entry.operation.slice(0, 12).padEnd(13)} `} />}
+                    {!narrow && <text fg={entryColor(entry)} content={`${entry.operation.slice(0, 9).padEnd(10)} `} />}
                     <text fg={active ? theme.text : theme.muted} attributes={active ? 1 : 0} content={entry.tool || entry.event} />
                   </box>
                 )
@@ -239,14 +268,37 @@ export function AuditScreen({
             </box>
           )}
         </Panel>
-        <Panel title="Record details" style={{ width: width >= 110 ? Math.max(36, Math.floor(width * 0.31)) : "100%", height: width >= 110 ? "100%" : 8, padding: 1 }}>
+        <Panel
+          title="Call details"
+          style={{
+            width: width >= 110 ? Math.max(44, Math.floor(width * 0.38)) : "100%",
+            height: detailHeight,
+            padding: 1,
+            gap: 1,
+          }}
+        >
           {current ? (
-            <scrollbox focused={false} style={{ flexGrow: 1 }} scrollY verticalScrollbarOptions={{ visible: true }}>
-              <text fg={colors.accent} attributes={1} content={current.tool || current.event} />
-              <text fg={theme.faint} content={`${new Date(current.ts * 1000).toLocaleString()} · ${current.node}`} />
-              <text fg={theme.muted} content={`\n${detail(current)}`} />
-              <text fg={theme.faint} content={`\n\n${JSON.stringify(current, null, 2)}`} />
-            </scrollbox>
+            <>
+              <box style={{ height: 1, flexDirection: "row" }}>
+                <text fg={colors.accent} attributes={1} content={current.tool || current.event} />
+                <box style={{ flexGrow: 1 }} />
+                <text fg={entryColor(current)} attributes={1} content={statusLabel(current)} />
+              </box>
+              <text
+                fg={theme.faint}
+                content={`${new Date(current.ts * 1000).toLocaleString()} · ${current.node}${duration ? ` · ${duration}` : ""}`}
+              />
+              <Panel title="Call result" style={{ flexGrow: 1, padding: 1 }}>
+                <scrollbox focused={false} style={{ flexGrow: 1 }} scrollY verticalScrollbarOptions={{ visible: true }}>
+                  <text fg={theme.muted} content={outputText} />
+                </scrollbox>
+              </Panel>
+              <Panel title="Call input" style={{ flexGrow: 1, padding: 1 }}>
+                <scrollbox focused={false} style={{ flexGrow: 1 }} scrollY verticalScrollbarOptions={{ visible: true }}>
+                  <text fg={theme.faint} content={inputText} />
+                </scrollbox>
+              </Panel>
+            </>
           ) : (
             <EmptyState title="No record selected" detail="Use j/k to inspect entries" />
           )}

--- a/ui/src/audit-utils.test.ts
+++ b/ui/src/audit-utils.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test"
+import {
+  AUDIT_OPERATIONS,
+  auditInput,
+  auditOutput,
+  formatAuditValue,
+  selectionAfterRefresh,
+} from "./audit-utils"
+import type { AuditEntry } from "./types"
+
+function entry(id: string, ts: number): AuditEntry {
+  return {
+    id,
+    ts,
+    event: "mcp_tool_call",
+    node: "local",
+    operation: "files",
+    tool: "read_file",
+  }
+}
+
+describe("audit selection", () => {
+  test("keeps following the newest record when the first row is selected", () => {
+    expect(selectionAfterRefresh([entry("a", 2)], 0, [entry("b", 3), entry("a", 2)])).toBe(0)
+  })
+
+  test("preserves a non-top selected record when new rows arrive", () => {
+    const previous = [entry("a", 2), entry("b", 1)]
+    const next = [entry("c", 3), entry("a", 2), entry("b", 1)]
+    expect(selectionAfterRefresh(previous, 1, next)).toBe(2)
+  })
+})
+
+describe("audit formatting", () => {
+  test("shows only useful data from the standard tool envelope", () => {
+    expect(
+      formatAuditValue({ ok: true, message: "", data: { path: "a.txt", machine: null } }, "empty"),
+    ).toBe('{\n  "path": "a.txt"\n}')
+  })
+
+  test("uses keyword arguments as call input and result as call output", () => {
+    const call: AuditEntry = {
+      ...entry("call", 1),
+      arguments: { positional_count: 0, keyword_args: { path: "a.txt", machine: null } },
+      result: { ok: true, message: "", data: { bytes: 4 } },
+    }
+    expect(auditInput(call)).toEqual({ path: "a.txt", machine: null })
+    expect(auditOutput(call)).toEqual({ ok: true, message: "", data: { bytes: 4 } })
+  })
+})
+
+test("operation filters match the compact current tool groups", () => {
+  expect(AUDIT_OPERATIONS).toEqual([
+    "",
+    "files",
+    "shell",
+    "jobs",
+    "transfer",
+    "browser",
+    "remote",
+    "agent",
+  ])
+})

--- a/ui/src/audit-utils.ts
+++ b/ui/src/audit-utils.ts
@@ -1,0 +1,108 @@
+import type { AuditEntry } from "./types"
+
+export const AUDIT_OPERATIONS = ["", "files", "shell", "jobs", "transfer", "browser", "remote", "agent"] as const
+
+type JsonRecord = Record<string, unknown>
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+export function auditEntryKey(entry: AuditEntry): string {
+  if (entry.id) return entry.id
+  if (entry.call_id) return `call:${entry.call_id}`
+  return [entry.event, entry.tool || "", entry.ts, entry.node, entry.session || ""].join("|")
+}
+
+export function selectionAfterRefresh(
+  previousEntries: AuditEntry[],
+  previousSelected: number,
+  nextEntries: AuditEntry[],
+): number {
+  if (nextEntries.length === 0 || previousSelected <= 0) return 0
+  const previous = previousEntries[previousSelected]
+  if (!previous) return Math.min(previousSelected, nextEntries.length - 1)
+  const key = auditEntryKey(previous)
+  const preserved = nextEntries.findIndex((entry) => auditEntryKey(entry) === key)
+  return preserved >= 0 ? preserved : Math.min(previousSelected, nextEntries.length - 1)
+}
+
+function cleanAuditValue(value: unknown): unknown {
+  if (value === null || value === undefined || value === "") return undefined
+  if (Array.isArray(value)) {
+    const items = value.map(cleanAuditValue).filter((item) => item !== undefined)
+    return items.length ? items : undefined
+  }
+  if (isRecord(value)) {
+    const entries = Object.entries(value)
+      .map(([key, item]) => [key, cleanAuditValue(item)] as const)
+      .filter(([, item]) => item !== undefined)
+    return entries.length ? Object.fromEntries(entries) : undefined
+  }
+  return value
+}
+
+function parseJsonString(value: string): unknown {
+  const trimmed = value.trim()
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return value
+  try {
+    return JSON.parse(trimmed)
+  } catch {
+    return value
+  }
+}
+
+function unwrapToolEnvelope(value: unknown): unknown {
+  if (!isRecord(value) || !("data" in value)) return value
+  const allowed = new Set(["ok", "message", "data", "error", "error_type"])
+  if (Object.keys(value).some((key) => !allowed.has(key))) return value
+
+  const data = cleanAuditValue(value.data)
+  const message = cleanAuditValue(value.message)
+  const error = cleanAuditValue(value.error)
+  const errorType = cleanAuditValue(value.error_type)
+  if (value.ok === false || error !== undefined || errorType !== undefined) {
+    return cleanAuditValue({ message, error, error_type: errorType, data })
+  }
+  return data ?? message
+}
+
+export function formatAuditValue(value: unknown, emptyLabel: string): string {
+  const parsed = typeof value === "string" ? parseJsonString(value) : value
+  const cleaned = cleanAuditValue(unwrapToolEnvelope(parsed))
+  if (cleaned === undefined) return emptyLabel
+  if (typeof cleaned === "string") return cleaned
+  return JSON.stringify(cleaned, null, 2)
+}
+
+export function auditInput(entry: AuditEntry): unknown {
+  if (entry.input !== undefined) return entry.input
+  if (isRecord(entry.arguments)) {
+    return entry.arguments.keyword_args ?? entry.arguments
+  }
+  const input: JsonRecord = {}
+  for (const key of ["command", "cwd", "path", "url", "session", "machine"]) {
+    if (entry[key] !== undefined) input[key] = entry[key]
+  }
+  return cleanAuditValue(input)
+}
+
+export function auditOutput(entry: AuditEntry): unknown {
+  if (entry.output !== undefined) return entry.output
+  if (entry.result !== undefined) return entry.result
+  const output: JsonRecord = {}
+  for (const key of [
+    "ok",
+    "error",
+    "error_type",
+    "exit_code",
+    "timed_out",
+    "duration_ms",
+    "stdout",
+    "stderr",
+    "truncated",
+  ]) {
+    if (entry[key] !== undefined) output[key] = entry[key]
+  }
+  return cleanAuditValue(output)
+}

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -71,6 +71,8 @@ export interface TodoPayload {
 }
 
 export interface AuditEntry {
+  id?: string
+  call_id?: string
   ts: number
   event: string
   node: string
@@ -80,7 +82,15 @@ export interface AuditEntry {
   command?: string
   cwd?: string
   ok?: boolean
+  paired?: boolean
+  status?: "success" | "failed" | "running" | "unpaired" | "completed" | string
+  duration_ms?: number
+  input?: unknown
+  output?: unknown
+  result?: unknown
+  arguments?: unknown
   error?: string
+  error_type?: string
   [key: string]: unknown
 }
 


### PR DESCRIPTION
## Summary
- hide successful auth noise and pair MCP start/end audit records into one logical call
- color completed calls green/red and unpaired or running calls yellow
- show formatted call result above formatted input without duplicate raw JSON
- preserve non-top selection while new audit records arrive
- replace obsolete operation filters with compact groups matching the current tool surface

## Validation
- `PYTHONPATH=src python3 -m ruff check src tests`
- `PYTHONPATH=src python3 -m pytest -q` (446 passed)
- `bun test` (21 passed)
- `bun run typecheck`
- `bun run build`