### PR TITLE
Fix stale runtime version and validate release consistency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,12 +62,23 @@ jobs:
           with open("pyproject.toml", "rb") as f:
               version = tomllib.load(f)["project"]["version"]
 
-              release_version = tag[1:] if tag.startswith("v") else tag
-              if release_version != version:
-                  raise SystemExit(
-                      f"Release tag {tag!r} resolves to version {release_version!r}, "
-                      f"but pyproject.toml declares {version!r}"
-                  )
+          init_namespace = {}
+          with open("src/local_shell_mcp/__init__.py", encoding="utf-8") as f:
+              exec(f.read(), init_namespace)
+          package_version = init_namespace["__version__"]
+
+          if package_version != version:
+              raise SystemExit(
+                  f"src/local_shell_mcp/__init__.py declares {package_version!r}, "
+                  f"but pyproject.toml declares {version!r}"
+              )
+
+          release_version = tag[1:] if tag.startswith("v") else tag
+          if release_version != version:
+              raise SystemExit(
+                  f"Release tag {tag!r} resolves to version {release_version!r}, "
+                  f"but pyproject.toml declares {version!r}"
+              )
 
           print(f"version={version}")
           PY

--- a/src/local_shell_mcp/__init__.py
+++ b/src/local_shell_mcp/__init__.py
@@ -1,3 +1,3 @@
 """local-shell-mcp."""
 
-__version__ = "3.0.1"
+__version__ = "3.0.3"

--- a/tests/test_main_complete.py
+++ b/tests/test_main_complete.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
+import local_shell_mcp
 import local_shell_mcp.human_ui as human_ui
 import local_shell_mcp.jobs as jobs
 import local_shell_mcp.main as main_module
@@ -159,9 +160,11 @@ def test_main_subcommands_and_version(monkeypatch, capsys):
     main_module.main(["-V"])
 
     assert calls == [("job", ["a"]), ("worker", ["b"]), ("tui", ["c"])]
-    output = capsys.readouterr().out
-    assert "version-info" in output
-    assert output.count("3.0.1") == 2
+    assert capsys.readouterr().out.splitlines() == [
+        "version-info",
+        local_shell_mcp.__version__,
+        local_shell_mcp.__version__,
+    ]
 
 
 def test_main_modes_config_and_errors(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- preserve the original runtime version fix from #31 by @LeonardNJU
- keep release-time validation that `pyproject.toml`, `local_shell_mcp.__version__`, and the release tag agree
- replace the remaining hard-coded `3.0.1` CLI assertion with an exact comparison against `local_shell_mcp.__version__`

This branch starts from the head commit of #31 and adds one focused test fix. It supersedes #31 because the original branch is in a fork that this repository cannot update directly.

## Validation

- full CI matrix passed
- coverage collection passed
- Linux x86_64/aarch64 and Windows Python matrices passed
- package, standalone binary, Docker, Human UI, OAuth browser E2E, endpoint, lint, docs, and schema checks passed