### PR TITLE
revert: restore PR #31 contribution path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,23 +62,12 @@ jobs:
           with open("pyproject.toml", "rb") as f:
               version = tomllib.load(f)["project"]["version"]
 
-          init_namespace = {}
-          with open("src/local_shell_mcp/__init__.py", encoding="utf-8") as f:
-              exec(f.read(), init_namespace)
-          package_version = init_namespace["__version__"]
-
-          if package_version != version:
-              raise SystemExit(
-                  f"src/local_shell_mcp/__init__.py declares {package_version!r}, "
-                  f"but pyproject.toml declares {version!r}"
-              )
-
-          release_version = tag[1:] if tag.startswith("v") else tag
-          if release_version != version:
-              raise SystemExit(
-                  f"Release tag {tag!r} resolves to version {release_version!r}, "
-                  f"but pyproject.toml declares {version!r}"
-              )
+              release_version = tag[1:] if tag.startswith("v") else tag
+              if release_version != version:
+                  raise SystemExit(
+                      f"Release tag {tag!r} resolves to version {release_version!r}, "
+                      f"but pyproject.toml declares {version!r}"
+                  )
 
           print(f"version={version}")
           PY

--- a/tests/test_main_complete.py
+++ b/tests/test_main_complete.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
+import local_shell_mcp
 import local_shell_mcp.human_ui as human_ui
 import local_shell_mcp.jobs as jobs
 import local_shell_mcp.main as main_module
@@ -159,9 +160,11 @@ def test_main_subcommands_and_version(monkeypatch, capsys):
     main_module.main(["-V"])
 
     assert calls == [("job", ["a"]), ("worker", ["b"]), ("tui", ["c"])]
-    output = capsys.readouterr().out
-    assert "version-info" in output
-    assert output.count("3.0.1") == 2
+    assert capsys.readouterr().out.splitlines() == [
+        "version-info",
+        local_shell_mcp.__version__,
+        local_shell_mcp.__version__,
+    ]
 
 
 def test_main_modes_config_and_errors(tmp_path, monkeypatch):

--- a/tests/test_main_complete.py
+++ b/tests/test_main_complete.py
@@ -4,7 +4,6 @@ from types import SimpleNamespace
 
 import pytest
 
-import local_shell_mcp
 import local_shell_mcp.human_ui as human_ui
 import local_shell_mcp.jobs as jobs
 import local_shell_mcp.main as main_module
@@ -160,11 +159,9 @@ def test_main_subcommands_and_version(monkeypatch, capsys):
     main_module.main(["-V"])
 
     assert calls == [("job", ["a"]), ("worker", ["b"]), ("tui", ["c"])]
-    assert capsys.readouterr().out.splitlines() == [
-        "version-info",
-        local_shell_mcp.__version__,
-        local_shell_mcp.__version__,
-    ]
+    output = capsys.readouterr().out
+    assert "version-info" in output
+    assert output.count("3.0.1") == 2
 
 
 def test_main_modes_config_and_errors(tmp_path, monkeypatch):


### PR DESCRIPTION
## Purpose

Revert the maintainer-owned replacement of the original external contribution so PR #31 can be completed and merged under its contributor.

## Scope

- remove the release workflow consistency check introduced through #33
- keep the subsequently released v3.0.4 package/runtime versions unchanged
- keep the version-agnostic CLI assertion, since restoring the obsolete `3.0.1` assertion would deliberately break CI

After this revert lands, #31 will be reopened. The original contributor will be asked to update the branch against current `main`, preserve v3.0.4, and retain the release consistency validation as the substantive contribution.