### PR TITLE
fix(ui): render images in Files preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Standalone release archives and Docker images also include the native OpenTUI si
 local-shell-mcp tui
 ```
 
-Files follows a Yazi-derived three-pane interaction model and Docker images include `yazi` and `ya`. Manual actions entered through either human interface are excluded from the MCP audit log; the Audit screen and terminal audit rail show model-originated MCP activity.
+Files follows a Yazi-derived three-pane interaction model, renders bounded PNG/JPEG/GIF/WebP thumbnails directly in OpenTUI, and Docker images include `yazi` and `ya`. Manual actions entered through either human interface are excluded from the MCP audit log; the Audit screen and terminal audit rail show model-originated MCP activity.
 
 See the [human interface guide](https://fwerkor.github.io/local-shell-mcp/guides/human-interface/).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
   "aiofiles>=23.2.1",
   "python-multipart>=0.0.9",
   "pathspec>=0.12.1",
+  "pillow>=10.3.0",
   "playwright>=1.44.0",
   "pywinpty>=2.0.13; platform_system == \"Windows\"",
 ]

--- a/src/local_shell_mcp/human_ui.py
+++ b/src/local_shell_mcp/human_ui.py
@@ -35,6 +35,7 @@ from .fs_ops import (
     resolve_path,
     write_text,
 )
+from .image_ops import make_image_preview
 from .oauth import ALL_OAUTH_SCOPES
 from .remote import remote_manager
 from .settings import get_settings
@@ -398,6 +399,32 @@ async def api_file_preview(request: Request) -> Response:
                     return _json_ok(
                         {"kind": "directory", "entries": _normalize_file_entries(listed, windows_paths)}
                     )
+
+        if path.lower().endswith((".png", ".jpg", ".jpeg", ".gif", ".webp")):
+            columns = max(8, min(int(request.query_params.get("columns", "96")), 200))
+            rows = max(4, min(int(request.query_params.get("rows", "32")), 100))
+            from .tools import load_image_for_machine
+
+            image, display_path = await load_image_for_machine(
+                path,
+                None if machine == "local" else machine,
+            )
+            rendered = await asyncio.to_thread(make_image_preview, image, columns, rows)
+            return _json_ok(
+                {
+                    "kind": "image",
+                    "path": display_path,
+                    "bytes": image.size,
+                    "mime_type": image.mime_type,
+                    "rgba": base64.b64encode(rendered.rgba).decode("ascii"),
+                    "width": rendered.width,
+                    "height": rendered.height,
+                    "cell_width": rendered.cell_width,
+                    "cell_height": rendered.cell_height,
+                    "original_width": rendered.original_width,
+                    "original_height": rendered.original_height,
+                }
+            )
 
         content = await _machine_dispatch(
             machine,

--- a/src/local_shell_mcp/image_ops.py
+++ b/src/local_shell_mcp/image_ops.py
@@ -82,10 +82,11 @@ def make_image_preview(
 
     columns = max(2, min(int(max_columns), 200))
     rows = max(1, min(int(max_rows), 100))
-    # OpenTUI's supersampled renderer maps one source pixel to two terminal
-    # columns and two vertical pixels to one terminal row.
-    max_pixel_width = max(1, columns // 2)
-    max_pixel_height = max(1, rows * 2)
+    # OpenTUI's supersampled renderer consumes a 2x2 source-pixel block for
+    # each terminal cell, so the source raster may be twice the cell bounds
+    # in both dimensions.
+    max_pixel_width = columns * 2
+    max_pixel_height = rows * 2
 
     with Image.open(BytesIO(image.data)) as opened:
         opened.seek(0)
@@ -111,7 +112,9 @@ def make_image_preview(
         rgba=rgba,
         width=width,
         height=height,
-        cell_width=width * 2,
+        # Keep a two-column minimum for the preview render box while reporting
+        # the actual 2x2 supersampling footprint for normal images.
+        cell_width=max(2, (width + 1) // 2),
         cell_height=(height + 1) // 2,
         original_width=original_width,
         original_height=original_height,

--- a/src/local_shell_mcp/image_ops.py
+++ b/src/local_shell_mcp/image_ops.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from io import BytesIO
+
+from PIL import Image, ImageOps
 
 from .fs_ops import relative_display, resolve_path
 
 MAX_VIEW_IMAGE_BYTES = 20 * 1024 * 1024
+MAX_PREVIEW_SOURCE_PIXELS = 25_000_000
 
 
 @dataclass(frozen=True)
@@ -14,6 +18,17 @@ class ImageFile:
     format: str
     mime_type: str
     size: int
+
+
+@dataclass(frozen=True)
+class ImagePreview:
+    rgba: bytes
+    width: int
+    height: int
+    cell_width: int
+    cell_height: int
+    original_width: int
+    original_height: int
 
 
 def assert_view_image_size(size: int) -> None:
@@ -55,4 +70,49 @@ def read_image(path: str) -> ImageFile:
         format=image_format,
         mime_type=mime_type,
         size=len(data),
+    )
+
+
+def make_image_preview(
+    image: ImageFile,
+    max_columns: int,
+    max_rows: int,
+) -> ImagePreview:
+    """Decode a bounded first-frame RGBA thumbnail for OpenTUI's pixel buffer."""
+
+    columns = max(2, min(int(max_columns), 200))
+    rows = max(1, min(int(max_rows), 100))
+    # OpenTUI's supersampled renderer maps one source pixel to two terminal
+    # columns and two vertical pixels to one terminal row.
+    max_pixel_width = max(1, columns // 2)
+    max_pixel_height = max(1, rows * 2)
+
+    with Image.open(BytesIO(image.data)) as opened:
+        opened.seek(0)
+        oriented = ImageOps.exif_transpose(opened)
+        original_width, original_height = oriented.size
+        if original_width <= 0 or original_height <= 0:
+            raise ValueError("Image has invalid dimensions")
+        if original_width * original_height > MAX_PREVIEW_SOURCE_PIXELS:
+            raise ValueError(
+                "Refusing to decode image preview with "
+                f"{original_width * original_height} pixels; max is {MAX_PREVIEW_SOURCE_PIXELS}"
+            )
+        frame = oriented.convert("RGBA")
+        frame.thumbnail(
+            (max_pixel_width, max_pixel_height),
+            Image.Resampling.LANCZOS,
+            reducing_gap=3.0,
+        )
+        width, height = frame.size
+        rgba = frame.tobytes()
+
+    return ImagePreview(
+        rgba=rgba,
+        width=width,
+        height=height,
+        cell_width=width * 2,
+        cell_height=(height + 1) // 2,
+        original_width=original_width,
+        original_height=original_height,
     )

--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -1135,37 +1135,45 @@ def _view_image_error_result(
     )
 
 
+async def load_image_for_machine(
+    path: str,
+    machine: str | None = None,
+) -> tuple[ImageFile, str]:
+    display_path = path
+    if machine:
+        if not get_settings().remote_enabled:
+            raise RuntimeError("Remote workers are disabled")
+        stat = await _remote_transfer_data(
+            machine,
+            "transfer_stat",
+            {"path": path, "sha256": False},
+        )
+        if not isinstance(stat, dict) or stat.get("type") != "file":
+            raise ValueError(f"source is not a file: {path}")
+        assert_view_image_size(int(stat.get("size") or 0))
+        temporary = await asyncio.to_thread(transfer_alloc_temp_path, ".bin")
+        temporary_path = temporary["path"]
+        try:
+            await _copy_remote_file_to_local(
+                machine,
+                path,
+                temporary_path,
+                True,
+            )
+            image = await asyncio.to_thread(read_image, temporary_path)
+        finally:
+            with suppress(Exception):
+                await asyncio.to_thread(delete_path, temporary_path, False)
+        display_path = str(stat.get("path") or path)
+    else:
+        image = await asyncio.to_thread(read_image, path)
+        display_path = image.path
+    return image, display_path
+
+
 async def _view_image_result(path: str, machine: str | None = None) -> CallToolResult:
     try:
-        display_path = path
-        if machine:
-            if not get_settings().remote_enabled:
-                raise RuntimeError("Remote workers are disabled")
-            stat = await _remote_transfer_data(
-                machine,
-                "transfer_stat",
-                {"path": path, "sha256": False},
-            )
-            if not isinstance(stat, dict) or stat.get("type") != "file":
-                raise ValueError(f"source is not a file: {path}")
-            assert_view_image_size(int(stat.get("size") or 0))
-            temporary = await asyncio.to_thread(transfer_alloc_temp_path, ".bin")
-            temporary_path = temporary["path"]
-            try:
-                await _copy_remote_file_to_local(
-                    machine,
-                    path,
-                    temporary_path,
-                    True,
-                )
-                image = await asyncio.to_thread(read_image, temporary_path)
-            finally:
-                with suppress(Exception):
-                    await asyncio.to_thread(delete_path, temporary_path, False)
-            display_path = str(stat.get("path") or path)
-        else:
-            image = await asyncio.to_thread(read_image, path)
-            display_path = image.path
+        image, display_path = await load_image_for_machine(path, machine)
         return _view_image_success_result(image, display_path, machine)
     except Exception as exc:
         return _view_image_error_result(path, machine, exc)

--- a/tests/test_human_ui.py
+++ b/tests/test_human_ui.py
@@ -115,6 +115,28 @@ def test_human_file_api_has_yazi_style_directory_payload(tmp_path, monkeypatch):
     assert any(entry["name"] == "alpha.txt" and entry["type"] == "file" for entry in payload["entries"])
 
 
+def test_human_file_api_renders_image_preview(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    png = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+    )
+    (tmp_path / "pixel.png").write_bytes(png)
+
+    client = TestClient(build_http_app())
+    response = client.get(
+        "/api/ui/files/preview",
+        params={"machine": "local", "path": "pixel.png", "columns": 20, "rows": 8},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()["data"]
+    assert payload["kind"] == "image"
+    assert payload["mime_type"] == "image/png"
+    assert (payload["width"], payload["height"]) == (1, 1)
+    assert (payload["cell_width"], payload["cell_height"]) == (2, 1)
+    assert len(base64.b64decode(payload["rgba"])) == 4
+
+
 def test_editor_content_reads_the_complete_bounded_file(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
     content = "\n".join(f"line-{index}" for index in range(350))

--- a/tests/test_view_image.py
+++ b/tests/test_view_image.py
@@ -55,9 +55,11 @@ def test_make_image_preview_returns_bounded_rgba(tmp_path, monkeypatch):
     preview = make_image_preview(read_image("wide.png"), max_columns=12, max_rows=4)
 
     assert (preview.original_width, preview.original_height) == (100, 50)
-    assert (preview.width, preview.height) == (6, 3)
-    assert (preview.cell_width, preview.cell_height) == (12, 2)
-    assert len(preview.rgba) == 6 * 3 * 4
+    assert (preview.width, preview.height) == (16, 8)
+    assert (preview.cell_width, preview.cell_height) == (8, 4)
+    assert preview.cell_width <= 12
+    assert preview.cell_height <= 4
+    assert len(preview.rgba) == 16 * 8 * 4
 
 
 def test_image_validation_errors(tmp_path, monkeypatch):

--- a/tests/test_view_image.py
+++ b/tests/test_view_image.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
 import base64
+from io import BytesIO
 from pathlib import Path
 
 import pytest
 from mcp.types import CallToolResult, ImageContent, TextContent
+from PIL import Image
 
 import local_shell_mcp.tools as tools
 from local_shell_mcp.image_ops import (
     MAX_VIEW_IMAGE_BYTES,
     assert_view_image_size,
     detect_image_type,
+    make_image_preview,
     read_image,
 )
 from local_shell_mcp.settings import get_settings
@@ -41,6 +44,20 @@ def _configure(tmp_path: Path, monkeypatch, *, remote_enabled: bool = True) -> N
 )
 def test_detect_image_type(header, expected):
     assert detect_image_type(header) == expected
+
+
+def test_make_image_preview_returns_bounded_rgba(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    buffer = BytesIO()
+    Image.new("RGB", (100, 50), (12, 34, 56)).save(buffer, format="PNG")
+    (tmp_path / "wide.png").write_bytes(buffer.getvalue())
+
+    preview = make_image_preview(read_image("wide.png"), max_columns=12, max_rows=4)
+
+    assert (preview.original_width, preview.original_height) == (100, 50)
+    assert (preview.width, preview.height) == (6, 3)
+    assert (preview.cell_width, preview.cell_height) == (12, 2)
+    assert len(preview.rgba) == 6 * 3 * 4
 
 
 def test_image_validation_errors(tmp_path, monkeypatch):

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -71,8 +71,8 @@ export const api = {
   files(machine: string, path: string, signal?: AbortSignal): Promise<FilesPayload> {
     return request(`/files${queryString({ machine, path })}`, { signal })
   },
-  filePreview(machine: string, path: string): Promise<FilePreview> {
-    return request(`/files/preview${queryString({ machine, path })}`)
+  filePreview(machine: string, path: string, columns?: number, rows?: number): Promise<FilePreview> {
+    return request(`/files/preview${queryString({ machine, path, columns, rows })}`)
   },
   fileContent(machine: string, path: string): Promise<FilePreview> {
     return request(`/files/content${queryString({ machine, path })}`)

--- a/ui/src/files-screen.tsx
+++ b/ui/src/files-screen.tsx
@@ -1,4 +1,4 @@
-import type { TextareaRenderable } from "@opentui/core"
+import type { OptimizedBuffer, Renderable, TextareaRenderable } from "@opentui/core"
 import { useKeyboard } from "@opentui/react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { api, formatError } from "./api"
@@ -90,6 +90,46 @@ function FileRows({
   )
 }
 
+function ImagePreview({ preview, entry }: { preview: FilePreview; entry: FileEntry }) {
+  const pixelWidth = Number(preview.width || 0)
+  const pixelHeight = Number(preview.height || 0)
+  const cellWidth = Number(preview.cell_width || pixelWidth * 2)
+  const cellHeight = Number(preview.cell_height || Math.ceil(pixelHeight / 2))
+  let pixels: Uint8Array
+  try {
+    pixels = Uint8Array.from(Buffer.from(String(preview.rgba || ""), "base64"))
+  } catch {
+    return <EmptyState title={entry.name} detail="Invalid image preview data" />
+  }
+  if (!pixelWidth || !pixelHeight || pixels.byteLength !== pixelWidth * pixelHeight * 4) {
+    return <EmptyState title={entry.name} detail="Invalid image preview dimensions" />
+  }
+  const sourceWidth = Number(preview.original_width || pixelWidth)
+  const sourceHeight = Number(preview.original_height || pixelHeight)
+  const drawPixels = function (this: Renderable, buffer: OptimizedBuffer) {
+    buffer.drawSuperSampleBuffer(
+      this.screenX,
+      this.screenY,
+      pixels as never,
+      pixels.byteLength,
+      "rgba8unorm",
+      pixelWidth * 4,
+    )
+  }
+  return (
+    <box style={{ flexGrow: 1, flexDirection: "column", alignItems: "center", justifyContent: "center" }}>
+      <box
+        style={{ width: cellWidth, height: cellHeight, flexShrink: 0 }}
+        renderAfter={drawPixels}
+      />
+      <text
+        fg={theme.faint}
+        content={`${sourceWidth}×${sourceHeight} · ${formatBytes(Number(preview.bytes || entry.size || 0))}`}
+      />
+    </box>
+  )
+}
+
 function Preview({ preview, entry }: { preview: FilePreview | null; entry?: FileEntry }) {
   if (!entry) return <EmptyState title="No selection" detail="Choose an entry to inspect" />
   if (!preview) return <EmptyState title={entry.name} detail="Loading preview…" />
@@ -110,6 +150,7 @@ function Preview({ preview, entry }: { preview: FilePreview | null; entry?: File
       </box>
     )
   }
+  if (preview.kind === "image") return <ImagePreview preview={preview} entry={entry} />
   const text = String(preview.content || preview.preview || "")
   return (
     <scrollbox
@@ -151,6 +192,7 @@ export function FilesScreen({
   const [clipboard, setClipboard] = useState<ClipboardState | null>(null)
   const [busy, setBusy] = useState(false)
   const [narrowPane, setNarrowPane] = useState<"list" | "preview">("list")
+  const [previewBounds, setPreviewBounds] = useState<{ columns: number; rows: number } | null>(null)
   const editorRef = useRef<TextareaRenderable>(null)
   const refreshRequest = useRef(0)
   const refreshController = useRef<AbortController | null>(null)
@@ -174,6 +216,12 @@ export function FilesScreen({
   }, [entries.length])
   const narrow = width < 70
   const compact = width < 105
+  const fallbackPreviewColumns = Math.max(
+    8,
+    narrow ? width - 8 : compact ? Math.floor(width * 0.45) - 6 : Math.floor(width * 0.4) - 8,
+  )
+  const previewColumns = previewBounds?.columns || fallbackPreviewColumns
+  const previewRows = previewBounds?.rows || Math.max(4, listHeight - 3)
 
   const refresh = useCallback(async () => {
     const requestId = ++refreshRequest.current
@@ -224,7 +272,7 @@ export function FilesScreen({
     if (!current) return
     const timer = setTimeout(() => {
       void api
-        .filePreview(machine, current.path)
+        .filePreview(machine, current.path, previewColumns, previewRows)
         .then((result) => {
           if (!cancelled) setPreview(result)
         })
@@ -236,7 +284,7 @@ export function FilesScreen({
       cancelled = true
       clearTimeout(timer)
     }
-  }, [current?.path, machine, setStatus])
+  }, [current?.path, machine, previewColumns, previewRows, setStatus])
 
   useEffect(() => {
     onInteractionLockChange(dialog.type !== "none")
@@ -526,7 +574,22 @@ export function FilesScreen({
             )}
             {(!narrow || narrowPane === "preview") && (
               <Panel title={current ? `Preview · ${current.name}` : "Preview"} style={{ flexGrow: 1, width: narrow ? "100%" : undefined, paddingTop: 1 }}>
-                <Preview preview={preview} entry={current} />
+                <box
+                  style={{ flexGrow: 1, flexDirection: "column" }}
+                  onSizeChange={function (this: Renderable) {
+                    const next = {
+                      columns: Math.max(8, this.width),
+                      rows: Math.max(4, this.height - 1),
+                    }
+                    setPreviewBounds((currentBounds) =>
+                      currentBounds?.columns === next.columns && currentBounds.rows === next.rows
+                        ? currentBounds
+                        : next,
+                    )
+                  }}
+                >
+                  <Preview preview={preview} entry={current} />
+                </box>
               </Panel>
             )}
           </box>

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -34,9 +34,17 @@ export interface FilesPayload {
 }
 
 export interface FilePreview {
-  kind: "directory" | "text" | "binary"
+  kind: "directory" | "text" | "binary" | "image"
   content?: string
   preview?: string
+  rgba?: string
+  mime_type?: string
+  width?: number
+  height?: number
+  cell_width?: number
+  cell_height?: number
+  original_width?: number
+  original_height?: number
   entries?: FileEntry[]
   size?: number
   path?: string


### PR DESCRIPTION
## Summary

- detect PNG, JPEG, GIF, and WebP files in the Files preview API
- decode bounded first-frame RGBA thumbnails with Pillow for local and remote machines
- render thumbnails directly through OpenTUI's supersampled pixel buffer instead of showing binary hex
- measure the real preview pane so images stay within its borders at different terminal sizes
- keep the existing `view_image` tool and UI on one shared local/remote image loading path

## Validation

- `PYTHONPATH=/workspace/local-shell-mcp/src python -m pytest -q` — 452 passed
- coverage — 94.0% total
- `ruff check .`
- `bun run typecheck`
- `bun test` — 25 passed
- `bun run build`
- browser smoke test with a WebP image in the authenticated PTY WebUI; thumbnail rendered inside the preview pane
