### PR TITLE
fix(release): ship standalone UI as one executable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -534,6 +534,7 @@ jobs:
           ./dist/${{ matrix.binary }} --version
           ./dist/${{ matrix.binary }} version
           ./dist/${{ matrix.binary }} --help
+          python scripts/standalone-ui-smoke.py --server ./dist/${{ matrix.binary }}
 
 
   bundled-tmux:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,7 +188,7 @@ jobs:
         shell: bash
         run: scripts/build-tmux-helper.sh "src/local_shell_mcp/helpers/${{ matrix.helper_tag }}/tmux" "${{ matrix.helper_platform }}"
 
-      - name: Build OpenTUI sidecar and embedded WebUI
+      - name: Build OpenTUI runtime and embedded WebUI
         working-directory: ui
         run: |
           bun install --frozen-lockfile
@@ -216,11 +216,12 @@ jobs:
           fi
           pyinstaller "${PYINSTALLER_ARGS[@]}" scripts/pyinstaller-entry.py
 
-      - name: Smoke test executables
+      - name: Smoke test embedded OpenTUI runtime
         shell: bash
         run: |
           ./dist/${{ matrix.binary }} --help
           ./ui/dist/${{ matrix.tui_binary }} --version
+          python scripts/standalone-ui-smoke.py --server ./dist/${{ matrix.binary }}
 
       - name: Package executable
         shell: bash
@@ -228,7 +229,6 @@ jobs:
           set -euo pipefail
           mkdir -p release/local-shell-mcp-${{ matrix.artifact }}
           cp dist/${{ matrix.binary }} release/local-shell-mcp-${{ matrix.artifact }}/
-          cp ui/dist/${{ matrix.tui_binary }} release/local-shell-mcp-${{ matrix.artifact }}/
           cp README.md LICENSE release/local-shell-mcp-${{ matrix.artifact }}/
           cat > release/local-shell-mcp-${{ matrix.artifact }}/QUICKSTART.txt <<'EOF'
           Start local-shell-mcp without Docker:
@@ -239,8 +239,6 @@ jobs:
 
             ./local-shell-mcp tui
 
-          The native TUI sidecar must remain beside the main executable.
-
           Useful environment variables:
 
             LOCAL_SHELL_MCP_HOST=0.0.0.0
@@ -248,7 +246,7 @@ jobs:
             LOCAL_SHELL_MCP_WORKSPACE_ROOT=/path/to/workspace
             LOCAL_SHELL_MCP_AUTH_MODE=oauth
             LOCAL_SHELL_MCP_PUBLIC_BASE_URL=https://your-public-host.example.com
-            Generate and export LOCAL_SHELL_MCP_OAUTH_ADMIN_PIN as at least 12 random characters.
+            Generate and export LOCAL_SHELL_MCP_OAUTH_ADMIN_PIN as at least 8 random characters.
             Generate and export LOCAL_SHELL_MCP_OAUTH_JWT_SECRET as at least 32 random bytes.
           EOF
           cd release
@@ -469,7 +467,7 @@ jobs:
           ./local-shell-mcp --mode mcp
           \`\`\`
 
-          Then open \`http://127.0.0.1:8765/ui\`, or launch the included native TUI sidecar through:
+          Then open \`http://127.0.0.1:8765/ui\`, or launch the embedded native TUI through:
 
           \`\`\`bash
           ./local-shell-mcp tui

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ http://127.0.0.1:8765/ui
 
 The WebUI uses the same OAuth flow as MCP. Its responsive terminal frame supports mouse interaction on the actual OpenTUI top bar, automatic PTY resizing, reconnects, fullscreen mode, and a cached Bing background with an animated fallback.
 
-Standalone release archives and Docker images also include the native OpenTUI sidecar. Start the service, then launch it without a human login prompt:
+Standalone release executables embed the native OpenTUI runtime, while Docker images provide it inside the image. Start the service, then launch it without a human login prompt:
 
 ```bash
 local-shell-mcp tui

--- a/docs/guides/human-interface.md
+++ b/docs/guides/human-interface.md
@@ -141,6 +141,6 @@ Each screen displays its contextual shortcuts in the footer.
 
 - Docker images include the WebUI assets, native OpenTUI runtime, and Yazi, and configure the service to use the bundled runtime directly.
 - Standalone release executables contain the WebUI assets and a compressed platform OpenTUI runtime; neither WebUI nor native TUI requires a neighboring sidecar.
-- Release archives may retain a neighboring TUI executable for compatibility with older launchers, but current executables do not depend on it.
+- Release archives contain one standalone executable; the OpenTUI runtime is compressed inside it and extracted into PyInstaller's temporary runtime directory when needed.
 - Python wheels include the WebUI assets. A native TUI requires a release executable or a source checkout with Bun and the UI dependencies installed.
 - The WebUI is served from the same process and port as MCP; no additional web service is required.

--- a/scripts/check-release-matrix.py
+++ b/scripts/check-release-matrix.py
@@ -22,6 +22,13 @@ def matrix_values(job: dict, key: str) -> set[str]:
     return {str(row[key]) for row in rows if key in row}
 
 
+def step_script(job: dict, name: str) -> str:
+    for step in job.get("steps", []):
+        if step.get("name") == name:
+            return str(step.get("run") or "")
+    return ""
+
+
 def main() -> int:
     workflow = yaml.safe_load(RELEASE.read_text(encoding="utf-8"))
     jobs = workflow.get("jobs", {})
@@ -36,6 +43,19 @@ def main() -> int:
         print(f"extra: {extra_binary}")
         return 1
 
+    package_script = step_script(binary_job, "Package executable")
+    if not package_script:
+        print("Release binary packaging step is missing.")
+        return 1
+    if "matrix.tui_binary" in package_script:
+        print("Release archives must not include the OpenTUI sidecar executable.")
+        return 1
+
+    smoke_script = step_script(binary_job, "Smoke test embedded OpenTUI runtime")
+    if "standalone-ui-smoke.py" not in smoke_script:
+        print("Release binaries must exercise the embedded OpenTUI runtime before packaging.")
+        return 1
+
     docker_job = jobs.get("publish-docker-platform", {})
     docker_platforms = matrix_values(docker_job, "platform")
     missing_docker = sorted(EXPECTED_DOCKER_PLATFORMS - docker_platforms)
@@ -46,7 +66,9 @@ def main() -> int:
         print(f"extra: {extra_docker}")
         return 1
 
-    print("Release build matrices cover all expected binary artifacts and Docker platforms.")
+    print(
+        "Release build matrices and single-executable packaging checks passed for all expected platforms."
+    )
     return 0
 
 


### PR DESCRIPTION
## Summary
- stop adding `local-shell-mcp-tui` to standalone release archives
- verify the embedded OpenTUI runtime through the real WebUI PTY path in CI and release builds
- guard the release workflow against reintroducing a sidecar executable
- update release notes and documentation for the single-executable layout

## Verification
- `python scripts/check-release-matrix.py`
- `python -m ruff check scripts/check-release-matrix.py scripts/standalone-ui-smoke.py`
- rebuilt the Linux PyInstaller executable with an embedded OpenTUI payload
- removed any neighboring `local-shell-mcp-tui` and passed `scripts/standalone-ui-smoke.py`
- created and inspected a test archive containing only `local-shell-mcp`, README, and LICENSE

## Existing unrelated local test failures
`tests/test_human_ui.py` currently has two failures on `main`: image preview classification and audit operation filtering. This change does not touch those paths.
