### PR TITLE
fix(oauth): reuse matching public client registrations

### DIFF
--- a/src/local_shell_mcp/oauth.py
+++ b/src/local_shell_mcp/oauth.py
@@ -208,6 +208,46 @@ def _prune_clients_locked(now: int, *, reserve_slot: bool = False) -> None:
         _CLIENTS.pop(oldest.client_id, None)
 
 
+def _registration_key(
+    client_name: str | None,
+    redirect_uris: list[str],
+) -> tuple[str | None, tuple[str, ...]]:
+    """Return the stable identity used for idempotent public-client registration."""
+
+    return client_name, tuple(sorted(set(redirect_uris)))
+
+
+def _matching_registered_client_locked(
+    client_name: str | None,
+    redirect_uris: list[str],
+) -> OAuthClient | None:
+    requested = _registration_key(client_name, redirect_uris)
+    matches = [
+        client
+        for client in _CLIENTS.values()
+        if _registration_key(client.client_name, client.redirect_uris) == requested
+    ]
+    if not matches:
+        return None
+    return min(matches, key=lambda client: (not client.approved, client.created_at, client.client_id))
+
+
+def _registration_response(client: OAuthClient, *, reused: bool) -> JSONResponse:
+    return _json(
+        {
+            "client_id": client.client_id,
+            "client_id_issued_at": client.created_at,
+            "client_name": client.client_name or "ChatGPT",
+            "redirect_uris": client.redirect_uris,
+            "grant_types": ["authorization_code"],
+            "response_types": ["code"],
+            "token_endpoint_auth_method": "none",
+            "reused": reused,
+        },
+        status_code=200 if reused else 201,
+    )
+
+
 def _approve_client(client_id: str) -> OAuthClient | None:
     with _CLIENT_STORE_LOCK:
         _load_clients_locked()
@@ -350,15 +390,19 @@ async def oauth_register(request: Request) -> JSONResponse:
             {"error": "invalid_client_metadata", "error_description": "client_name is too long"},
             status_code=400,
         )
-    client_id = "local-shell-mcp-" + secrets.token_urlsafe(24)
-    client = OAuthClient(
-        client_id=client_id,
-        redirect_uris=redirect_uris,
-        client_name=client_name,
-    )
     with _CLIENT_STORE_LOCK:
         _load_clients_locked()
-        _prune_clients_locked(int(time.time()), reserve_slot=True)
+        now = int(time.time())
+        _prune_clients_locked(now)
+        existing = _matching_registered_client_locked(client_name, redirect_uris)
+        if existing is not None:
+            audit(
+                "oauth_client_reused",
+                client_id=existing.client_id,
+                redirect_uris=existing.redirect_uris,
+            )
+            return _registration_response(existing, reused=True)
+        _prune_clients_locked(now, reserve_slot=True)
         if len(_CLIENTS) >= MAX_OAUTH_CLIENTS:
             return _json(
                 {
@@ -367,20 +411,15 @@ async def oauth_register(request: Request) -> JSONResponse:
                 },
                 status_code=503,
             )
+        client_id = "local-shell-mcp-" + secrets.token_urlsafe(24)
+        client = OAuthClient(
+            client_id=client_id,
+            redirect_uris=redirect_uris,
+            client_name=client_name,
+        )
         _CLIENTS[client_id] = client
     audit("oauth_client_registered", client_id=client_id, redirect_uris=redirect_uris)
-    return _json(
-        {
-            "client_id": client_id,
-            "client_id_issued_at": client.created_at,
-            "client_name": client.client_name or "ChatGPT",
-            "redirect_uris": redirect_uris,
-            "grant_types": ["authorization_code"],
-            "response_types": ["code"],
-            "token_endpoint_auth_method": "none",
-        },
-        status_code=201,
-    )
+    return _registration_response(client, reused=False)
 
 
 def _validate_authorize_params(params: dict[str, str]) -> str | None:

--- a/tests/test_oauth_complete.py
+++ b/tests/test_oauth_complete.py
@@ -117,6 +117,78 @@ def test_registration_rejects_every_invalid_shape(tmp_path, monkeypatch):
     ).status_code == 503
 
 
+def test_registration_reuses_matching_public_client_without_consuming_capacity(
+    tmp_path, monkeypatch
+):
+    _configure(tmp_path, monkeypatch)
+    client = TestClient(_app())
+    body = {
+        "client_name": "local-shell-mcp WebUI",
+        "redirect_uris": [
+            "https://client.test/second",
+            "https://client.test/first",
+        ],
+    }
+
+    first = client.post("/oauth/register", json=body)
+    repeated = client.post(
+        "/oauth/register",
+        json={**body, "redirect_uris": list(reversed(body["redirect_uris"]))},
+    )
+
+    assert first.status_code == 201
+    assert first.json()["reused"] is False
+    assert repeated.status_code == 200
+    assert repeated.json()["reused"] is True
+    assert repeated.json()["client_id"] == first.json()["client_id"]
+    assert len(oauth._CLIENTS) == 1
+
+    monkeypatch.setattr(oauth, "MAX_OAUTH_CLIENTS", 1)
+    at_capacity = client.post("/oauth/register", json=body)
+    assert at_capacity.status_code == 200
+    assert at_capacity.json()["client_id"] == first.json()["client_id"]
+    assert len(oauth._CLIENTS) == 1
+
+
+def test_registration_reuses_approved_client_after_memory_reload(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    client = TestClient(_app())
+    redirect = "https://client.test/ui-callback"
+    body = {
+        "client_name": "local-shell-mcp WebUI",
+        "redirect_uris": [redirect],
+    }
+    registered = client.post("/oauth/register", json=body)
+    client_id = registered.json()["client_id"]
+    approved = client.post(
+        "/oauth/authorize",
+        data={
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": redirect,
+            "code_challenge": "challenge",
+            "code_challenge_method": "S256",
+            "pin": "correct-admin-pin",
+        },
+        follow_redirects=False,
+    )
+    assert approved.status_code == 302
+
+    oauth._CLIENTS.clear()
+    repeated = client.post("/oauth/register", json=body)
+
+    assert repeated.status_code == 200
+    assert repeated.json()["client_id"] == client_id
+    assert repeated.json()["reused"] is True
+
+    monkeypatch.setattr(oauth, "MAX_OAUTH_CLIENTS", 1)
+    distinct = client.post(
+        "/oauth/register",
+        json={**body, "client_name": "different client"},
+    )
+    assert distinct.status_code == 503
+
+
 def test_registered_clients_survive_memory_reset_after_approval(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
     client = TestClient(_app())


### PR DESCRIPTION
## Summary
- make dynamic public-client registration idempotent for identical client names and redirect URI sets
- return the existing approved or pending `client_id` before reserving another registry slot
- keep distinct approved clients protected by the existing registry capacity limit
- add regression coverage for repeated WebUI registration, full capacity, and server memory reload

## Validation
- `PYTHONPATH=src pytest -q` — 457 passed
- `ruff check src tests`
- secret scan: no findings
