### PR TITLE
Support multiple Agent Skill sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,13 +145,9 @@ See the [remote workers guide](https://fwerkor.github.io/local-shell-mcp/guides/
 
 ## Agent Skills
 
-Place externally managed Skill directories under:
+Skills are discovered from three ordered sources: project-level `/workspace/.agents/skills`, the LSM-managed `/workspace/.local-shell-mcp/agent_config/skills`, and global `~/.config/agents/skills`. Higher-priority sources override lower-priority Skills with the same name, and symlinked Skill directories and files are supported.
 
-```text
-/workspace/.local-shell-mcp/agent_config/skills/<skill-name>/SKILL.md
-```
-
-Use `skills_list` to discover installed Skills, `skill_load` to load one instruction set, and `skill_read_file` to read a related file by the returned Skill-relative path. Skill changes are detected on the next call; no per-Skill MCP tools are registered and no client reconnect is required. The runtime intentionally leaves installation, updates, and removal to ordinary file or Git operations.
+This makes the universal Skills CLI layout work directly, for example `npx skills add owner/repo --agent universal -y`. Use `skills_list` to discover installed Skills, `skill_load` to load one instruction set, and `skill_read_file` to read a related file by the returned Skill-relative path. Changes are detected on the next call; no per-Skill MCP tools are registered and no client reconnect is required.
 
 See the [Agent Skills guide](https://fwerkor.github.io/local-shell-mcp/guides/skills/).
 

--- a/docs/guides/skills.md
+++ b/docs/guides/skills.md
@@ -1,37 +1,35 @@
 # Agent Skills
 
-`local-shell-mcp` supports reusable Markdown-based Agent Skills through a fixed MCP tool surface. Installing or removing a Skill never adds or removes MCP tools, so clients do not need to refresh `tools/list` or reconnect.
+`local-shell-mcp` supports reusable Markdown-based Agent Skills through a fixed MCP tool surface. Installing or removing a Skill never changes the MCP tool list, so clients do not need to reconnect.
 
-## Directory layout
+## Skill sources
 
-Skills are read from:
+LSM scans these directories in priority order:
 
 ```text
-<state_dir>/agent_config/skills/
-  debugging/
-    SKILL.md
-    checklist.md
-  pdfs/
-    SKILL.md
-    scripts/
-      render.py
+1. <workspace_root>/.agents/skills/
+2. <state_dir>/agent_config/skills/
+3. ${XDG_CONFIG_HOME:-~/.config}/agents/skills/
 ```
 
-With the default workspace, this is:
+With the default workspace and state directory, the first two paths are:
 
 ```text
+/workspace/.agents/skills
 /workspace/.local-shell-mcp/agent_config/skills
 ```
 
-Each immediate child directory is one Skill. Its directory name is the Skill name, and it must contain a regular `SKILL.md` file. A `config.json` file is not required for Skills.
+Each immediate child directory is one Skill. Its directory name is the Skill name and it must provide `SKILL.md`. Skill directories, `SKILL.md`, related files, and related directories may be symlinks.
+
+When the same Skill name appears in multiple sources, the project source wins over the LSM-managed source, which wins over the global source. `skills_list` reports each accepted Skill's `source` and `source_path`, plus the complete ordered `skills_dirs` list.
 
 ## Fixed tools
 
 | Tool | Purpose |
 |---|---|
-| `skills_list` | Rescan the directory and list installed Skill names, descriptions, entry paths, related files, and non-fatal warnings. It does not load instructions. |
-| `skill_load` | Load the complete `SKILL.md` instructions for one exact name returned by `skills_list`. Related files are returned as Skill-relative paths. |
-| `skill_read_file` | Read one bounded related text file using the exact Skill name and path returned by `skill_load`. |
+| `skills_list` | Rescan all sources and list Skill names, descriptions, sources, entry paths, related files, and non-fatal warnings without loading full instructions. |
+| `skill_load` | Load the complete `SKILL.md` instructions for one exact name returned by `skills_list`. |
+| `skill_read_file` | Read one bounded related text file using the Skill-relative path returned by `skill_load`. |
 
 Recommended flow:
 
@@ -39,45 +37,54 @@ Recommended flow:
 skills_list
   -> choose the relevant Skill
   -> skill_load(name)
-  -> skill_read_file(name, path) only for a related file that is needed
-  -> follow its instructions with the existing shell, Git, browser, or machine-routed tools
+  -> skill_read_file(name, path) only when a related file is needed
+  -> follow the Skill with the existing shell, Git, browser, and remote tools
 ```
 
-All three tools are fixed and read-only. `skills_list` performs a bounded registry scan; `skill_load` and `skill_read_file` access only the requested Skill. Changes on disk are visible on the next call.
+Changes on disk are visible on the next call. No per-Skill MCP tools are registered.
 
-## Installing and updating Skills
+## Installing with the Skills CLI
 
-The runtime deliberately does not include a Skill marketplace or package manager. Manage the directory with ordinary file or Git operations, for example:
+The project and global sources match the universal directories used by the open `skills` CLI.
+
+Install into the current LSM workspace:
 
 ```bash
-cp -R ./my-skill /workspace/.local-shell-mcp/agent_config/skills/my-skill
+cd /workspace
+npx skills add owner/repository --agent universal -y
 ```
 
-or:
+Install globally:
 
 ```bash
-git clone https://example.com/team/skills.git /tmp/team-skills
-cp -R /tmp/team-skills/debugging /workspace/.local-shell-mcp/agent_config/skills/debugging
+npx skills add owner/repository --agent universal --global -y
 ```
 
-Updates and removals use the same normal file or Git workflow. The next `skills_list` or `skill_load` call sees the new contents without changing the MCP tool list.
+For a specific Skill:
 
-## Validation and safety
+```bash
+npx skills add XiNian-dada/Fuck_My_Shit_Mountain \
+  --skill fuck-my-shit-mountain \
+  --agent universal \
+  -y
+```
 
-The scanner:
+The LSM-managed source remains available for direct file or Git workflows:
 
-- rejects Skill directories and `SKILL.md` entries that escape the configured directory;
-- rejects symlinked Skill directories, entry files, and related files;
-- skips directories without `SKILL.md` and reports a warning;
-- parses bounded YAML or TOML front-matter descriptions, with prose and heading fallbacks;
-- enforces file-size, Skill-count, scan-entry, related-file, and path-output limits;
-- returns Skill-relative related paths and reads them through `skill_read_file` without exposing an external config directory to general file tools.
+```bash
+git clone https://example.com/team/my-skill.git \
+  /workspace/.local-shell-mcp/agent_config/skills/my-skill
+```
 
-Treat Skills as instructions and code from their publisher. Review `SKILL.md` and any scripts before placing them in the server-side directory.
+Updates and removals made by the CLI, Git, or ordinary filesystem operations are picked up automatically on the next Skill call.
+
+## Validation
+
+The registry skips malformed Skill names and directories without a readable `SKILL.md`. File-size, Skill-count, scan-entry, related-file, and path-output limits still apply. Directory traversal strings are rejected, while filesystem symlinks are followed.
 
 ## REST compatibility
 
-The optional REST surface exposes the same registry through:
+The optional REST surface exposes the same merged registry:
 
 ```text
 GET  /tools/skills_list

--- a/docs/guides/skills.zh-Hant.md
+++ b/docs/guides/skills.zh-Hant.md
@@ -1,37 +1,35 @@
 # Agent Skills
 
-`local-shell-mcp` 透過固定的 MCP 工具面支援基於 Markdown 的可重用 Agent Skill。安裝或刪除 Skill 不會增刪 MCP 工具，因此客戶端無需刷新 `tools/list`，也無需重新連接。
+`local-shell-mcp` 透過固定的 MCP 工具面支援基於 Markdown 的可重用 Agent Skill。安裝或刪除 Skill 不會改變 MCP 工具列表，因此客戶端無需重新連接。
 
-## 目錄結構
+## Skill 來源
 
-Skill 從以下目錄讀取：
+LSM 按以下優先級掃描目錄：
 
 ```text
-<state_dir>/agent_config/skills/
-  debugging/
-    SKILL.md
-    checklist.md
-  pdfs/
-    SKILL.md
-    scripts/
-      render.py
+1. <workspace_root>/.agents/skills/
+2. <state_dir>/agent_config/skills/
+3. ${XDG_CONFIG_HOME:-~/.config}/agents/skills/
 ```
 
-預設工作區下的實際路徑是：
+預設工作區和狀態目錄下，前兩個路徑是：
 
 ```text
+/workspace/.agents/skills
 /workspace/.local-shell-mcp/agent_config/skills
 ```
 
-每個直接子目錄代表一個 Skill。目錄名就是 Skill 名稱，目錄內必須包含普通檔案 `SKILL.md`。Skills 不要求存在 `config.json`。
+每個直接子目錄代表一個 Skill。目錄名就是 Skill 名稱，目錄中必須提供 `SKILL.md`。Skill 目錄、`SKILL.md`、關聯檔案和關聯目錄均可使用符號連結。
+
+同名 Skill 出現在多個來源時，專案級來源優先於 LSM 管理目錄，LSM 管理目錄優先於全域目錄。`skills_list` 會返回每個有效 Skill 的 `source` 和 `source_path`，並透過 `skills_dirs` 給出完整的有序來源列表。
 
 ## 固定工具
 
 | 工具 | 用途 |
 |---|---|
-| `skills_list` | 重新掃描目錄並列出已安裝 Skill 的名稱、描述、入口路徑、關聯檔案和非致命警告，不載入完整指令。 |
-| `skill_load` | 按 `skills_list` 返回的精確名稱載入完整 `SKILL.md`。關聯檔案返回 Skill 內相對路徑。 |
-| `skill_read_file` | 使用 `skill_load` 返回的 Skill 名稱和相對路徑，讀取一個受大小限制的關聯文字檔案。 |
+| `skills_list` | 重新掃描所有來源，列出 Skill 名稱、描述、來源、入口路徑、關聯檔案和非致命警告，不載入完整指令。 |
+| `skill_load` | 按 `skills_list` 返回的精確名稱載入完整 `SKILL.md`。 |
+| `skill_read_file` | 使用 `skill_load` 返回的 Skill 內相對路徑讀取受大小限制的關聯文字檔案。 |
 
 推薦流程：
 
@@ -40,44 +38,53 @@ skills_list
   -> 選擇相關 Skill
   -> skill_load(name)
   -> 僅在需要關聯檔案時調用 skill_read_file(name, path)
-  -> 按 Skill 指令調用已有 shell、Git、瀏覽器或遠程工具
+  -> 按 Skill 指令調用現有 shell、Git、瀏覽器和遠端工具
 ```
 
-三個工具都是固定的只讀工具。`skills_list` 執行有界註冊表掃描；`skill_load` 和 `skill_read_file` 只訪問指定 Skill。磁碟修改會在下一次調用時生效。
+磁碟上的修改會在下一次調用時生效，不會為每個 Skill 動態註冊 MCP 工具。
 
-## 安裝和更新 Skill
+## 使用 Skills CLI 安裝
 
-運行時有意不內置 Skill 市場或包管理器。使用普通檔案或 Git 操作管理該目錄，例如：
+專案級和全域來源與開放的 `skills` CLI 使用的 universal 目錄一致。
+
+安裝到目前 LSM 工作區：
 
 ```bash
-cp -R ./my-skill /workspace/.local-shell-mcp/agent_config/skills/my-skill
+cd /workspace
+npx skills add owner/repository --agent universal -y
 ```
 
-或者：
+安裝到全域目錄：
 
 ```bash
-git clone https://example.com/team/skills.git /tmp/team-skills
-cp -R /tmp/team-skills/debugging /workspace/.local-shell-mcp/agent_config/skills/debugging
+npx skills add owner/repository --agent universal --global -y
 ```
 
-更新和刪除同樣使用普通檔案或 Git 工作流。之後調用 `skills_list` 或 `skill_load` 即可看到新內容，不會改變 MCP 工具列表。
+安裝指定 Skill：
 
-## 校驗與安全
+```bash
+npx skills add XiNian-dada/Fuck_My_Shit_Mountain \
+  --skill fuck-my-shit-mountain \
+  --agent universal \
+  -y
+```
 
-掃描器會：
+LSM 管理目錄仍可透過普通檔案或 Git 操作維護：
 
-- 拒絕逃逸出配置目錄的 Skill 目錄和 `SKILL.md`；
-- 拒絕符號連結形式的 Skill 目錄、入口檔案和關聯檔案；
-- 跳過缺少 `SKILL.md` 的目錄並返回警告；
-- 解析有長度上限的 YAML 或 TOML front matter 描述，並支援正文和標題回退；
-- 限制入口檔案大小、Skill 數量、掃描條目數、關聯檔案數和路徑輸出總量；
-- 返回 Skill 內相對路徑，並透過 `skill_read_file` 讀取，避免向普通檔案工具暴露工作區外配置目錄。
+```bash
+git clone https://example.com/team/my-skill.git \
+  /workspace/.local-shell-mcp/agent_config/skills/my-skill
+```
 
-應把 Skill 視為發布者提供的指令和代碼。放入服務端目錄前，先審查 `SKILL.md` 和其中腳本。
+透過 CLI、Git 或普通檔案操作完成的更新和刪除，會在下一次 Skill 調用時自動生效。
 
-## REST 相容接口
+## 校驗
 
-可選 REST 接口使用同一份 Skill Registry：
+Registry 會跳過非法 Skill 名稱和缺少可讀 `SKILL.md` 的目錄。入口檔案大小、Skill 數量、掃描條目數、關聯檔案數和路徑輸出限制仍然有效。路徑遍歷字串仍會被拒絕，但檔案系統符號連結會被正常跟隨。
+
+## REST 相容介面
+
+可選 REST 介面使用同一份合併後的 Registry：
 
 ```text
 GET  /tools/skills_list

--- a/docs/guides/skills.zh.md
+++ b/docs/guides/skills.zh.md
@@ -1,37 +1,35 @@
 # Agent Skills
 
-`local-shell-mcp` 通过固定的 MCP 工具面支持基于 Markdown 的可复用 Agent Skill。安装或删除 Skill 不会增删 MCP 工具，因此客户端无需刷新 `tools/list`，也无需重新连接。
+`local-shell-mcp` 通过固定的 MCP 工具面支持基于 Markdown 的可复用 Agent Skill。安装或删除 Skill 不会改变 MCP 工具列表，因此客户端无需重新连接。
 
-## 目录结构
+## Skill 来源
 
-Skill 从以下目录读取：
+LSM 按以下优先级扫描目录：
 
 ```text
-<state_dir>/agent_config/skills/
-  debugging/
-    SKILL.md
-    checklist.md
-  pdfs/
-    SKILL.md
-    scripts/
-      render.py
+1. <workspace_root>/.agents/skills/
+2. <state_dir>/agent_config/skills/
+3. ${XDG_CONFIG_HOME:-~/.config}/agents/skills/
 ```
 
-默认工作区下的实际路径是：
+默认工作区和状态目录下，前两个路径是：
 
 ```text
+/workspace/.agents/skills
 /workspace/.local-shell-mcp/agent_config/skills
 ```
 
-每个直接子目录代表一个 Skill。目录名就是 Skill 名称，目录内必须包含普通文件 `SKILL.md`。Skills 不要求存在 `config.json`。
+每个直接子目录代表一个 Skill。目录名就是 Skill 名称，目录中必须提供 `SKILL.md`。Skill 目录、`SKILL.md`、关联文件和关联目录均可使用符号链接。
+
+同名 Skill 出现在多个来源时，项目级来源优先于 LSM 管理目录，LSM 管理目录优先于全局目录。`skills_list` 会返回每个有效 Skill 的 `source` 和 `source_path`，并通过 `skills_dirs` 给出完整的有序来源列表。
 
 ## 固定工具
 
 | 工具 | 用途 |
 |---|---|
-| `skills_list` | 重新扫描目录并列出已安装 Skill 的名称、描述、入口路径、关联文件和非致命警告，不加载完整指令。 |
-| `skill_load` | 按 `skills_list` 返回的精确名称加载完整 `SKILL.md`。关联文件返回 Skill 内相对路径。 |
-| `skill_read_file` | 使用 `skill_load` 返回的 Skill 名称和相对路径，读取一个受大小限制的关联文本文件。 |
+| `skills_list` | 重新扫描所有来源，列出 Skill 名称、描述、来源、入口路径、关联文件和非致命警告，不加载完整指令。 |
+| `skill_load` | 按 `skills_list` 返回的精确名称加载完整 `SKILL.md`。 |
+| `skill_read_file` | 使用 `skill_load` 返回的 Skill 内相对路径读取受大小限制的关联文本文件。 |
 
 推荐流程：
 
@@ -40,44 +38,53 @@ skills_list
   -> 选择相关 Skill
   -> skill_load(name)
   -> 仅在需要关联文件时调用 skill_read_file(name, path)
-  -> 按 Skill 指令调用已有 shell、Git、浏览器或远程工具
+  -> 按 Skill 指令调用现有 shell、Git、浏览器和远程工具
 ```
 
-三个工具都是固定的只读工具。`skills_list` 执行有界注册表扫描；`skill_load` 和 `skill_read_file` 只访问指定 Skill。磁盘修改会在下一次调用时生效。
+磁盘上的修改会在下一次调用时生效，不会为每个 Skill 动态注册 MCP 工具。
 
-## 安装和更新 Skill
+## 使用 Skills CLI 安装
 
-运行时有意不内置 Skill 市场或包管理器。使用普通文件或 Git 操作管理该目录，例如：
+项目级和全局来源与开放的 `skills` CLI 使用的 universal 目录一致。
+
+安装到当前 LSM 工作区：
 
 ```bash
-cp -R ./my-skill /workspace/.local-shell-mcp/agent_config/skills/my-skill
+cd /workspace
+npx skills add owner/repository --agent universal -y
 ```
 
-或者：
+安装到全局目录：
 
 ```bash
-git clone https://example.com/team/skills.git /tmp/team-skills
-cp -R /tmp/team-skills/debugging /workspace/.local-shell-mcp/agent_config/skills/debugging
+npx skills add owner/repository --agent universal --global -y
 ```
 
-更新和删除同样使用普通文件或 Git 工作流。之后调用 `skills_list` 或 `skill_load` 即可看到新内容，不会改变 MCP 工具列表。
+安装指定 Skill：
 
-## 校验与安全
+```bash
+npx skills add XiNian-dada/Fuck_My_Shit_Mountain \
+  --skill fuck-my-shit-mountain \
+  --agent universal \
+  -y
+```
 
-扫描器会：
+LSM 管理目录仍可通过普通文件或 Git 操作维护：
 
-- 拒绝逃逸出配置目录的 Skill 目录和 `SKILL.md`；
-- 拒绝符号链接形式的 Skill 目录、入口文件和关联文件；
-- 跳过缺少 `SKILL.md` 的目录并返回警告；
-- 解析有长度上限的 YAML 或 TOML front matter 描述，并支持正文和标题回退；
-- 限制入口文件大小、Skill 数量、扫描条目数、关联文件数和路径输出总量；
-- 返回 Skill 内相对路径，并通过 `skill_read_file` 读取，避免向普通文件工具暴露工作区外配置目录。
+```bash
+git clone https://example.com/team/my-skill.git \
+  /workspace/.local-shell-mcp/agent_config/skills/my-skill
+```
 
-应把 Skill 视为发布者提供的指令和代码。放入服务端目录前，先审查 `SKILL.md` 和其中脚本。
+通过 CLI、Git 或普通文件操作完成的更新和删除，会在下一次 Skill 调用时自动生效。
+
+## 校验
+
+Registry 会跳过非法 Skill 名称和缺少可读 `SKILL.md` 的目录。入口文件大小、Skill 数量、扫描条目数、关联文件数和路径输出限制仍然有效。路径遍历字符串仍会被拒绝，但文件系统符号链接会被正常跟随。
 
 ## REST 兼容接口
 
-可选 REST 接口使用同一份 Skill Registry：
+可选 REST 接口使用同一份合并后的 Registry：
 
 ```text
 GET  /tools/skills_list

--- a/src/local_shell_mcp/agent_bridge/models.py
+++ b/src/local_shell_mcp/agent_bridge/models.py
@@ -25,3 +25,5 @@ class SkillScanResult:
     """Accepted skills keyed by skill name."""
     warnings: list[str] = field(default_factory=list)
     """Non-fatal discovery warnings for ignored or invalid entries."""
+    scanned_entries: int = 0
+    """Filesystem entries consumed from the registry scan budget."""

--- a/src/local_shell_mcp/agent_bridge/skills.py
+++ b/src/local_shell_mcp/agent_bridge/skills.py
@@ -59,9 +59,7 @@ def validate_skill_file_path(path: str) -> Path:
     if not path:
         raise ValueError("Skill file path must not be empty")
     if len(path) > MAX_SKILL_FILE_PATH_CHARS:
-        raise ValueError(
-            f"Skill file path must be at most {MAX_SKILL_FILE_PATH_CHARS} characters"
-        )
+        raise ValueError(f"Skill file path must be at most {MAX_SKILL_FILE_PATH_CHARS} characters")
     if "\\" in path or ":" in path:
         raise ValueError("Skill file path must use portable POSIX separators")
     if any(ord(character) < 32 or ord(character) == 127 for character in path):
@@ -175,23 +173,16 @@ def _resolved_skills_directory(config_dir: Path, directory: str) -> tuple[Path, 
     directory_path = Path(directory)
     if not _is_relative_child_path(directory_path):
         raise ValueError(f"Skills directory must be inside config directory: {directory}")
-    skills_dir = (config_root / directory_path).resolve()
-    if not skills_dir.is_relative_to(config_root):
-        raise ValueError(f"Skills directory must be inside config directory: {directory}")
+    skills_dir = config_root / directory_path
     return config_root, skills_dir
 
 
-def _open_regular_file(
-    path: Path, allowed_root: Path, max_bytes: int
-) -> tuple[str, int, Path]:
-    """Open a bounded regular file without following its final symlink and verify it stayed in-root."""
+def _open_regular_file(path: Path, max_bytes: int) -> tuple[str, int, Path]:
+    """Open a bounded regular file, following symlinks when present."""
     limit = _bounded(max_bytes, DEFAULT_MAX_ENTRY_BYTES)
-    root = allowed_root.resolve()
     flags = os.O_RDONLY
     if hasattr(os, "O_BINARY"):
         flags |= os.O_BINARY
-    if hasattr(os, "O_NOFOLLOW"):
-        flags |= os.O_NOFOLLOW
 
     try:
         descriptor = os.open(path, flags)
@@ -204,16 +195,10 @@ def _open_regular_file(
             if not stat.S_ISREG(opened_stat.st_mode):
                 raise ValueError("Skill file path must be a regular file")
             if opened_stat.st_size > limit:
-                raise ValueError(
-                    f"Skill file is {opened_stat.st_size} bytes; maximum is {limit}"
-                )
+                raise ValueError(f"Skill file is {opened_stat.st_size} bytes; maximum is {limit}")
 
             resolved = path.resolve(strict=True)
-            if not resolved.is_relative_to(root):
-                raise ValueError("Skill file path must stay inside the skill directory")
-            current_stat = path.stat(follow_symlinks=False)
-            if stat.S_ISLNK(current_stat.st_mode):
-                raise ValueError("Skill file path must not be a symlink")
+            current_stat = path.stat()
             if (
                 opened_stat.st_ino
                 and current_stat.st_ino
@@ -231,9 +216,7 @@ def _open_regular_file(
                 chunks.append(chunk)
                 total += len(chunk)
                 if total > limit:
-                    raise ValueError(
-                        f"Skill file exceeds maximum size of {limit} bytes"
-                    )
+                    raise ValueError(f"Skill file exceeds maximum size of {limit} bytes")
             data = b"".join(chunks)
         except OSError as exc:
             raise ValueError(
@@ -251,19 +234,16 @@ def _resolve_skill_root(skills_dir: Path, name: str) -> Path:
     validated_name = validate_skill_name(name)
     candidate = skills_dir / validated_name
     try:
-        candidate_stat = candidate.stat(follow_symlinks=False)
+        resolved = candidate.resolve(strict=True)
     except FileNotFoundError as exc:
         raise ValueError(
             f"Unknown skill: {validated_name}. Call skills_list to see installed skills."
         ) from exc
     except OSError as exc:
         raise ValueError(f"Could not inspect skill {validated_name}: {exc}") from exc
-    if stat.S_ISLNK(candidate_stat.st_mode) or not stat.S_ISDIR(candidate_stat.st_mode):
-        raise ValueError("Skill directory must be a regular directory, not a symlink")
-    resolved = candidate.resolve(strict=True)
-    if not resolved.is_relative_to(skills_dir):
-        raise ValueError("Skill directory must stay inside the skills directory")
-    return resolved
+    if not resolved.is_dir():
+        raise ValueError("Skill path must resolve to a directory")
+    return candidate
 
 
 def _scan_related_files(
@@ -293,10 +273,20 @@ def _scan_related_files(
         )
         return related_files, warnings, scanned_entries
     path_bytes = 0
-    stack = [skill_root]
+    stack: list[tuple[Path, tuple[str, ...]]] = [(skill_root, ())]
+    visited_directories: set[Path] = set()
+    resolved_entry = entry_path.resolve(strict=True)
 
     while stack:
-        current = stack.pop()
+        current, relative_parts = stack.pop()
+        try:
+            resolved_current = current.resolve(strict=True)
+        except OSError as exc:
+            _append_warning(warnings, f"Could not resolve related directory {current}: {exc}")
+            continue
+        if resolved_current in visited_directories:
+            continue
+        visited_directories.add(resolved_current)
         try:
             with os.scandir(current) as iterator:
                 entries = []
@@ -314,31 +304,19 @@ def _scan_related_files(
             continue
 
         for entry in sorted(entries, key=lambda item: item.name, reverse=True):
-            path = Path(entry.path)
+            path = current / entry.name
+            logical_parts = (*relative_parts, entry.name)
+            relative = PurePosixPath(*logical_parts).as_posix()
             try:
-                entry_stat = entry.stat(follow_symlinks=False)
-                if stat.S_ISLNK(entry_stat.st_mode):
-                    _append_warning(
-                        warnings,
-                        f"Skipping related path {path.name}: symlinks are not allowed",
-                    )
-                    continue
+                entry_stat = entry.stat(follow_symlinks=True)
                 if stat.S_ISDIR(entry_stat.st_mode):
-                    resolved_dir = path.resolve(strict=True)
-                    if resolved_dir.is_relative_to(skill_root):
-                        stack.append(resolved_dir)
-                    else:
-                        _append_warning(
-                            warnings,
-                            f"Skipping related directory {path.name}: path escaped the Skill",
-                        )
+                    stack.append((path, logical_parts))
                     continue
                 if not stat.S_ISREG(entry_stat.st_mode):
                     continue
                 resolved = path.resolve(strict=True)
-                if resolved == entry_path or not resolved.is_relative_to(skill_root):
+                if relative == "SKILL.md" or resolved == resolved_entry:
                     continue
-                relative = _relative_posix(skill_root, resolved)
                 validate_skill_file_path(relative)
                 encoded_bytes = len(relative.encode("utf-8"))
                 if len(related_files) >= related_limit:
@@ -378,9 +356,7 @@ def _load_skill_record(
     entry_path = skill_root / "SKILL.md"
     if not entry_path.exists():
         raise ValueError(f"Skill {name} is missing SKILL.md")
-    content, content_bytes, resolved_entry = _open_regular_file(
-        entry_path, skill_root, max_entry_bytes
-    )
+    content, content_bytes, resolved_entry = _open_regular_file(entry_path, max_entry_bytes)
     related_files, warnings, scanned_entries = _scan_related_files(
         skill_root,
         resolved_entry,
@@ -390,7 +366,7 @@ def _load_skill_record(
     )
     record = SkillRecord(
         name=name,
-        entry_path=_relative_posix(config_root, resolved_entry),
+        entry_path=_relative_posix(config_root, entry_path),
         description=_skill_description(content),
         related_files=related_files,
     )
@@ -433,21 +409,18 @@ def scan_agent_skills(
                     break
                 scanned_entries += 1
                 try:
-                    entry_stat = entry.stat(follow_symlinks=False)
+                    entry_stat = entry.stat(follow_symlinks=True)
                 except OSError as exc:
                     _append_warning(warnings, f"Skipping skill {entry.name!r}: {exc}")
-                    continue
-                if stat.S_ISLNK(entry_stat.st_mode):
-                    _append_warning(
-                        warnings,
-                        f"Skipping skill {entry.name!r}: skill directory is a symlink",
-                    )
                     continue
                 if not stat.S_ISDIR(entry_stat.st_mode):
                     continue
                 candidates.append(entry.name)
     except OSError as exc:
-        return SkillScanResult(warnings=[f"Could not scan skills directory {directory}: {exc}"])
+        return SkillScanResult(
+            warnings=[f"Could not scan skills directory {directory}: {exc}"],
+            scanned_entries=scanned_entries,
+        )
 
     candidates.sort()
     if len(candidates) > skill_limit:
@@ -458,6 +431,7 @@ def scan_agent_skills(
         candidates = candidates[:skill_limit]
 
     skills: dict[str, SkillRecord] = {}
+    total_scanned_entries = scanned_entries
     remaining_scan_entries = max(0, scan_limit - scanned_entries)
     remaining_path_bytes = max(0, int(max_path_bytes))
     for name in candidates:
@@ -476,15 +450,18 @@ def scan_agent_skills(
             _append_warning(warnings, f"Skipping skill {name!r}: {exc}")
             continue
         skills[name] = record
+        total_scanned_entries += related_scanned
         remaining_scan_entries = max(0, remaining_scan_entries - related_scanned)
         for warning in skill_warnings:
             _append_warning(warnings, f"Skill {name}: {warning}")
-        remaining_path_bytes -= sum(
-            len(path.encode("utf-8")) for path in record.related_files
-        )
+        remaining_path_bytes -= sum(len(path.encode("utf-8")) for path in record.related_files)
         remaining_path_bytes = max(0, remaining_path_bytes)
 
-    return SkillScanResult(skills=skills, warnings=warnings)
+    return SkillScanResult(
+        skills=skills,
+        warnings=warnings,
+        scanned_entries=total_scanned_entries,
+    )
 
 
 def load_agent_skill(
@@ -535,9 +512,7 @@ def read_agent_skill_file(
     if relative_path.as_posix() == "SKILL.md":
         raise ValueError("Use skill_load to read SKILL.md")
     file_path = skill_root / relative_path
-    content, content_bytes, _ = _open_regular_file(
-        file_path, skill_root, max_file_bytes
-    )
+    content, content_bytes, _ = _open_regular_file(file_path, max_file_bytes)
     return {
         "name": skill_name,
         "path": relative_path.as_posix(),
@@ -558,9 +533,7 @@ def activate_skill(
     if not _is_relative_child_path(entry_relative):
         raise ValueError("Skill entry path must be inside config directory")
     entry_path = config_root / entry_relative
-    content, content_bytes, _ = _open_regular_file(
-        entry_path, entry_path.parent.resolve(), max_entry_bytes
-    )
+    content, content_bytes, _ = _open_regular_file(entry_path, max_entry_bytes)
     return {
         "name": skill.name,
         "entry_path": skill.entry_path,

--- a/src/local_shell_mcp/agent_bridge/skills.py
+++ b/src/local_shell_mcp/agent_bridge/skills.py
@@ -4,7 +4,7 @@ import os
 import re
 import stat
 import tomllib
-from pathlib import Path, PurePosixPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any
 
 import yaml
@@ -27,8 +27,16 @@ def _relative_posix(base: Path, path: Path) -> str:
 
 
 def _is_relative_child_path(value: Path) -> bool:
-    """Accept only relative child paths so skill references cannot escape their root."""
-    return not value.is_absolute() and ".." not in value.parts
+    """Accept portable relative child paths on every host platform."""
+    raw = os.fspath(value)
+    posix = PurePosixPath(raw)
+    windows = PureWindowsPath(raw)
+    return (
+        not posix.anchor
+        and not windows.anchor
+        and ".." not in posix.parts
+        and ".." not in windows.parts
+    )
 
 
 def validate_skill_name(name: str) -> str:

--- a/src/local_shell_mcp/settings.py
+++ b/src/local_shell_mcp/settings.py
@@ -355,8 +355,8 @@ if _PYDANTIC_AVAILABLE:
         ui_terminal_max_sessions: int = 8
         ui_remote_request_timeout_s: int = 30
 
-        # Skills use the fixed skills_list and skill_load tools and are read
-        # from agent_config_dir/skills. The MCP tool surface remains static.
+        # Skills use a fixed tool surface and are merged from workspace-level
+        # .agents/skills, agent_config_dir/skills, and the global universal directory.
 
         file_download_enabled: bool = True
         file_download_default_ttl_s: int = 3600

--- a/src/local_shell_mcp/skill_ops.py
+++ b/src/local_shell_mcp/skill_ops.py
@@ -1,6 +1,7 @@
 """Fixed operations for discovering and loading installed agent skills."""
 
-from dataclasses import asdict
+import os
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
@@ -8,57 +9,168 @@ from .agent_bridge.skills import (
     load_agent_skill,
     read_agent_skill_file,
     scan_agent_skills,
+    validate_skill_name,
 )
 from .settings import Settings, get_settings
 
 SKILLS_DIRECTORY = "skills"
+UNIVERSAL_SKILLS_DIRECTORY = ".agents/skills"
+GLOBAL_SKILLS_DIRECTORY = "agents/skills"
+
+
+@dataclass(frozen=True)
+class SkillSource:
+    """One ordered Agent Skill registry root."""
+
+    name: str
+    config_dir: Path
+    directory: str
+
+    @property
+    def path(self) -> Path:
+        return self.config_dir.expanduser().resolve() / self.directory
 
 
 def skills_directory(settings: Settings | None = None) -> Path:
-    """Return the externally managed skills directory."""
+    """Return the LSM-managed skills directory kept for API compatibility."""
     active_settings = settings or get_settings()
     return active_settings.agent_config_dir / SKILLS_DIRECTORY
 
 
-def _scan_limits(settings: Settings) -> dict[str, int]:
+def skill_sources(settings: Settings | None = None) -> tuple[SkillSource, ...]:
+    """Return Skill roots in lookup priority order."""
+    active_settings = settings or get_settings()
+    config_home = Path(os.environ.get("XDG_CONFIG_HOME", str(Path.home() / ".config"))).expanduser()
+    candidates = (
+        SkillSource("project", active_settings.workspace_root, UNIVERSAL_SKILLS_DIRECTORY),
+        SkillSource("managed", active_settings.agent_config_dir, SKILLS_DIRECTORY),
+        SkillSource("global", config_home, GLOBAL_SKILLS_DIRECTORY),
+    )
+
+    unique: list[SkillSource] = []
+    seen_paths: set[Path] = set()
+    for source in candidates:
+        resolved_path = source.path.resolve()
+        if resolved_path in seen_paths:
+            continue
+        seen_paths.add(resolved_path)
+        unique.append(source)
+    return tuple(unique)
+
+
+def _source_list(settings: Settings) -> list[dict[str, str]]:
+    return [{"source": source.name, "path": str(source.path)} for source in skill_sources(settings)]
+
+
+def _common_registry_metadata(settings: Settings) -> dict[str, Any]:
     return {
-        "max_skills": settings.max_skills,
-        "max_related_files": settings.max_skill_related_files,
-        "max_scan_entries": settings.max_skill_scan_entries,
-        "max_path_bytes": settings.max_skill_path_bytes,
-        "max_entry_bytes": settings.max_file_read_bytes,
+        "skills_dir": str(skills_directory(settings)),
+        "skills_dirs": _source_list(settings),
     }
 
 
 def list_installed_skills(settings: Settings | None = None) -> dict[str, Any]:
-    """Scan installed skills and return compact metadata without loading instructions."""
+    """Scan all Skill roots and return compact metadata without loading instructions."""
     active_settings = settings or get_settings()
-    result = scan_agent_skills(
-        active_settings.agent_config_dir,
-        SKILLS_DIRECTORY,
-        **_scan_limits(active_settings),
-    )
+    skills: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    accepted_names: set[str] = set()
+    remaining_skills = max(0, active_settings.max_skills)
+    remaining_scan_entries = max(0, active_settings.max_skill_scan_entries)
+    remaining_path_bytes = max(0, active_settings.max_skill_path_bytes)
+
+    for source in skill_sources(active_settings):
+        if remaining_skills == 0:
+            warnings.append(f"Skill list truncated at {active_settings.max_skills} directories")
+            break
+        if remaining_scan_entries == 0:
+            warnings.append(
+                f"Skill directory scan stopped after "
+                f"{active_settings.max_skill_scan_entries} entries"
+            )
+            break
+        result = scan_agent_skills(
+            source.config_dir,
+            source.directory,
+            max_skills=active_settings.max_skills,
+            max_related_files=active_settings.max_skill_related_files,
+            max_scan_entries=remaining_scan_entries,
+            max_path_bytes=remaining_path_bytes,
+            max_entry_bytes=active_settings.max_file_read_bytes,
+        )
+        warnings.extend(f"{source.name}: {warning}" for warning in result.warnings)
+        remaining_scan_entries = max(
+            0,
+            remaining_scan_entries - result.scanned_entries,
+        )
+
+        for record in result.skills.values():
+            if record.name in accepted_names:
+                warnings.append(
+                    f"{source.name}: skipped duplicate Skill {record.name!r}; "
+                    "a higher-priority source already provides it"
+                )
+                continue
+            payload = asdict(record)
+            payload["source"] = source.name
+            payload["source_path"] = str(source.path)
+            skills.append(payload)
+            accepted_names.add(record.name)
+            remaining_skills -= 1
+            remaining_path_bytes = max(
+                0,
+                remaining_path_bytes
+                - sum(len(path.encode("utf-8")) for path in record.related_files),
+            )
+            if remaining_skills == 0:
+                break
+
     return {
-        "skills_dir": str(skills_directory(active_settings)),
-        "skills": [asdict(skill) for skill in result.skills.values()],
-        "warnings": result.warnings,
+        **_common_registry_metadata(active_settings),
+        "skills": skills,
+        "warnings": warnings,
     }
 
 
+def _load_skill_from_sources(
+    name: str,
+    settings: Settings,
+) -> tuple[SkillSource, dict[str, Any]]:
+    validated_name = validate_skill_name(name)
+    errors: list[str] = []
+
+    for source in skill_sources(settings):
+        candidate = source.path / validated_name
+        try:
+            if not candidate.exists() or not candidate.is_dir():
+                continue
+            payload = load_agent_skill(
+                source.config_dir,
+                validated_name,
+                source.directory,
+                max_related_files=settings.max_skill_related_files,
+                max_scan_entries=settings.max_skill_scan_entries,
+                max_path_bytes=settings.max_skill_path_bytes,
+                max_entry_bytes=settings.max_file_read_bytes,
+            )
+        except (OSError, RuntimeError, ValueError) as exc:
+            errors.append(f"{source.name}: {exc}")
+            continue
+        return source, payload
+
+    if errors:
+        raise ValueError(f"Could not load skill {validated_name}: " + "; ".join(errors))
+    raise ValueError(f"Unknown skill: {validated_name}. Call skills_list to see installed skills.")
+
+
 def load_installed_skill(name: str, settings: Settings | None = None) -> dict[str, Any]:
-    """Load one installed skill directly by its exact directory name."""
+    """Load one installed Skill from the highest-priority valid source."""
     active_settings = settings or get_settings()
-    payload = load_agent_skill(
-        active_settings.agent_config_dir,
-        name,
-        SKILLS_DIRECTORY,
-        max_related_files=active_settings.max_skill_related_files,
-        max_scan_entries=active_settings.max_skill_scan_entries,
-        max_path_bytes=active_settings.max_skill_path_bytes,
-        max_entry_bytes=active_settings.max_file_read_bytes,
-    )
+    source, payload = _load_skill_from_sources(name, active_settings)
     return {
-        "skills_dir": str(skills_directory(active_settings)),
+        **_common_registry_metadata(active_settings),
+        "source": source.name,
+        "source_path": str(source.path),
         **payload,
     }
 
@@ -68,16 +180,19 @@ def read_installed_skill_file(
     path: str,
     settings: Settings | None = None,
 ) -> dict[str, Any]:
-    """Read one bounded related file from an installed Skill."""
+    """Read one bounded related file from the selected installed Skill."""
     active_settings = settings or get_settings()
+    source, _ = _load_skill_from_sources(name, active_settings)
     payload = read_agent_skill_file(
-        active_settings.agent_config_dir,
+        source.config_dir,
         name,
         path,
-        SKILLS_DIRECTORY,
+        source.directory,
         max_file_bytes=active_settings.max_file_read_bytes,
     )
     return {
-        "skills_dir": str(skills_directory(active_settings)),
+        **_common_registry_metadata(active_settings),
+        "source": source.name,
+        "source_path": str(source.path),
         **payload,
     }

--- a/tests/test_skill_tools.py
+++ b/tests/test_skill_tools.py
@@ -20,15 +20,30 @@ def _skills_root(tmp_path):
     return tmp_path / ".local-shell-mcp" / "agent_config" / "skills"
 
 
+def _project_skills_root(tmp_path):
+    return tmp_path / ".agents" / "skills"
+
+
+def _global_skills_root(tmp_path):
+    return tmp_path / "home" / ".config" / "agents" / "skills"
+
+
 def _configure(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "home" / ".config"))
     monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
     monkeypatch.setenv("LOCAL_SHELL_MCP_AUTH_MODE", "none")
     monkeypatch.setenv("LOCAL_SHELL_MCP_REMOTE_ENABLED", "false")
     get_settings.cache_clear()
 
 
-def _install_skill(tmp_path, name="debugging"):
-    skill_dir = _skills_root(tmp_path) / name
+def _install_skill(tmp_path, name="debugging", source="managed"):
+    roots = {
+        "project": _project_skills_root(tmp_path),
+        "managed": _skills_root(tmp_path),
+        "global": _global_skills_root(tmp_path),
+    }
+    skill_dir = roots[source] / name
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(
         "---\ndescription: Diagnose failing tests safely.\n---\n\n# Debugging\n",
@@ -46,6 +61,11 @@ def test_skills_list_is_empty_when_no_skills_are_installed(tmp_path, monkeypatch
     assert payload["skills"] == []
     assert payload["warnings"] == []
     assert payload["skills_dir"] == str(_skills_root(tmp_path))
+    assert payload["skills_dirs"] == [
+        {"source": "project", "path": str(_project_skills_root(tmp_path))},
+        {"source": "managed", "path": str(_skills_root(tmp_path))},
+        {"source": "global", "path": str(_global_skills_root(tmp_path))},
+    ]
 
 
 def test_skill_load_returns_instructions_and_related_paths(tmp_path, monkeypatch):
@@ -61,11 +81,78 @@ def test_skill_load_returns_instructions_and_related_paths(tmp_path, monkeypatch
             "entry_path": "skills/debugging/SKILL.md",
             "description": "Diagnose failing tests safely.",
             "related_files": ["checklist.md"],
+            "source": "managed",
+            "source_path": str(_skills_root(tmp_path)),
         }
     ]
     assert loaded["name"] == "debugging"
     assert loaded["content"].startswith("---\ndescription:")
     assert loaded["related_files"] == ["checklist.md"]
+    assert loaded["source"] == "managed"
+    assert loaded["source_path"] == str(_skills_root(tmp_path))
+
+
+def test_skill_sources_merge_with_project_then_managed_then_global_priority(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    project = _install_skill(tmp_path, "shared", "project")
+    managed = _install_skill(tmp_path, "shared", "managed")
+    _install_skill(tmp_path, "managed-only", "managed")
+    _install_skill(tmp_path, "global-only", "global")
+    (project / "SKILL.md").write_text("# Project copy\n", encoding="utf-8")
+    (managed / "SKILL.md").write_text("# Managed copy\n", encoding="utf-8")
+
+    listed = list_installed_skills()
+    loaded = load_installed_skill("shared")
+    related = read_installed_skill_file("shared", "checklist.md")
+
+    assert [(skill["name"], skill["source"]) for skill in listed["skills"]] == [
+        ("shared", "project"),
+        ("managed-only", "managed"),
+        ("global-only", "global"),
+    ]
+    assert loaded["content"] == "# Project copy\n"
+    assert loaded["source"] == "project"
+    assert related["source"] == "project"
+    assert any("skipped duplicate Skill 'shared'" in warning for warning in listed["warnings"])
+
+
+def test_skill_sources_share_one_registry_scan_budget(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_SKILL_SCAN_ENTRIES", "3")
+    get_settings.cache_clear()
+    _install_skill(tmp_path, "project-only", "project")
+    _install_skill(tmp_path, "managed-only", "managed")
+
+    listed = list_installed_skills()
+
+    assert [(skill["name"], skill["source"]) for skill in listed["skills"]] == [
+        ("project-only", "project")
+    ]
+    assert any("stopped after 3 entries" in warning for warning in listed["warnings"])
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires privileges on Windows")
+def test_symlinked_skill_directory_and_entry_file_are_supported(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    real_skill = tmp_path / "real-skill"
+    real_skill.mkdir()
+    real_entry = tmp_path / "real-entry.md"
+    real_entry.write_text("# Linked Skill\n", encoding="utf-8")
+    (real_skill / "SKILL.md").symlink_to(real_entry)
+    (real_skill / "guide.md").write_text("linked guide", encoding="utf-8")
+    project_root = _project_skills_root(tmp_path)
+    project_root.mkdir(parents=True)
+    (project_root / "linked-skill").symlink_to(real_skill, target_is_directory=True)
+
+    listed = list_installed_skills()
+    loaded = load_installed_skill("linked-skill")
+    related = read_installed_skill_file("linked-skill", "guide.md")
+
+    assert [(skill["name"], skill["source"]) for skill in listed["skills"]] == [
+        ("linked-skill", "project")
+    ]
+    assert loaded["content"] == "# Linked Skill\n"
+    assert related["content"] == "linked guide"
 
 
 def test_mcp_instructions_describe_the_fixed_skill_flow(tmp_path, monkeypatch):
@@ -143,9 +230,7 @@ def test_skill_load_rejects_unknown_names(tmp_path, monkeypatch):
         load_installed_skill("missing")
 
 
-def test_skill_read_file_works_when_agent_config_is_outside_workspace(
-    tmp_path, monkeypatch
-):
+def test_skill_read_file_works_when_agent_config_is_outside_workspace(tmp_path, monkeypatch):
     workspace = tmp_path / "workspace"
     agent_config = tmp_path / "external-agent-config"
     monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(workspace))
@@ -184,9 +269,7 @@ def test_skill_text_normalizes_newlines_across_platforms(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
     skill_dir = _skills_root(tmp_path) / "crlf"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_bytes(
-        b"---\r\ndescription: CRLF skill.\r\n---\r\n# CRLF\r\n"
-    )
+    (skill_dir / "SKILL.md").write_bytes(b"---\r\ndescription: CRLF skill.\r\n---\r\n# CRLF\r\n")
     (skill_dir / "reference.md").write_bytes(b"Line one.\r\nLine two.\r")
 
     loaded = load_installed_skill("crlf")
@@ -209,9 +292,7 @@ def test_skill_rest_rejects_non_string_arguments(tmp_path, monkeypatch):
     client = TestClient(build_http_app(), raise_server_exceptions=False)
 
     load_response = client.post("/tools/skill_load", json={"name": 123})
-    read_response = client.post(
-        "/tools/skill_read_file", json={"name": "debugging", "path": 123}
-    )
+    read_response = client.post("/tools/skill_read_file", json={"name": "debugging", "path": 123})
 
     assert load_response.status_code == 400
     assert read_response.status_code == 400
@@ -321,15 +402,18 @@ def test_skill_read_file_rejects_path_traversal(tmp_path, monkeypatch):
 
 
 @pytest.mark.skipif(os.name == "nt", reason="symlink creation requires privileges on Windows")
-def test_skill_read_file_rejects_symlinks(tmp_path, monkeypatch):
+def test_skill_read_file_follows_symlinks(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
     skill_dir = _install_skill(tmp_path)
     outside = tmp_path / "outside.md"
     outside.write_text("outside", encoding="utf-8")
     (skill_dir / "linked.md").symlink_to(outside)
 
-    with pytest.raises(ValueError, match="regular file"):
-        read_installed_skill_file("debugging", "linked.md")
+    loaded = load_installed_skill("debugging")
+    related = read_installed_skill_file("debugging", "linked.md")
+
+    assert "linked.md" in loaded["related_files"]
+    assert related["content"] == "outside"
 
 
 def test_skill_path_budget_is_strict_across_registry(tmp_path, monkeypatch):
@@ -343,11 +427,7 @@ def test_skill_path_budget_is_strict_across_registry(tmp_path, monkeypatch):
         (skill_dir / "x").write_text("x", encoding="utf-8")
 
     listed = list_installed_skills()
-    returned_paths = [
-        path
-        for skill in listed["skills"]
-        for path in skill["related_files"]
-    ]
+    returned_paths = [path for skill in listed["skills"] for path in skill["related_files"]]
 
     assert sum(len(path.encode("utf-8")) for path in returned_paths) <= 1
     assert any("path budget is exhausted" in warning for warning in listed["warnings"])

--- a/tests/test_skills_edge_complete.py
+++ b/tests/test_skills_edge_complete.py
@@ -21,7 +21,19 @@ def test_skill_name_and_path_validation_all_rejections(monkeypatch):
         skills.validate_skill_name(surrogate)
     assert skills.validate_skill_name("合法-name") == "合法-name"
 
-    invalid_paths = [None, "", "x" * (skills.MAX_SKILL_FILE_PATH_CHARS + 1), r"a\b", "a:b", "a\x01", "/a", "../a", ".", "a//b", "a/./b"]
+    invalid_paths = [
+        None,
+        "",
+        "x" * (skills.MAX_SKILL_FILE_PATH_CHARS + 1),
+        r"a\b",
+        "a:b",
+        "a\x01",
+        "/a",
+        "../a",
+        ".",
+        "a//b",
+        "a/./b",
+    ]
     for value in invalid_paths:
         with pytest.raises(ValueError):
             skills.validate_skill_file_path(value)  # type: ignore[arg-type]
@@ -37,7 +49,10 @@ def test_descriptions_front_matter_and_warning_cap():
     assert skills._normalize_description("   ") is None
     assert skills._normalize_description("x" * 600).endswith("…")
 
-    assert skills._skill_description("\n---\ndescription: Useful skill\n---\n# Heading") == "Useful skill"
+    assert (
+        skills._skill_description("\n---\ndescription: Useful skill\n---\n# Heading")
+        == "Useful skill"
+    )
     assert skills._skill_description("+++\ndescription = 'TOML skill'\n+++\nbody") == "TOML skill"
     assert skills._skill_description("---\n[bad\n---\n# Heading\n```\nignored\n```\n") == "Heading"
     assert skills._skill_description("```\nignored\n```\n") == "Agent skill"
@@ -66,20 +81,20 @@ def test_resolved_directories_regular_files_and_roots(tmp_path, monkeypatch):
         skills._resolve_skill_root(directory, "missing")
     file_skill = directory / "file"
     file_skill.write_text("x", encoding="utf-8")
-    with pytest.raises(ValueError, match="regular directory"):
+    with pytest.raises(ValueError, match="resolve to a directory"):
         skills._resolve_skill_root(directory, "file")
 
     skill = directory / "good"
     skill.mkdir()
     entry = skill / "SKILL.md"
     entry.write_bytes(b"line\r\nnext\r")
-    content, size, resolved = skills._open_regular_file(entry, skill, 100)
+    content, size, resolved = skills._open_regular_file(entry, 100)
     assert content == "line\nnext\n"
     assert size > 0 and resolved == entry.resolve()
     with pytest.raises(ValueError, match="maximum"):
-        skills._open_regular_file(entry, skill, 1)
+        skills._open_regular_file(entry, 1)
     with pytest.raises(ValueError, match="readable regular"):
-        skills._open_regular_file(skill / "missing", skill, 100)
+        skills._open_regular_file(skill / "missing", 100)
 
     if hasattr(os, "symlink"):
         link = skill / "link.md"
@@ -88,8 +103,10 @@ def test_resolved_directories_regular_files_and_roots(tmp_path, monkeypatch):
         except OSError:
             pass
         else:
-            with pytest.raises(ValueError):
-                skills._open_regular_file(link, skill, 100)
+            linked_content, linked_size, linked_resolved = skills._open_regular_file(link, 100)
+            assert linked_content == content
+            assert linked_size == size
+            assert linked_resolved == entry.resolve()
 
 
 def test_related_scan_budgets_symlinks_and_failures(tmp_path, monkeypatch):
@@ -156,14 +173,15 @@ def test_related_scan_budgets_symlinks_and_failures(tmp_path, monkeypatch):
         except OSError:
             pass
         else:
-            _, warnings, _ = skills._scan_related_files(
+            related, warnings, _ = skills._scan_related_files(
                 skill,
                 entry.resolve(),
                 max_related_files=10,
                 max_scan_entries=100,
                 max_path_bytes=1000,
             )
-            assert any("symlinks" in warning for warning in warnings)
+            assert "link" not in related
+            assert not any("symlink" in warning for warning in warnings)
 
     real_scandir = skills.os.scandir
 

--- a/tests/test_skills_edge_complete.py
+++ b/tests/test_skills_edge_complete.py
@@ -68,10 +68,9 @@ def test_descriptions_front_matter_and_warning_cap():
 def test_resolved_directories_regular_files_and_roots(tmp_path, monkeypatch):
     config = tmp_path / "config"
     config.mkdir()
-    with pytest.raises(ValueError, match="inside"):
-        skills._resolved_skills_directory(config, "../outside")
-    with pytest.raises(ValueError, match="inside"):
-        skills._resolved_skills_directory(config, "/absolute")
+    for invalid_directory in ("../outside", "/absolute", r"\absolute", "C:/absolute"):
+        with pytest.raises(ValueError, match="inside"):
+            skills._resolved_skills_directory(config, invalid_directory)
     root, directory = skills._resolved_skills_directory(config, "skills")
     assert root == config.resolve()
     assert directory == config.resolve() / "skills"


### PR DESCRIPTION
## Summary

- discover Agent Skills from project `.agents/skills`, the LSM-managed registry, and global `~/.config/agents/skills`
- resolve duplicate names by project > managed > global priority and expose source metadata
- allow symlinked Skill directories, `SKILL.md`, related files, and related directories
- preserve one shared registry scan budget across all sources and keep the fixed MCP tool surface unchanged
- document direct `skills` CLI installation through the universal agent target

## Validation

- [x] `ruff check .`
- [x] `pytest -q` — 453 passed
- [x] `mkdocs build --strict`
- [x] `bash scripts/run-coverage.sh` — 94.54% total, every module >= 90%
- [x] HTTP, OAuth, TUI, and browser UI smoke tests
- [ ] VS Code extension compile if extension files changed — not applicable

## Safety checklist

- [x] No secrets, tunnel tokens, OAuth pins, private keys, or bearer file-link URLs are committed.
- [x] New or changed MCP tools are documented and tested — the fixed tool list is unchanged; Skill response metadata and lookup behavior are documented and tested.
- [x] Host-control, remote-worker, file-link, or credential behavior is explicitly described — not affected.
- [x] Backwards compatibility impact is noted — the existing managed directory and `skills_dir` field remain; list/load/read responses add source metadata, and symlinks that were previously rejected are now followed intentionally.
