### PR TITLE
fix(audit): preserve complete call inputs and outputs

### DIFF
--- a/src/local_shell_mcp/audit.py
+++ b/src/local_shell_mcp/audit.py
@@ -22,6 +22,7 @@ _AUDIT_LOCK = threading.Lock()
 _AUDIT_PREVIEW_STRING_CHARS = 2_000
 _AUDIT_PREVIEW_ITEMS = 100
 _AUDIT_INLINE_VALUE_BYTES = 16 * 1024
+_AUDIT_PAYLOAD_PRUNE_GRACE_S = 300
 _AUDIT_PAYLOAD_DIRECTORY = "audit-payloads"
 _AUDIT_PAYLOAD_MARKER = "$local_shell_mcp_audit_payload"
 _AUDIT_PAYLOAD_VERSION = 1
@@ -121,7 +122,9 @@ def _serialize_audit_value(value: Any) -> Any:
         separators=(",", ":"),
         default=str,
     ).encode("utf-8")
-    if len(encoded) <= _AUDIT_INLINE_VALUE_BYTES:
+    retention_budget = max(1, get_settings().max_audit_log_bytes)
+    inline_limit = min(_AUDIT_INLINE_VALUE_BYTES, max(128, retention_budget // 2))
+    if len(encoded) <= inline_limit:
         return serialized
     return _write_payload(serialized)
 
@@ -195,11 +198,17 @@ def _prune_payload_store(log_path: Path) -> None:
     for line in lines:
         with contextlib.suppress(json.JSONDecodeError):
             _collect_payload_ids(json.loads(line), referenced)
+    prune_before = time.time() - _AUDIT_PAYLOAD_PRUNE_GRACE_S
     for payload in directory.glob("*.json.gz"):
         digest = payload.name.removesuffix(".json.gz")
-        if digest not in referenced:
-            with contextlib.suppress(OSError):
-                payload.unlink()
+        if digest in referenced:
+            continue
+        try:
+            if payload.stat().st_mtime > prune_before:
+                continue
+            payload.unlink()
+        except OSError:
+            continue
 
 
 def _payload_file_size(digest: str, log_path: Path | None = None) -> int:
@@ -698,8 +707,8 @@ def query_audit(
     }
 
 
-def get_audit_entry(entry_id: str) -> dict[str, Any]:
-    """Return one coalesced audit entry with complete external payloads materialized."""
+def get_audit_entry(entry_id: str, *, full: bool = True) -> dict[str, Any]:
+    """Return one coalesced audit entry, optionally materializing external payloads."""
 
     normalized = str(entry_id).strip()
     if not normalized:
@@ -713,6 +722,8 @@ def get_audit_entry(entry_id: str) -> dict[str, Any]:
     )
     if selected is None:
         raise ValueError(f"Unknown audit entry: {normalized}")
+    if not full:
+        return _public_audit_entry(selected)
 
     materialized_records = list(preview_records)
     for index in selected[_AUDIT_SOURCE_INDEXES]:

--- a/src/local_shell_mcp/audit.py
+++ b/src/local_shell_mcp/audit.py
@@ -23,7 +23,9 @@ _AUDIT_PREVIEW_STRING_CHARS = 2_000
 _AUDIT_PREVIEW_ITEMS = 100
 _AUDIT_INLINE_VALUE_BYTES = 16 * 1024
 _AUDIT_PAYLOAD_DIRECTORY = "audit-payloads"
-_AUDIT_PAYLOAD_MARKER = "$audit_payload"
+_AUDIT_PAYLOAD_MARKER = "$local_shell_mcp_audit_payload"
+_AUDIT_PAYLOAD_VERSION = 1
+_AUDIT_SOURCE_INDEXES = "_audit_source_indexes"
 
 
 def _format_audit_text(value: str) -> str:
@@ -53,10 +55,7 @@ def _preview_audit_value(value: Any) -> Any:
             for name, item in list(value.items())[:_AUDIT_PREVIEW_ITEMS]
         }
     if isinstance(value, (list, tuple)):
-        return [
-            _preview_audit_value(item)
-            for item in list(value)[:_AUDIT_PREVIEW_ITEMS]
-        ]
+        return [_preview_audit_value(item) for item in list(value)[:_AUDIT_PREVIEW_ITEMS]]
     if isinstance(value, (int, float, bool)) or value is None:
         return value
     return _format_audit_text(repr(value))
@@ -72,6 +71,13 @@ def _payload_path(digest: str) -> Path:
     return _payload_directory() / f"{digest}.json.gz"
 
 
+def _write_private_bytes(path: Path, data: bytes) -> None:
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(descriptor, "wb") as handle:
+        handle.write(data)
+        handle.flush()
+
+
 def _write_payload(value: Any) -> dict[str, Any]:
     raw = json.dumps(
         value,
@@ -82,20 +88,22 @@ def _write_payload(value: Any) -> dict[str, Any]:
     digest = hashlib.sha256(raw).hexdigest()
     path = _payload_path(digest)
     if not path.exists():
-        temporary = path.with_name(
-            f".{path.name}.{os.getpid()}.{threading.get_ident()}.tmp"
-        )
+        temporary = path.with_name(f".{path.name}.{os.getpid()}.{threading.get_ident()}.tmp")
         try:
-            temporary.write_bytes(gzip.compress(raw, compresslevel=6, mtime=0))
-            with contextlib.suppress(OSError):
-                temporary.chmod(0o600)
+            _write_private_bytes(
+                temporary,
+                gzip.compress(raw, compresslevel=6, mtime=0),
+            )
             os.replace(temporary, path)
         finally:
             with contextlib.suppress(OSError):
                 temporary.unlink(missing_ok=True)
     return {
-        _AUDIT_PAYLOAD_MARKER: digest,
-        "bytes": len(raw),
+        _AUDIT_PAYLOAD_MARKER: {
+            "version": _AUDIT_PAYLOAD_VERSION,
+            "sha256": digest,
+            "bytes": len(raw),
+        },
         "preview": _preview_audit_value(value),
     }
 
@@ -116,46 +124,58 @@ def _serialize_audit_value(value: Any) -> Any:
 def _is_payload_reference(value: Any) -> bool:
     if not isinstance(value, dict):
         return False
-    digest = value.get(_AUDIT_PAYLOAD_MARKER)
+    if set(value) != {_AUDIT_PAYLOAD_MARKER, "preview"}:
+        return False
+    metadata = value.get(_AUDIT_PAYLOAD_MARKER)
+    if not isinstance(metadata, dict):
+        return False
+    if set(metadata) != {"version", "sha256", "bytes"}:
+        return False
+    digest = metadata.get("sha256")
     return (
-        isinstance(digest, str)
+        metadata.get("version") == _AUDIT_PAYLOAD_VERSION
+        and isinstance(metadata.get("bytes"), int)
+        and metadata["bytes"] >= 0
+        and isinstance(digest, str)
         and len(digest) == 64
         and all(character in "0123456789abcdef" for character in digest)
     )
 
 
+def _payload_digest(value: dict[str, Any]) -> str:
+    metadata = value[_AUDIT_PAYLOAD_MARKER]
+    assert isinstance(metadata, dict)
+    return str(metadata["sha256"])
+
+
 def _resolve_payload_reference(value: Any, *, full: bool) -> Any:
-    if _is_payload_reference(value):
-        if not full:
-            return _resolve_payload_reference(value.get("preview"), full=False)
-        digest = str(value[_AUDIT_PAYLOAD_MARKER])
-        try:
-            raw = gzip.decompress(_payload_path(digest).read_bytes())
-            return json.loads(raw)
-        except (OSError, EOFError, gzip.BadGzipFile, json.JSONDecodeError, zlib.error) as exc:
-            return {
-                "error": "Audit payload is unavailable",
-                "payload_id": digest,
-                "detail": str(exc),
-                "preview": _resolve_payload_reference(value.get("preview"), full=False),
-            }
-    if isinstance(value, dict):
-        return {name: _resolve_payload_reference(item, full=full) for name, item in value.items()}
-    if isinstance(value, list):
-        return [_resolve_payload_reference(item, full=full) for item in value]
-    return value
+    if not _is_payload_reference(value):
+        return value
+    if not full:
+        return value.get("preview")
+    digest = _payload_digest(value)
+    try:
+        raw = gzip.decompress(_payload_path(digest).read_bytes())
+        return json.loads(raw)
+    except (OSError, EOFError, gzip.BadGzipFile, json.JSONDecodeError, zlib.error) as exc:
+        return {
+            "error": "Audit payload is unavailable",
+            "payload_id": digest,
+            "detail": str(exc),
+            "preview": value.get("preview"),
+        }
 
 
-def _collect_payload_ids(value: Any, destination: set[str]) -> None:
-    if _is_payload_reference(value):
-        destination.add(str(value[_AUDIT_PAYLOAD_MARKER]))
+def _resolve_record_payloads(record: dict[str, Any], *, full: bool) -> dict[str, Any]:
+    return {name: _resolve_payload_reference(value, full=full) for name, value in record.items()}
+
+
+def _collect_payload_ids(record: Any, destination: set[str]) -> None:
+    if not isinstance(record, dict):
         return
-    if isinstance(value, dict):
-        for item in value.values():
-            _collect_payload_ids(item, destination)
-    elif isinstance(value, list):
-        for item in value:
-            _collect_payload_ids(item, destination)
+    for value in record.values():
+        if _is_payload_reference(value):
+            destination.add(_payload_digest(value))
 
 
 def _prune_payload_store(log_path: Path) -> None:
@@ -163,15 +183,106 @@ def _prune_payload_store(log_path: Path) -> None:
     if not directory.is_dir():
         return
     referenced: set[str] = set()
-    with contextlib.suppress(OSError):
-        for line in log_path.read_text(encoding="utf-8", errors="ignore").splitlines():
-            with contextlib.suppress(json.JSONDecodeError):
-                _collect_payload_ids(json.loads(line), referenced)
+    try:
+        lines = log_path.read_text(encoding="utf-8", errors="ignore").splitlines()
+    except OSError:
+        return
+    for line in lines:
+        with contextlib.suppress(json.JSONDecodeError):
+            _collect_payload_ids(json.loads(line), referenced)
     for payload in directory.glob("*.json.gz"):
         digest = payload.name.removesuffix(".json.gz")
         if digest not in referenced:
             with contextlib.suppress(OSError):
                 payload.unlink()
+
+
+def _payload_file_size(digest: str) -> int:
+    try:
+        return _payload_path(digest).stat().st_size
+    except OSError:
+        return 0
+
+
+def _encode_audit_record(record: dict[str, Any]) -> bytes:
+    return (json.dumps(record, ensure_ascii=False, default=str) + "\n").encode("utf-8")
+
+
+def _bounded_preview_record(record: dict[str, Any], max_bytes: int) -> bytes:
+    preview = _resolve_record_payloads(record, full=False)
+    encoded = _encode_audit_record(preview)
+    if len(encoded) <= max_bytes:
+        return encoded
+    essential = {
+        name: preview[name]
+        for name in ("id", "ts", "event", "tool", "call_id", "ok", "error", "error_type")
+        if name in preview
+    }
+    essential["audit_payloads_omitted"] = "record exceeded audit retention limit"
+    encoded = _encode_audit_record(essential)
+    return encoded if len(encoded) <= max_bytes else b""
+
+
+def _enforce_audit_storage_limit(log_path: Path, max_bytes: int) -> None:
+    if max_bytes <= 0 or not log_path.exists():
+        return
+    try:
+        raw_lines = log_path.read_bytes().splitlines(keepends=True)
+    except OSError:
+        return
+
+    parsed: list[tuple[bytes, dict[str, Any] | None, set[str]]] = []
+    all_referenced: set[str] = set()
+    for raw_line in raw_lines:
+        record: dict[str, Any] | None = None
+        payload_ids: set[str] = set()
+        try:
+            loaded = json.loads(raw_line)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            loaded = None
+        if isinstance(loaded, dict):
+            record = loaded
+            _collect_payload_ids(record, payload_ids)
+            all_referenced.update(payload_ids)
+        parsed.append((raw_line, record, payload_ids))
+
+    payload_sizes = {digest: _payload_file_size(digest) for digest in all_referenced}
+    total_bytes = sum(len(raw_line) for raw_line in raw_lines) + sum(payload_sizes.values())
+    if total_bytes <= max_bytes:
+        _prune_payload_store(log_path)
+        return
+
+    target_bytes = max(1, max_bytes // 2)
+    selected: list[bytes] = []
+    selected_payloads: set[str] = set()
+    selected_bytes = 0
+    for raw_line, record, payload_ids in reversed(parsed):
+        new_payloads = payload_ids - selected_payloads
+        added_bytes = len(raw_line) + sum(payload_sizes.get(item, 0) for item in new_payloads)
+        if selected and selected_bytes + added_bytes > target_bytes:
+            break
+        if not selected and added_bytes > max_bytes:
+            if record is None:
+                continue
+            raw_line = _bounded_preview_record(record, max_bytes)
+            if not raw_line:
+                continue
+            payload_ids = set()
+            new_payloads = set()
+            added_bytes = len(raw_line)
+        selected.append(raw_line)
+        selected_payloads.update(payload_ids)
+        selected_bytes += added_bytes
+
+    selected.reverse()
+    temporary = log_path.with_name(f".{log_path.name}.{os.getpid()}.{threading.get_ident()}.tmp")
+    try:
+        _write_private_bytes(temporary, b"".join(selected))
+        os.replace(temporary, log_path)
+    finally:
+        with contextlib.suppress(OSError):
+            temporary.unlink(missing_ok=True)
+    _prune_payload_store(log_path)
 
 
 def _trim_audit_log(path: Path, max_bytes: int) -> bool:
@@ -190,9 +301,7 @@ def _trim_audit_log(path: Path, max_bytes: int) -> bool:
         data = data[first_newline + 1 :]
     tmp = path.with_name(f".{path.name}.{os.getpid()}.{threading.get_ident()}.tmp")
     try:
-        tmp.write_bytes(data)
-        with contextlib.suppress(OSError):
-            tmp.chmod(0o600)
+        _write_private_bytes(tmp, data)
         tmp.replace(path)
     finally:
         with contextlib.suppress(OSError):
@@ -218,7 +327,6 @@ def audit(event: str, **fields: Any) -> None:
     path: Path = settings.audit_log_path
     with _AUDIT_LOCK:
         path.parent.mkdir(parents=True, exist_ok=True)
-        trimmed = _trim_audit_log(path, settings.max_audit_log_bytes)
         record = {
             "id": uuid.uuid4().hex,
             "ts": time.time(),
@@ -232,8 +340,7 @@ def audit(event: str, **fields: Any) -> None:
             f.flush()
         with contextlib.suppress(OSError):
             path.chmod(0o600)
-        if trimmed:
-            _prune_payload_store(path)
+        _enforce_audit_storage_limit(path, settings.max_audit_log_bytes)
 
 
 _TOOL_OPERATION_GROUPS: dict[str, frozenset[str]] = {
@@ -293,9 +400,7 @@ _TOOL_OPERATION_GROUPS: dict[str, frozenset[str]] = {
     ),
 }
 _TOOL_OPERATION_BY_NAME = {
-    tool: operation
-    for operation, tools in _TOOL_OPERATION_GROUPS.items()
-    for tool in tools
+    tool: operation for operation, tools in _TOOL_OPERATION_GROUPS.items() for tool in tools
 }
 
 
@@ -420,6 +525,7 @@ def _coalesce_audit_records(records: list[dict[str, Any]]) -> list[dict[str, Any
             continue
         if event == "mcp_tool_call_start":
             entry = _new_call_entry(record, index)
+            entry[_AUDIT_SOURCE_INDEXES] = [index]
             rows.append(entry)
             call_id = str(record.get("call_id") or "")
             if call_id:
@@ -435,9 +541,12 @@ def _coalesce_audit_records(records: list[dict[str, Any]]) -> list[dict[str, Any
                 if pending:
                     entry = pending.pop(0)
             if entry is None:
-                rows.append(_unpaired_end_entry(record, index))
+                unpaired = _unpaired_end_entry(record, index)
+                unpaired[_AUDIT_SOURCE_INDEXES] = [index]
+                rows.append(unpaired)
             else:
                 _finish_call_entry(entry, record)
+                entry[_AUDIT_SOURCE_INDEXES].append(index)
             continue
 
         rows.append(
@@ -446,13 +555,18 @@ def _coalesce_audit_records(records: list[dict[str, Any]]) -> list[dict[str, Any
                 "id": str(record.get("id") or f"record:{record.get('ts', 0)}:{index}"),
                 "node": _record_node(record),
                 "operation": _operation_type(record),
+                _AUDIT_SOURCE_INDEXES: [index],
             }
         )
 
     return rows
 
 
-def _read_audit_records(*, full_payloads: bool) -> list[dict[str, Any]]:
+def _public_audit_entry(row: dict[str, Any]) -> dict[str, Any]:
+    return {name: value for name, value in row.items() if name != _AUDIT_SOURCE_INDEXES}
+
+
+def _read_audit_records() -> list[dict[str, Any]]:
     settings = get_settings()
     path = settings.audit_log_path
     if not path.exists():
@@ -473,7 +587,7 @@ def _read_audit_records(*, full_payloads: bool) -> list[dict[str, Any]]:
         except (json.JSONDecodeError, UnicodeDecodeError):
             continue
         if isinstance(record, dict):
-            records.append(_resolve_payload_reference(record, full=full_payloads))
+            records.append(record)
     return records
 
 
@@ -492,11 +606,12 @@ def query_audit(
     """Read, pair, filter, and sort the bounded JSONL audit log for the human UI."""
 
     bounded_limit = max(1, min(int(limit), 2_000))
-    records = _read_audit_records(full_payloads=False)
+    records = _read_audit_records()
     if not records:
         return {"entries": [], "count": 0, "total_matched": 0}
 
-    rows = _coalesce_audit_records(records)
+    preview_records = [_resolve_record_payloads(record, full=False) for record in records]
+    rows = _coalesce_audit_records(preview_records)
     needle = (search or "").casefold().strip()
     node_filter = (node or "").casefold().strip()
     event_filter = (event or "").casefold().strip()
@@ -529,10 +644,11 @@ def query_audit(
     matched.sort(key=lambda item: float(item.get("ts") or 0), reverse=reverse)
     total = len(matched)
     return {
-        "entries": matched[:bounded_limit],
+        "entries": [_public_audit_entry(row) for row in matched[:bounded_limit]],
         "count": min(total, bounded_limit),
         "total_matched": total,
     }
+
 
 def get_audit_entry(entry_id: str) -> dict[str, Any]:
     """Return one coalesced audit entry with complete external payloads materialized."""
@@ -540,8 +656,21 @@ def get_audit_entry(entry_id: str) -> dict[str, Any]:
     normalized = str(entry_id).strip()
     if not normalized:
         raise ValueError("audit entry id is required")
-    rows = _coalesce_audit_records(_read_audit_records(full_payloads=True))
-    for row in rows:
+    records = _read_audit_records()
+    preview_records = [_resolve_record_payloads(record, full=False) for record in records]
+    preview_rows = _coalesce_audit_records(preview_records)
+    selected = next(
+        (row for row in preview_rows if str(row.get("id") or "") == normalized),
+        None,
+    )
+    if selected is None:
+        raise ValueError(f"Unknown audit entry: {normalized}")
+
+    materialized_records = list(preview_records)
+    for index in selected[_AUDIT_SOURCE_INDEXES]:
+        materialized_records[index] = _resolve_record_payloads(records[index], full=True)
+
+    for row in _coalesce_audit_records(materialized_records):
         if str(row.get("id") or "") == normalized:
-            return row
+            return _public_audit_entry(row)
     raise ValueError(f"Unknown audit entry: {normalized}")

--- a/src/local_shell_mcp/audit.py
+++ b/src/local_shell_mcp/audit.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import contextlib
+import gzip
+import hashlib
 import json
 import os
 import threading
 import time
+import uuid
+import zlib
 from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -15,36 +19,167 @@ from .settings import get_settings
 
 _AUDIT_ENABLED: ContextVar[bool] = ContextVar("local_shell_mcp_audit_enabled", default=True)
 _AUDIT_LOCK = threading.Lock()
-_AUDIT_MAX_STRING = 2_000
+_AUDIT_PREVIEW_STRING_CHARS = 2_000
+_AUDIT_PREVIEW_ITEMS = 100
+_AUDIT_INLINE_VALUE_BYTES = 16 * 1024
+_AUDIT_PAYLOAD_DIRECTORY = "audit-payloads"
+_AUDIT_PAYLOAD_MARKER = "$audit_payload"
 
 
 def _format_audit_text(value: str) -> str:
-    if len(value) > _AUDIT_MAX_STRING:
-        return value[:_AUDIT_MAX_STRING] + "…<truncated>"
+    if len(value) > _AUDIT_PREVIEW_STRING_CHARS:
+        return value[:_AUDIT_PREVIEW_STRING_CHARS] + "…<preview>"
     return value
 
 
-def _serialize_audit_value(value: Any) -> Any:
+def _jsonable_audit_value(value: Any) -> Any:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        return {str(name): _jsonable_audit_value(item) for name, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable_audit_value(item) for item in value]
+    if isinstance(value, (int, float, bool)) or value is None:
+        return value
+    return repr(value)
+
+
+def _preview_audit_value(value: Any) -> Any:
     if isinstance(value, str):
         return _format_audit_text(value)
     if isinstance(value, dict):
         return {
-            str(name): _serialize_audit_value(item)
-            for name, item in list(value.items())[:100]
+            str(name): _preview_audit_value(item)
+            for name, item in list(value.items())[:_AUDIT_PREVIEW_ITEMS]
         }
     if isinstance(value, (list, tuple)):
-        return [_serialize_audit_value(item) for item in list(value)[:100]]
+        return [
+            _preview_audit_value(item)
+            for item in list(value)[:_AUDIT_PREVIEW_ITEMS]
+        ]
     if isinstance(value, (int, float, bool)) or value is None:
         return value
     return _format_audit_text(repr(value))
 
 
-def _trim_audit_log(path: Path, max_bytes: int) -> None:
-    if max_bytes <= 0 or not path.exists():
+def _payload_directory() -> Path:
+    directory = get_settings().state_dir / _AUDIT_PAYLOAD_DIRECTORY
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+
+def _payload_path(digest: str) -> Path:
+    return _payload_directory() / f"{digest}.json.gz"
+
+
+def _write_payload(value: Any) -> dict[str, Any]:
+    raw = json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    digest = hashlib.sha256(raw).hexdigest()
+    path = _payload_path(digest)
+    if not path.exists():
+        temporary = path.with_name(
+            f".{path.name}.{os.getpid()}.{threading.get_ident()}.tmp"
+        )
+        try:
+            temporary.write_bytes(gzip.compress(raw, compresslevel=6, mtime=0))
+            with contextlib.suppress(OSError):
+                temporary.chmod(0o600)
+            os.replace(temporary, path)
+        finally:
+            with contextlib.suppress(OSError):
+                temporary.unlink(missing_ok=True)
+    return {
+        _AUDIT_PAYLOAD_MARKER: digest,
+        "bytes": len(raw),
+        "preview": _preview_audit_value(value),
+    }
+
+
+def _serialize_audit_value(value: Any) -> Any:
+    serialized = _jsonable_audit_value(value)
+    encoded = json.dumps(
+        serialized,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    if len(encoded) <= _AUDIT_INLINE_VALUE_BYTES:
+        return serialized
+    return _write_payload(serialized)
+
+
+def _is_payload_reference(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    digest = value.get(_AUDIT_PAYLOAD_MARKER)
+    return (
+        isinstance(digest, str)
+        and len(digest) == 64
+        and all(character in "0123456789abcdef" for character in digest)
+    )
+
+
+def _resolve_payload_reference(value: Any, *, full: bool) -> Any:
+    if _is_payload_reference(value):
+        if not full:
+            return _resolve_payload_reference(value.get("preview"), full=False)
+        digest = str(value[_AUDIT_PAYLOAD_MARKER])
+        try:
+            raw = gzip.decompress(_payload_path(digest).read_bytes())
+            return json.loads(raw)
+        except (OSError, EOFError, gzip.BadGzipFile, json.JSONDecodeError, zlib.error) as exc:
+            return {
+                "error": "Audit payload is unavailable",
+                "payload_id": digest,
+                "detail": str(exc),
+                "preview": _resolve_payload_reference(value.get("preview"), full=False),
+            }
+    if isinstance(value, dict):
+        return {name: _resolve_payload_reference(item, full=full) for name, item in value.items()}
+    if isinstance(value, list):
+        return [_resolve_payload_reference(item, full=full) for item in value]
+    return value
+
+
+def _collect_payload_ids(value: Any, destination: set[str]) -> None:
+    if _is_payload_reference(value):
+        destination.add(str(value[_AUDIT_PAYLOAD_MARKER]))
         return
+    if isinstance(value, dict):
+        for item in value.values():
+            _collect_payload_ids(item, destination)
+    elif isinstance(value, list):
+        for item in value:
+            _collect_payload_ids(item, destination)
+
+
+def _prune_payload_store(log_path: Path) -> None:
+    directory = get_settings().state_dir / _AUDIT_PAYLOAD_DIRECTORY
+    if not directory.is_dir():
+        return
+    referenced: set[str] = set()
+    with contextlib.suppress(OSError):
+        for line in log_path.read_text(encoding="utf-8", errors="ignore").splitlines():
+            with contextlib.suppress(json.JSONDecodeError):
+                _collect_payload_ids(json.loads(line), referenced)
+    for payload in directory.glob("*.json.gz"):
+        digest = payload.name.removesuffix(".json.gz")
+        if digest not in referenced:
+            with contextlib.suppress(OSError):
+                payload.unlink()
+
+
+def _trim_audit_log(path: Path, max_bytes: int) -> bool:
+    if max_bytes <= 0 or not path.exists():
+        return False
     size = path.stat().st_size
     if size <= max_bytes:
-        return
+        return False
 
     keep_bytes = max(1, max_bytes // 2)
     with path.open("rb") as f:
@@ -62,6 +197,7 @@ def _trim_audit_log(path: Path, max_bytes: int) -> None:
     finally:
         with contextlib.suppress(OSError):
             tmp.unlink(missing_ok=True)
+    return True
 
 
 @contextmanager
@@ -79,22 +215,25 @@ def audit(event: str, **fields: Any) -> None:
     if not _AUDIT_ENABLED.get():
         return
     settings = get_settings()
-    record = {
-        "ts": time.time(),
-        "event": _format_audit_text(event),
-        **{name: _serialize_audit_value(value) for name, value in fields.items()},
-    }
     path: Path = settings.audit_log_path
-    encoded = json.dumps(record, ensure_ascii=False, default=str) + "\n"
     with _AUDIT_LOCK:
         path.parent.mkdir(parents=True, exist_ok=True)
-        _trim_audit_log(path, settings.max_audit_log_bytes)
+        trimmed = _trim_audit_log(path, settings.max_audit_log_bytes)
+        record = {
+            "id": uuid.uuid4().hex,
+            "ts": time.time(),
+            "event": event,
+            **{name: _serialize_audit_value(value) for name, value in fields.items()},
+        }
+        encoded = json.dumps(record, ensure_ascii=False, default=str) + "\n"
         descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
         with os.fdopen(descriptor, "a", encoding="utf-8") as f:
             f.write(encoded)
             f.flush()
         with contextlib.suppress(OSError):
             path.chmod(0o600)
+        if trimmed:
+            _prune_payload_store(path)
 
 
 _TOOL_OPERATION_GROUPS: dict[str, frozenset[str]] = {
@@ -313,25 +452,11 @@ def _coalesce_audit_records(records: list[dict[str, Any]]) -> list[dict[str, Any
     return rows
 
 
-def query_audit(
-    *,
-    limit: int = 200,
-    node: str | None = None,
-    event: str | None = None,
-    operation: str | None = None,
-    session: str | None = None,
-    search: str | None = None,
-    start_ts: float | None = None,
-    end_ts: float | None = None,
-    sort: str = "desc",
-) -> dict[str, Any]:
-    """Read, pair, filter, and sort the bounded JSONL audit log for the human UI."""
-
+def _read_audit_records(*, full_payloads: bool) -> list[dict[str, Any]]:
     settings = get_settings()
     path = settings.audit_log_path
-    bounded_limit = max(1, min(int(limit), 2_000))
     if not path.exists():
-        return {"entries": [], "count": 0, "total_matched": 0}
+        return []
 
     max_bytes = max(1, min(settings.max_audit_tail_bytes * 4, settings.max_audit_log_bytes))
     size = path.stat().st_size
@@ -348,7 +473,28 @@ def query_audit(
         except (json.JSONDecodeError, UnicodeDecodeError):
             continue
         if isinstance(record, dict):
-            records.append(record)
+            records.append(_resolve_payload_reference(record, full=full_payloads))
+    return records
+
+
+def query_audit(
+    *,
+    limit: int = 200,
+    node: str | None = None,
+    event: str | None = None,
+    operation: str | None = None,
+    session: str | None = None,
+    search: str | None = None,
+    start_ts: float | None = None,
+    end_ts: float | None = None,
+    sort: str = "desc",
+) -> dict[str, Any]:
+    """Read, pair, filter, and sort the bounded JSONL audit log for the human UI."""
+
+    bounded_limit = max(1, min(int(limit), 2_000))
+    records = _read_audit_records(full_payloads=False)
+    if not records:
+        return {"entries": [], "count": 0, "total_matched": 0}
 
     rows = _coalesce_audit_records(records)
     needle = (search or "").casefold().strip()
@@ -387,3 +533,15 @@ def query_audit(
         "count": min(total, bounded_limit),
         "total_matched": total,
     }
+
+def get_audit_entry(entry_id: str) -> dict[str, Any]:
+    """Return one coalesced audit entry with complete external payloads materialized."""
+
+    normalized = str(entry_id).strip()
+    if not normalized:
+        raise ValueError("audit entry id is required")
+    rows = _coalesce_audit_records(_read_audit_records(full_payloads=True))
+    for row in rows:
+        if str(row.get("id") or "") == normalized:
+            return row
+    raise ValueError(f"Unknown audit entry: {normalized}")

--- a/src/local_shell_mcp/audit.py
+++ b/src/local_shell_mcp/audit.py
@@ -61,14 +61,19 @@ def _preview_audit_value(value: Any) -> Any:
     return _format_audit_text(repr(value))
 
 
-def _payload_directory() -> Path:
-    directory = get_settings().state_dir / _AUDIT_PAYLOAD_DIRECTORY
+def _payload_directory_path(log_path: Path | None = None) -> Path:
+    audit_log_path = log_path or get_settings().audit_log_path
+    return audit_log_path.parent / _AUDIT_PAYLOAD_DIRECTORY
+
+
+def _payload_directory(log_path: Path | None = None) -> Path:
+    directory = _payload_directory_path(log_path)
     directory.mkdir(parents=True, exist_ok=True)
     return directory
 
 
-def _payload_path(digest: str) -> Path:
-    return _payload_directory() / f"{digest}.json.gz"
+def _payload_path(digest: str, log_path: Path | None = None) -> Path:
+    return _payload_directory(log_path) / f"{digest}.json.gz"
 
 
 def _write_private_bytes(path: Path, data: bytes) -> None:
@@ -179,7 +184,7 @@ def _collect_payload_ids(record: Any, destination: set[str]) -> None:
 
 
 def _prune_payload_store(log_path: Path) -> None:
-    directory = get_settings().state_dir / _AUDIT_PAYLOAD_DIRECTORY
+    directory = _payload_directory_path(log_path)
     if not directory.is_dir():
         return
     referenced: set[str] = set()
@@ -197,9 +202,9 @@ def _prune_payload_store(log_path: Path) -> None:
                 payload.unlink()
 
 
-def _payload_file_size(digest: str) -> int:
+def _payload_file_size(digest: str, log_path: Path | None = None) -> int:
     try:
-        return _payload_path(digest).stat().st_size
+        return _payload_path(digest, log_path).stat().st_size
     except OSError:
         return 0
 
@@ -221,6 +226,48 @@ def _bounded_preview_record(record: dict[str, Any], max_bytes: int) -> bytes:
     essential["audit_payloads_omitted"] = "record exceeded audit retention limit"
     encoded = _encode_audit_record(essential)
     return encoded if len(encoded) <= max_bytes else b""
+
+
+def _retention_units(
+    parsed: list[tuple[bytes, dict[str, Any] | None, set[str]]],
+) -> list[list[tuple[int, bytes, dict[str, Any] | None, set[str]]]]:
+    units: list[list[tuple[int, bytes, dict[str, Any] | None, set[str]]]] = []
+    call_units: dict[str, list[tuple[int, bytes, dict[str, Any] | None, set[str]]]] = {}
+    for index, (raw_line, record, payload_ids) in enumerate(parsed):
+        call_id = ""
+        if isinstance(record, dict) and record.get("event") in {
+            "mcp_tool_call_start",
+            "mcp_tool_call_end",
+        }:
+            call_id = str(record.get("call_id") or "")
+        if call_id:
+            unit = call_units.get(call_id)
+            if unit is None:
+                unit = []
+                call_units[call_id] = unit
+                units.append(unit)
+            unit.append((index, raw_line, record, payload_ids))
+        else:
+            units.append([(index, raw_line, record, payload_ids)])
+    units.sort(key=lambda unit: max(item[0] for item in unit))
+    return units
+
+
+def _bounded_preview_unit(
+    unit: list[tuple[int, bytes, dict[str, Any] | None, set[str]]],
+    max_bytes: int,
+) -> list[tuple[int, bytes]]:
+    if not unit:
+        return []
+    per_record = max(1, max_bytes // len(unit))
+    bounded: list[tuple[int, bytes]] = []
+    for index, _raw_line, record, _payload_ids in unit:
+        if record is None:
+            continue
+        encoded = _bounded_preview_record(record, per_record)
+        if encoded:
+            bounded.append((index, encoded))
+    return bounded if sum(len(raw_line) for _, raw_line in bounded) <= max_bytes else []
 
 
 def _enforce_audit_storage_limit(log_path: Path, max_bytes: int) -> None:
@@ -246,38 +293,39 @@ def _enforce_audit_storage_limit(log_path: Path, max_bytes: int) -> None:
             all_referenced.update(payload_ids)
         parsed.append((raw_line, record, payload_ids))
 
-    payload_sizes = {digest: _payload_file_size(digest) for digest in all_referenced}
+    payload_sizes = {digest: _payload_file_size(digest, log_path) for digest in all_referenced}
     total_bytes = sum(len(raw_line) for raw_line in raw_lines) + sum(payload_sizes.values())
     if total_bytes <= max_bytes:
         _prune_payload_store(log_path)
         return
 
     target_bytes = max(1, max_bytes // 2)
-    selected: list[bytes] = []
+    selected: list[tuple[int, bytes]] = []
     selected_payloads: set[str] = set()
     selected_bytes = 0
-    for raw_line, record, payload_ids in reversed(parsed):
-        new_payloads = payload_ids - selected_payloads
-        added_bytes = len(raw_line) + sum(payload_sizes.get(item, 0) for item in new_payloads)
+    for unit in reversed(_retention_units(parsed)):
+        unit_payloads = set().union(*(item[3] for item in unit))
+        new_payloads = unit_payloads - selected_payloads
+        added_bytes = sum(len(item[1]) for item in unit) + sum(
+            payload_sizes.get(item, 0) for item in new_payloads
+        )
         if selected and selected_bytes + added_bytes > target_bytes:
             break
         if not selected and added_bytes > max_bytes:
-            if record is None:
+            bounded = _bounded_preview_unit(unit, max_bytes)
+            if not bounded:
                 continue
-            raw_line = _bounded_preview_record(record, max_bytes)
-            if not raw_line:
-                continue
-            payload_ids = set()
-            new_payloads = set()
-            added_bytes = len(raw_line)
-        selected.append(raw_line)
-        selected_payloads.update(payload_ids)
+            selected.extend(bounded)
+            selected_bytes += sum(len(raw_line) for _, raw_line in bounded)
+            continue
+        selected.extend((index, raw_line) for index, raw_line, _record, _payload_ids in unit)
+        selected_payloads.update(unit_payloads)
         selected_bytes += added_bytes
 
-    selected.reverse()
+    selected.sort(key=lambda item: item[0])
     temporary = log_path.with_name(f".{log_path.name}.{os.getpid()}.{threading.get_ident()}.tmp")
     try:
-        _write_private_bytes(temporary, b"".join(selected))
+        _write_private_bytes(temporary, b"".join(raw_line for _, raw_line in selected))
         os.replace(temporary, log_path)
     finally:
         with contextlib.suppress(OSError):

--- a/src/local_shell_mcp/audit.py
+++ b/src/local_shell_mcp/audit.py
@@ -267,7 +267,7 @@ def _bounded_preview_unit(
         encoded = _bounded_preview_record(record, per_record)
         if encoded:
             bounded.append((index, encoded))
-    return bounded if sum(len(raw_line) for _, raw_line in bounded) <= max_bytes else []
+    return bounded
 
 
 def _enforce_audit_storage_limit(log_path: Path, max_bytes: int) -> None:

--- a/src/local_shell_mcp/human_ui.py
+++ b/src/local_shell_mcp/human_ui.py
@@ -24,7 +24,7 @@ from starlette.responses import FileResponse, HTMLResponse, JSONResponse, Redire
 from starlette.routing import Route, WebSocketRoute
 from starlette.websockets import WebSocket, WebSocketDisconnect
 
-from .audit import query_audit, suppress_audit
+from .audit import get_audit_entry, query_audit, suppress_audit
 from .auth import Principal, require_scopes, verify_request
 from .fs_ops import (
     FileConflictError,
@@ -662,6 +662,17 @@ async def api_audit(request: Request) -> Response:
         return _json_error(exc)
 
 
+async def api_audit_detail(request: Request) -> Response:
+    try:
+        _require_ui_scopes(request, "shell:read")
+        entry_id = str(request.query_params.get("id") or "")
+        return _json_ok(await asyncio.to_thread(get_audit_entry, entry_id))
+    except ValueError as exc:
+        return _json_error(exc, status_code=404)
+    except Exception as exc:
+        return _json_error(exc)
+
+
 async def api_remotes(request: Request) -> Response:
     try:
         _require_ui_scopes(request, "remote:use")
@@ -1158,6 +1169,7 @@ def ui_routes() -> list[Any]:
         Route(UI_API_PREFIX + "/terminals/{action}", api_terminal_action, methods=["POST"]),
         Route(UI_API_PREFIX + "/todos", api_todos, methods=["GET", "PUT"]),
         Route(UI_API_PREFIX + "/audit", api_audit, methods=["GET"]),
+        Route(UI_API_PREFIX + "/audit/detail", api_audit_detail, methods=["GET"]),
         Route(UI_API_PREFIX + "/remotes", api_remotes, methods=["GET", "POST"]),
         Route(UI_API_PREFIX + "/remotes/{action}", api_remote_action, methods=["POST"]),
     ]

--- a/src/local_shell_mcp/human_ui.py
+++ b/src/local_shell_mcp/human_ui.py
@@ -91,6 +91,48 @@ def _require_ui_scopes(
     require_scopes(_request_principal(request), required)
 
 
+_AUDIT_FILE_WRITE_TOOLS = frozenset(
+    {
+        "write_file",
+        "edit_file",
+        "delete_file_or_dir",
+        "apply_patch",
+        "todo_write_tool",
+    }
+)
+_AUDIT_EXECUTE_TOOLS = frozenset(
+    {
+        "run_shell_tool",
+        "run_python_tool",
+        "shell_start",
+        "shell_send",
+        "shell_kill",
+        "job_start",
+        "job_stop",
+        "job_retry",
+    }
+)
+
+
+def _audit_detail_scopes(entry: dict[str, Any]) -> tuple[str, ...]:
+    required = {"shell:read"}
+    tool = str(entry.get("tool") or "")
+    operation = str(entry.get("operation") or "")
+    if tool in _AUDIT_FILE_WRITE_TOOLS:
+        required.add("shell:write")
+    if tool in _AUDIT_EXECUTE_TOOLS or operation in {"shell", "jobs"}:
+        required.add("shell:execute")
+    if operation == "browser":
+        required.add("browser:use")
+    if operation == "transfer":
+        required.add("file:share")
+    if operation == "remote" or str(entry.get("node") or "local") != "local":
+        required.add("remote:use")
+    if operation == "other":
+        required.update(UI_FULL_SCOPES)
+    return tuple(scope for scope in UI_FULL_SCOPES if scope in required)
+
+
 def _bounded_int(
     raw: str | int | None,
     *,
@@ -663,8 +705,9 @@ async def api_audit(request: Request) -> Response:
 
 async def api_audit_detail(request: Request) -> Response:
     try:
-        _require_ui_scopes(request, "shell:read")
         entry_id = str(request.query_params.get("id") or "")
+        preview = await asyncio.to_thread(get_audit_entry, entry_id, full=False)
+        _require_ui_scopes(request, *_audit_detail_scopes(preview))
         return _json_ok(await asyncio.to_thread(get_audit_entry, entry_id))
     except ValueError as exc:
         return _json_error(exc, status_code=404)

--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -200,7 +200,6 @@ def _oauth_security_scheme(scopes: list[str] | tuple[str, ...]) -> dict[str, Any
 OAUTH_SECURITY_SCHEMES = [_oauth_security_scheme(ALL_OAUTH_SCOPES)]
 NOAUTH_SECURITY_SCHEMES = [{"type": "noauth"}]
 PUBLIC_TOOL_TIMEOUT_S = PUBLIC_TOOL_WATCHDOG_TIMEOUT_S
-MAX_AUDIT_TOOL_ARG_STRING = 500
 MCP_INSTRUCTIONS = (
     "When a task may benefit from an installed Agent Skill, call skills_list first "
     "to discover the exact Skill name and description. Before following a Skill's "
@@ -279,20 +278,13 @@ def _serialize_audit_value(value: Any) -> Any:
     if isinstance(value, BaseModel):
         return _serialize_audit_value(value.model_dump(mode="json"))
     if isinstance(value, str):
-        if len(value) > MAX_AUDIT_TOOL_ARG_STRING:
-            return value[:MAX_AUDIT_TOOL_ARG_STRING] + "…<truncated>"
         return value
     if isinstance(value, (int, float, bool)) or value is None:
         return value
-    if isinstance(value, list):
-        return [_serialize_audit_value(item) for item in value[:20]]
-    if isinstance(value, tuple):
-        return [_serialize_audit_value(item) for item in value[:20]]
+    if isinstance(value, (list, tuple)):
+        return [_serialize_audit_value(item) for item in value]
     if isinstance(value, dict):
-        return {
-            str(name): _serialize_audit_value(item)
-            for name, item in list(value.items())[:50]
-        }
+        return {str(name): _serialize_audit_value(item) for name, item in value.items()}
     return repr(value)
 
 

--- a/tests/test_audit_ui_complete.py
+++ b/tests/test_audit_ui_complete.py
@@ -205,7 +205,8 @@ def test_payload_files_are_created_private_from_the_first_write(tmp_path, monkey
 
     assert observed_modes
     assert set(observed_modes) == {0o600}
-    assert stat.S_IMODE(payload.stat().st_mode) == 0o600
+    if os.name != "nt":
+        assert stat.S_IMODE(payload.stat().st_mode) == 0o600
 
 
 def test_payload_pruning_defers_when_the_log_cannot_be_read(tmp_path, monkeypatch):

--- a/tests/test_audit_ui_complete.py
+++ b/tests/test_audit_ui_complete.py
@@ -213,7 +213,7 @@ def test_payload_files_are_created_private_from_the_first_write(tmp_path, monkey
 
 def test_payload_pruning_defers_when_the_log_cannot_be_read(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
-    directory = get_settings().state_dir / audit_module._AUDIT_PAYLOAD_DIRECTORY
+    directory = get_settings().audit_log_path.parent / audit_module._AUDIT_PAYLOAD_DIRECTORY
     directory.mkdir(parents=True)
     payload = directory / f"{'a' * 64}.json.gz"
     payload.write_bytes(b"payload")
@@ -282,6 +282,71 @@ def test_get_audit_entry_loads_only_the_selected_payloads(tmp_path, monkeypatch)
     assert detail["output"]["stdout"] == "s" * 30_000
 
 
+def test_payload_store_follows_configured_audit_log(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    audit_path = tmp_path / "persisted-audit" / "records.jsonl"
+    monkeypatch.setenv("LOCAL_SHELL_MCP_AUDIT_LOG_PATH", str(audit_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(tmp_path / "separate-state"))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_LOG_BYTES", "200000")
+    get_settings.cache_clear()
+
+    audit_module.audit("large_event", payload="x" * 30_000)
+
+    payloads = list((audit_path.parent / audit_module._AUDIT_PAYLOAD_DIRECTORY).glob("*.json.gz"))
+    assert len(payloads) == 1
+    assert not (get_settings().state_dir / audit_module._AUDIT_PAYLOAD_DIRECTORY).exists()
+
+
+def test_audit_retention_keeps_latest_call_pair_together(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_LOG_BYTES", "500000")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_TAIL_BYTES", "500000")
+    get_settings.cache_clear()
+
+    audit_module.audit("older_event", payload=os.urandom(18_000).hex())
+    latest_input = os.urandom(9_000).hex()
+    latest_output = os.urandom(9_000).hex()
+    audit_module.audit(
+        "mcp_tool_call_start",
+        call_id="latest-call",
+        tool="write_file",
+        arguments={"keyword_args": {"content": latest_input}},
+    )
+    audit_module.audit(
+        "mcp_tool_call_end",
+        call_id="latest-call",
+        tool="write_file",
+        ok=True,
+        result={"stdout": latest_output},
+    )
+
+    log_path = get_settings().audit_log_path
+    raw_lines = log_path.read_bytes().splitlines(keepends=True)
+    pair_records = [
+        json.loads(line) for line in raw_lines if json.loads(line).get("call_id") == "latest-call"
+    ]
+    pair_payloads: set[str] = set()
+    for record in pair_records:
+        audit_module._collect_payload_ids(record, pair_payloads)
+    pair_bytes = sum(
+        len(line) for line in raw_lines if json.loads(line).get("call_id") == "latest-call"
+    ) + sum(audit_module._payload_file_size(digest, log_path) for digest in pair_payloads)
+    total_bytes = log_path.stat().st_size + sum(
+        path.stat().st_size for path in audit_module._payload_directory().glob("*.json.gz")
+    )
+    assert total_bytes > pair_bytes + 100
+
+    audit_module._enforce_audit_storage_limit(log_path, pair_bytes + 100)
+
+    entries = audit_module.query_audit(sort="asc")["entries"]
+    assert len(entries) == 1
+    assert entries[0]["id"] == "call:latest-call"
+    assert entries[0]["paired"] is True
+    detail = audit_module.get_audit_entry("call:latest-call")
+    assert detail["input"]["content"] == latest_input
+    assert detail["output"]["stdout"] == latest_output
+
+
 def test_audit_retention_bounds_log_and_external_payload_bytes(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
     max_bytes = 26_000
@@ -293,13 +358,15 @@ def test_audit_retention_bounds_log_and_external_payload_bytes(tmp_path, monkeyp
     second = os.urandom(18_000).hex()
     audit_module.audit("first_large_event", payload=first)
     first_payloads = set(
-        (get_settings().state_dir / audit_module._AUDIT_PAYLOAD_DIRECTORY).glob("*.json.gz")
+        (get_settings().audit_log_path.parent / audit_module._AUDIT_PAYLOAD_DIRECTORY).glob(
+            "*.json.gz"
+        )
     )
     assert len(first_payloads) == 1
 
     audit_module.audit("second_large_event", payload=second)
 
-    payload_directory = get_settings().state_dir / audit_module._AUDIT_PAYLOAD_DIRECTORY
+    payload_directory = get_settings().audit_log_path.parent / audit_module._AUDIT_PAYLOAD_DIRECTORY
     stored_bytes = get_settings().audit_log_path.stat().st_size + sum(
         path.stat().st_size for path in payload_directory.glob("*.json.gz")
     )

--- a/tests/test_audit_ui_complete.py
+++ b/tests/test_audit_ui_complete.py
@@ -5,6 +5,8 @@ import os
 import stat
 from pathlib import Path
 
+import pytest
+
 import local_shell_mcp.audit as audit_module
 from local_shell_mcp.settings import get_settings
 
@@ -225,6 +227,15 @@ def test_payload_pruning_defers_when_the_log_cannot_be_read(tmp_path, monkeypatc
     audit_module._prune_payload_store(log_path)
 
     assert payload.exists()
+
+
+def test_get_audit_entry_rejects_empty_and_unknown_ids(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+
+    with pytest.raises(ValueError, match="audit entry id is required"):
+        audit_module.get_audit_entry("  ")
+    with pytest.raises(ValueError, match="Unknown audit entry: missing"):
+        audit_module.get_audit_entry("missing")
 
 
 def test_get_audit_entry_loads_only_the_selected_payloads(tmp_path, monkeypatch):

--- a/tests/test_audit_ui_complete.py
+++ b/tests/test_audit_ui_complete.py
@@ -282,6 +282,83 @@ def test_get_audit_entry_loads_only_the_selected_payloads(tmp_path, monkeypatch)
     assert detail["output"]["stdout"] == "s" * 30_000
 
 
+def test_audit_payload_helpers_cover_edge_paths(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_LOG_BYTES", "200000")
+    get_settings.cache_clear()
+
+    class CustomValue:
+        def __repr__(self) -> str:
+            return "custom-value"
+
+    assert audit_module._preview_audit_value([1, "x", CustomValue()]) == [
+        1,
+        "x",
+        "custom-value",
+    ]
+    assert audit_module._preview_audit_value(None) is None
+    assert (
+        audit_module._is_payload_reference(
+            {audit_module._AUDIT_PAYLOAD_MARKER: "invalid", "preview": "x"}
+        )
+        is False
+    )
+    assert (
+        audit_module._is_payload_reference(
+            {
+                audit_module._AUDIT_PAYLOAD_MARKER: {
+                    "version": audit_module._AUDIT_PAYLOAD_VERSION,
+                    "sha256": "a" * 64,
+                },
+                "preview": "x",
+            }
+        )
+        is False
+    )
+
+    missing_reference = {
+        audit_module._AUDIT_PAYLOAD_MARKER: {
+            "version": audit_module._AUDIT_PAYLOAD_VERSION,
+            "sha256": "f" * 64,
+            "bytes": 10,
+        },
+        "preview": "missing-preview",
+    }
+    unavailable = audit_module._resolve_payload_reference(missing_reference, full=True)
+    assert unavailable["error"] == "Audit payload is unavailable"
+    assert unavailable["preview"] == "missing-preview"
+
+    collected: set[str] = set()
+    audit_module._collect_payload_ids("not-a-record", collected)
+    assert collected == set()
+    assert audit_module._payload_file_size("e" * 64) == 0
+
+    oversized = {
+        "id": "oversized",
+        "ts": 1,
+        "event": "custom_event",
+        "payload": "x" * 10_000,
+    }
+    assert audit_module._bounded_preview_record(oversized, 20) == b""
+    bounded = json.loads(audit_module._bounded_preview_record(oversized, 300))
+    assert bounded["audit_payloads_omitted"] == "record exceeded audit retention limit"
+    assert audit_module._bounded_preview_unit([], 100) == []
+    unit = [
+        (0, b"invalid\n", None, set()),
+        (1, b"record\n", oversized, set()),
+    ]
+    assert [index for index, _ in audit_module._bounded_preview_unit(unit, 600)] == [1]
+
+    log_path = get_settings().audit_log_path
+    audit_module._enforce_audit_storage_limit(log_path, 100)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_bytes(b"{" + b"x" * 200 + b"\n" + audit_module._encode_audit_record(oversized))
+    audit_module._enforce_audit_storage_limit(log_path, 300)
+    retained = json.loads(log_path.read_text(encoding="utf-8"))
+    assert retained["id"] == "oversized"
+    assert retained["audit_payloads_omitted"] == "record exceeded audit retention limit"
+
+
 def test_payload_store_follows_configured_audit_log(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
     audit_path = tmp_path / "persisted-audit" / "records.jsonl"

--- a/tests/test_audit_ui_complete.py
+++ b/tests/test_audit_ui_complete.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import stat
+import time
 from pathlib import Path
 
 import pytest
@@ -211,6 +212,23 @@ def test_payload_files_are_created_private_from_the_first_write(tmp_path, monkey
         assert stat.S_IMODE(payload.stat().st_mode) == 0o600
 
 
+def test_payload_pruning_defers_recent_unreferenced_files(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    log_path = get_settings().audit_log_path
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text("{}\n", encoding="utf-8")
+    reference = audit_module._write_payload("pending:" + "x" * 30_000)
+    payload = audit_module._payload_path(audit_module._payload_digest(reference))
+
+    audit_module._prune_payload_store(log_path)
+    assert payload.exists()
+
+    stale = time.time() - audit_module._AUDIT_PAYLOAD_PRUNE_GRACE_S - 1
+    os.utime(payload, (stale, stale))
+    audit_module._prune_payload_store(log_path)
+    assert not payload.exists()
+
+
 def test_payload_pruning_defers_when_the_log_cannot_be_read(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
     directory = get_settings().audit_log_path.parent / audit_module._AUDIT_PAYLOAD_DIRECTORY
@@ -359,6 +377,21 @@ def test_audit_payload_helpers_cover_edge_paths(tmp_path, monkeypatch):
     assert retained["audit_payloads_omitted"] == "record exceeded audit retention limit"
 
 
+def test_small_retention_budget_externalizes_recoverable_values(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_LOG_BYTES", "12000")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_TAIL_BYTES", "12000")
+    get_settings.cache_clear()
+    value = "compressible:" + "x" * 10_000
+
+    audit_module.audit("budgeted_event", payload=value)
+
+    raw = json.loads(get_settings().audit_log_path.read_text(encoding="utf-8"))
+    assert audit_module._is_payload_reference(raw["payload"])
+    entry = audit_module.query_audit()["entries"][0]
+    assert audit_module.get_audit_entry(entry["id"])["payload"] == value
+
+
 def test_payload_store_follows_configured_audit_log(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
     audit_path = tmp_path / "persisted-audit" / "records.jsonl"
@@ -440,6 +473,9 @@ def test_audit_retention_bounds_log_and_external_payload_bytes(tmp_path, monkeyp
         )
     )
     assert len(first_payloads) == 1
+    stale = time.time() - audit_module._AUDIT_PAYLOAD_PRUNE_GRACE_S - 1
+    for payload in first_payloads:
+        os.utime(payload, (stale, stale))
 
     audit_module.audit("second_large_event", payload=second)
 

--- a/tests/test_audit_ui_complete.py
+++ b/tests/test_audit_ui_complete.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
+import stat
+from pathlib import Path
 
 import local_shell_mcp.audit as audit_module
 from local_shell_mcp.settings import get_settings
@@ -117,9 +120,27 @@ def test_query_audit_covers_tail_reading_and_filter_rejections(tmp_path, monkeyp
 
     path = get_settings().audit_log_path
     records = [
-        {"ts": 1, "event": "shell_send", "machine": "worker-a", "session": "one", "detail": "alpha"},
-        {"ts": 2, "event": "job_started", "machine": "worker-b", "session": "two", "detail": "beta"},
-        {"ts": 3, "event": "browser_capture", "machine": "worker-c", "session": "three", "detail": "gamma"},
+        {
+            "ts": 1,
+            "event": "shell_send",
+            "machine": "worker-a",
+            "session": "one",
+            "detail": "alpha",
+        },
+        {
+            "ts": 2,
+            "event": "job_started",
+            "machine": "worker-b",
+            "session": "two",
+            "detail": "beta",
+        },
+        {
+            "ts": 3,
+            "event": "browser_capture",
+            "machine": "worker-c",
+            "session": "three",
+            "detail": "gamma",
+        },
     ]
     payload = b"prefix-without-json\n" + b"x" * 500 + b"\n\xff\n"
     payload += ("\n".join(json.dumps(record) for record in records) + "\n").encode()
@@ -143,3 +164,135 @@ def test_trim_audit_log_without_newline_keeps_bounded_tail(tmp_path):
     audit_module._trim_audit_log(path, 100)
 
     assert path.read_bytes() == b"x" * 50
+
+
+def test_payload_reference_namespace_does_not_capture_user_dictionaries():
+    legacy_shaped = {
+        "$audit_payload": "a" * 64,
+        "bytes": 12,
+        "preview": "user value",
+    }
+    namespaced_but_not_internal = {
+        audit_module._AUDIT_PAYLOAD_MARKER: {
+            "version": audit_module._AUDIT_PAYLOAD_VERSION,
+            "sha256": "b" * 64,
+            "bytes": 12,
+        },
+        "preview": "user value",
+        "extra": True,
+    }
+
+    assert audit_module._resolve_payload_reference(legacy_shaped, full=True) == legacy_shaped
+    assert (
+        audit_module._resolve_payload_reference(namespaced_but_not_internal, full=True)
+        == namespaced_but_not_internal
+    )
+
+
+def test_payload_files_are_created_private_from_the_first_write(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    observed_modes: list[int] = []
+    real_open = os.open
+
+    def tracking_open(path, flags, mode=0o777):
+        if str(path).endswith(".tmp"):
+            observed_modes.append(mode)
+        return real_open(path, flags, mode)
+
+    monkeypatch.setattr(audit_module.os, "open", tracking_open)
+    reference = audit_module._write_payload("secret:" + "x" * 30_000)
+    payload = audit_module._payload_path(audit_module._payload_digest(reference))
+
+    assert observed_modes
+    assert set(observed_modes) == {0o600}
+    assert stat.S_IMODE(payload.stat().st_mode) == 0o600
+
+
+def test_payload_pruning_defers_when_the_log_cannot_be_read(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    directory = get_settings().state_dir / audit_module._AUDIT_PAYLOAD_DIRECTORY
+    directory.mkdir(parents=True)
+    payload = directory / f"{'a' * 64}.json.gz"
+    payload.write_bytes(b"payload")
+    log_path = get_settings().audit_log_path
+    log_path.write_text("{}\n", encoding="utf-8")
+
+    def fail_read_text(self: Path, *args, **kwargs):
+        raise OSError("temporary read failure")
+
+    monkeypatch.setattr(Path, "read_text", fail_read_text)
+    audit_module._prune_payload_store(log_path)
+
+    assert payload.exists()
+
+
+def test_get_audit_entry_loads_only_the_selected_payloads(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_TAIL_BYTES", "200000")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_LOG_BYTES", "200000")
+    get_settings.cache_clear()
+
+    for call_id, fill in (("selected", "s"), ("unrelated", "u")):
+        audit_module.audit(
+            "mcp_tool_call_start",
+            call_id=call_id,
+            tool="write_file",
+            arguments={"keyword_args": {"content": fill * 30_000}},
+        )
+        audit_module.audit(
+            "mcp_tool_call_end",
+            call_id=call_id,
+            tool="write_file",
+            ok=True,
+            result={"stdout": fill * 30_000},
+        )
+
+    records = [
+        json.loads(line)
+        for line in get_settings().audit_log_path.read_text(encoding="utf-8").splitlines()
+    ]
+    unrelated_ids: set[str] = set()
+    for record in records:
+        if record.get("call_id") == "unrelated":
+            audit_module._collect_payload_ids(record, unrelated_ids)
+
+    real_payload_path = audit_module._payload_path
+
+    def guarded_payload_path(digest: str):
+        if digest in unrelated_ids:
+            raise AssertionError("unrelated payload was materialized")
+        return real_payload_path(digest)
+
+    monkeypatch.setattr(audit_module, "_payload_path", guarded_payload_path)
+    detail = audit_module.get_audit_entry("call:selected")
+
+    assert detail["input"]["content"] == "s" * 30_000
+    assert detail["output"]["stdout"] == "s" * 30_000
+
+
+def test_audit_retention_bounds_log_and_external_payload_bytes(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    max_bytes = 26_000
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_TAIL_BYTES", "200000")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_LOG_BYTES", str(max_bytes))
+    get_settings.cache_clear()
+
+    first = os.urandom(18_000).hex()
+    second = os.urandom(18_000).hex()
+    audit_module.audit("first_large_event", payload=first)
+    first_payloads = set(
+        (get_settings().state_dir / audit_module._AUDIT_PAYLOAD_DIRECTORY).glob("*.json.gz")
+    )
+    assert len(first_payloads) == 1
+
+    audit_module.audit("second_large_event", payload=second)
+
+    payload_directory = get_settings().state_dir / audit_module._AUDIT_PAYLOAD_DIRECTORY
+    stored_bytes = get_settings().audit_log_path.stat().st_size + sum(
+        path.stat().st_size for path in payload_directory.glob("*.json.gz")
+    )
+    assert stored_bytes <= max_bytes
+    assert all(not path.exists() for path in first_payloads)
+    entries = audit_module.query_audit(sort="asc")["entries"]
+    assert [entry["event"] for entry in entries] == ["second_large_event"]
+    assert audit_module.get_audit_entry(entries[0]["id"])["payload"] == second

--- a/tests/test_edge_modules_complete.py
+++ b/tests/test_edge_modules_complete.py
@@ -92,6 +92,7 @@ def test_audit_serialization_trimming_and_all_filters(tmp_path, monkeypatch):
             "object": object(),
         }
     )
+    value = audit_module._resolve_payload_reference(value, full=True)
     assert value["token"] == "hidden"
     assert value["api_token"] == "hidden"
     assert value["token_id"] == "visible"

--- a/tests/test_edge_modules_complete.py
+++ b/tests/test_edge_modules_complete.py
@@ -79,7 +79,7 @@ def test_audit_serialization_trimming_and_all_filters(tmp_path, monkeypatch):
     settings = get_settings()
     sensitive_text = "Bearer abc.def configured-secret-pin ghp_" + "x" * 30
     assert audit_module._format_audit_text(sensitive_text) == sensitive_text
-    assert audit_module._format_audit_text("z" * 3000).endswith("…<truncated>")
+    assert audit_module._format_audit_text("z" * 3000).endswith("…<preview>")
 
     value = audit_module._serialize_audit_value(
         {
@@ -96,7 +96,7 @@ def test_audit_serialization_trimming_and_all_filters(tmp_path, monkeypatch):
     assert value["api_token"] == "hidden"
     assert value["token_id"] == "visible"
     assert value["db_password"] == "hidden"
-    assert len(value["items"]) == 100
+    assert len(value["items"]) == 110
     assert value["tuple"] == [1, 2]
     assert "object at" in value["object"]
 

--- a/tests/test_human_ui.py
+++ b/tests/test_human_ui.py
@@ -16,6 +16,7 @@ from starlette.requests import Request
 from starlette.routing import Route
 from starlette.websockets import WebSocket
 
+import local_shell_mcp.audit as audit_module
 from local_shell_mcp.audit import audit, query_audit, suppress_audit
 from local_shell_mcp.http_app import build_http_app
 from local_shell_mcp.human_ui import (
@@ -481,6 +482,8 @@ def test_audit_trim_prunes_unreferenced_payload_files(tmp_path, monkeypatch):
     audit("large_event", payload="z" * 30_000)
     payloads = list((get_settings().audit_log_path.parent / "audit-payloads").glob("*.json.gz"))
     assert len(payloads) == 1
+    stale = time.time() - audit_module._AUDIT_PAYLOAD_PRUNE_GRACE_S - 1
+    os.utime(payloads[0], (stale, stale))
 
     audit("small_event", value="kept" * 300)
 

--- a/tests/test_human_ui.py
+++ b/tests/test_human_ui.py
@@ -458,7 +458,7 @@ def test_audit_large_payloads_are_previewed_and_loaded_on_demand(tmp_path, monke
     assert "$local_shell_mcp_audit_payload" in raw_records[0]["arguments"]
     assert "$local_shell_mcp_audit_payload" in raw_records[1]["result"]
     assert large_input not in get_settings().audit_log_path.read_text(encoding="utf-8")
-    assert len(list((get_settings().state_dir / "audit-payloads").glob("*.json.gz"))) == 2
+    assert len(list((get_settings().audit_log_path.parent / "audit-payloads").glob("*.json.gz"))) == 2
 
     client = TestClient(build_http_app())
     listing = client.get("/api/ui/audit").json()["data"]["entries"][0]
@@ -479,7 +479,7 @@ def test_audit_trim_prunes_unreferenced_payload_files(tmp_path, monkeypatch):
     get_settings.cache_clear()
 
     audit("large_event", payload="z" * 30_000)
-    payloads = list((get_settings().state_dir / "audit-payloads").glob("*.json.gz"))
+    payloads = list((get_settings().audit_log_path.parent / "audit-payloads").glob("*.json.gz"))
     assert len(payloads) == 1
 
     audit("small_event", value="kept" * 300)

--- a/tests/test_human_ui.py
+++ b/tests/test_human_ui.py
@@ -429,6 +429,65 @@ def test_audit_storage_remains_valid_under_concurrent_trim_and_append(tmp_path, 
     assert not list(tmp_path.glob(".audit.jsonl.*.tmp"))
 
 
+def test_audit_large_payloads_are_previewed_and_loaded_on_demand(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_TAIL_BYTES", "200000")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_LOG_BYTES", "200000")
+    get_settings.cache_clear()
+    large_input = "input:" + "x" * 30_000
+    large_output = "output:" + "y" * 40_000
+
+    audit(
+        "mcp_tool_call_start",
+        call_id="large-call",
+        tool="write_file",
+        arguments={"keyword_args": {"content": large_input}},
+    )
+    audit(
+        "mcp_tool_call_end",
+        call_id="large-call",
+        tool="write_file",
+        ok=True,
+        result={"stdout": large_output},
+    )
+
+    raw_records = [
+        json.loads(line)
+        for line in get_settings().audit_log_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert "$audit_payload" in raw_records[0]["arguments"]
+    assert "$audit_payload" in raw_records[1]["result"]
+    assert large_input not in get_settings().audit_log_path.read_text(encoding="utf-8")
+    assert len(list((get_settings().state_dir / "audit-payloads").glob("*.json.gz"))) == 2
+
+    client = TestClient(build_http_app())
+    listing = client.get("/api/ui/audit").json()["data"]["entries"][0]
+    assert listing["id"] == "call:large-call"
+    assert listing["input"]["content"].endswith("…<preview>")
+    assert listing["output"]["stdout"].endswith("…<preview>")
+
+    detail = client.get(
+        "/api/ui/audit/detail", params={"id": listing["id"]}
+    ).json()["data"]
+    assert detail["input"]["content"] == large_input
+    assert detail["output"]["stdout"] == large_output
+
+
+def test_audit_trim_prunes_unreferenced_payload_files(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_LOG_BYTES", "1000")
+    get_settings.cache_clear()
+
+    audit("large_event", payload="z" * 30_000)
+    payloads = list((get_settings().state_dir / "audit-payloads").glob("*.json.gz"))
+    assert len(payloads) == 1
+
+    audit("small_event", value="kept")
+
+    assert not payloads[0].exists()
+    assert query_audit()["entries"][0]["event"] == "small_event"
+
+
 def test_query_audit_pairs_calls_filters_compact_operations_and_hides_auth(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
     path = tmp_path / "audit.jsonl"

--- a/tests/test_human_ui.py
+++ b/tests/test_human_ui.py
@@ -455,8 +455,8 @@ def test_audit_large_payloads_are_previewed_and_loaded_on_demand(tmp_path, monke
         json.loads(line)
         for line in get_settings().audit_log_path.read_text(encoding="utf-8").splitlines()
     ]
-    assert "$audit_payload" in raw_records[0]["arguments"]
-    assert "$audit_payload" in raw_records[1]["result"]
+    assert "$local_shell_mcp_audit_payload" in raw_records[0]["arguments"]
+    assert "$local_shell_mcp_audit_payload" in raw_records[1]["result"]
     assert large_input not in get_settings().audit_log_path.read_text(encoding="utf-8")
     assert len(list((get_settings().state_dir / "audit-payloads").glob("*.json.gz"))) == 2
 
@@ -475,14 +475,14 @@ def test_audit_large_payloads_are_previewed_and_loaded_on_demand(tmp_path, monke
 
 def test_audit_trim_prunes_unreferenced_payload_files(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
-    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_LOG_BYTES", "1000")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_LOG_BYTES", "3500")
     get_settings.cache_clear()
 
     audit("large_event", payload="z" * 30_000)
     payloads = list((get_settings().state_dir / "audit-payloads").glob("*.json.gz"))
     assert len(payloads) == 1
 
-    audit("small_event", value="kept")
+    audit("small_event", value="kept" * 300)
 
     assert not payloads[0].exists()
     assert query_audit()["entries"][0]["event"] == "small_event"

--- a/tests/test_human_ui_complete.py
+++ b/tests/test_human_ui_complete.py
@@ -93,6 +93,55 @@ def test_root_redirects_to_relative_ui_path_without_auth(tmp_path, monkeypatch):
     assert response.headers["location"] == "./console/"
 
 
+def test_audit_detail_requires_scopes_before_materializing_payloads(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    calls: list[bool] = []
+    preview = {
+        "id": "call:write",
+        "tool": "write_file",
+        "operation": "files",
+        "node": "local",
+    }
+
+    def fake_get_audit_entry(entry_id: str, *, full: bool = True):
+        assert entry_id == "call:write"
+        calls.append(full)
+        return {**preview, "input": {"content": "secret"}} if full else preview
+
+    monkeypatch.setattr(ui, "get_audit_entry", fake_get_audit_entry)
+    limited = _request("/api/ui/audit/detail", query=b"id=call%3Awrite")
+    limited.state.principal = Principal(
+        email=None,
+        subject="read-only",
+        claims={"scope": "shell:read"},
+    )
+
+    denied = asyncio.run(ui.api_audit_detail(limited))
+
+    assert denied.status_code == 403
+    assert calls == [False]
+
+    allowed = _request("/api/ui/audit/detail", query=b"id=call%3Awrite")
+    allowed.state.principal = Principal(
+        email=None,
+        subject="writer",
+        claims={"scope": "shell:read shell:write"},
+    )
+
+    response = asyncio.run(ui.api_audit_detail(allowed))
+
+    assert response.status_code == 200
+    assert calls == [False, False, True]
+    assert "secret" in response.body.decode()
+    assert set(ui._audit_detail_scopes({"operation": "browser", "node": "local"})) == {
+        "shell:read",
+        "browser:use",
+    }
+    assert set(ui._audit_detail_scopes({"operation": "other", "node": "worker"})) == set(
+        ui.UI_FULL_SCOPES
+    )
+
+
 def test_index_assets_principal_and_basic_helpers(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
     empty = tmp_path / "assets"

--- a/tests/test_tools_complete.py
+++ b/tests/test_tools_complete.py
@@ -321,7 +321,7 @@ async def test_tool_wrapper_error_paths_and_remote_disabled(tmp_path, monkeypatc
 
 def test_tool_helpers_audit_serialization_timeout_and_tail(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
-    assert tools._serialize_audit_value("x" * 501).endswith("…<truncated>")
+    assert tools._serialize_audit_value("x" * 501) == "x" * 501
     assert tools._serialize_audit_value((1, 2)) == [1, 2]
     serialized = tools._serialize_audit_value(
         {
@@ -334,7 +334,7 @@ def test_tool_helpers_audit_serialization_timeout_and_tail(tmp_path, monkeypatch
     )
     assert serialized["token"] == "secret"
     assert serialized["content"] == "body"
-    assert len(serialized["items"]) == 20
+    assert len(serialized["items"]) == 30
     assert "object at" in serialized["object"]
     assert tools._audit_tool_arguments((1, 2), {"password": "x"})["positional_count"] == 2
 

--- a/ui/src/api.test.ts
+++ b/ui/src/api.test.ts
@@ -37,6 +37,7 @@ describe("API client endpoint wrappers", () => {
       7,
     )
     await api.audit({ node: "worker a", empty: "", zero: 0, enabled: false, omitted: null })
+    await api.auditDetail("call:abc/123")
     await api.remotes()
     await api.invite({ name: "node", workdir: "/work", ttl_s: 60 })
     await api.remoteAction("rename node", { machine: "node", new_name: "next" })
@@ -54,6 +55,7 @@ describe("API client endpoint wrappers", () => {
       `${API_BASE}/todos`,
       `${API_BASE}/todos`,
       `${API_BASE}/audit?node=worker+a&zero=0&enabled=false`,
+      `${API_BASE}/audit/detail?id=call%3Aabc%2F123`,
       `${API_BASE}/remotes`,
       `${API_BASE}/remotes`,
       `${API_BASE}/remotes/rename%20node`,
@@ -66,7 +68,7 @@ describe("API client endpoint wrappers", () => {
       todos: [{ id: "a", content: "A", status: "pending", priority: "medium" }],
       expected_revision: 7,
     })
-    expect(calls[13]!.init?.method).toBe("POST")
+    expect(calls[14]!.init?.method).toBe("POST")
     expect(calls.every((call) => new Headers(call.init?.headers).get("Accept") === "application/json")).toBe(true)
     expect(calls.every((call) => new Headers(call.init?.headers).get("Content-Type") === "application/json")).toBe(true)
   })

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1,5 +1,6 @@
 import type {
   ApiEnvelope,
+  AuditEntry,
   AuditPayload,
   BootstrapPayload,
   FilePreview,
@@ -106,6 +107,9 @@ export const api = {
   },
   audit(filters: Record<string, string | number | boolean | null | undefined>, signal?: AbortSignal): Promise<AuditPayload> {
     return request(`/audit${queryString(filters)}`, { signal })
+  },
+  auditDetail(id: string, signal?: AbortSignal): Promise<AuditEntry> {
+    return request(`/audit/detail${queryString({ id })}`, { signal })
   },
   remotes(signal?: AbortSignal): Promise<MachinePayload> {
     return request("/remotes", { signal })

--- a/ui/src/audit-screen.tsx
+++ b/ui/src/audit-screen.tsx
@@ -72,8 +72,11 @@ export function AuditScreen({
   const [session, setSession] = useState("")
   const [dialog, setDialog] = useState<AuditDialog>({ type: "none" })
   const [loading, setLoading] = useState(false)
+  const [detail, setDetail] = useState<AuditEntry | null>(null)
   const refreshRequest = useRef(0)
   const refreshController = useRef<AbortController | null>(null)
+  const detailRequest = useRef(0)
+  const detailController = useRef<AbortController | null>(null)
   const entriesRef = useRef<AuditEntry[]>([])
   const selectedRef = useRef(0)
 
@@ -82,6 +85,7 @@ export function AuditScreen({
   const selectedOperation = AUDIT_OPERATIONS[operationIndex] || ""
   const timeRange = TIME_RANGES[timeIndex] || TIME_RANGES[2]!
   const current = entries[selected]
+  const displayed = detail?.id === current?.id ? detail : current
   const narrow = width < 70
   const tableHeight = Math.max(6, height - 15)
   const { rows, start } = useVisibleRows(entries, selected, tableHeight)
@@ -147,6 +151,30 @@ export function AuditScreen({
   }, [refresh])
 
   useEffect(() => {
+    detailController.current?.abort()
+    const controller = new AbortController()
+    detailController.current = controller
+    const requestId = ++detailRequest.current
+    setDetail(null)
+    if (!current?.id) return () => controller.abort()
+    void api
+      .auditDetail(current.id, controller.signal)
+      .then((entry) => {
+        if (requestId === detailRequest.current && !controller.signal.aborted) setDetail(entry)
+      })
+      .catch((error) => {
+        if (requestId === detailRequest.current && !controller.signal.aborted) {
+          setStatus(`Audit detail: ${formatError(error)}`)
+        }
+      })
+    return () => {
+      detailRequest.current += 1
+      controller.abort()
+      if (detailController.current === controller) detailController.current = null
+    }
+  }, [current?.id, current?.paired, current?.status, setStatus])
+
+  useEffect(() => {
     onInteractionLockChange(dialog.type !== "none")
     return () => onInteractionLockChange(false)
   }, [dialog.type, onInteractionLockChange])
@@ -191,11 +219,11 @@ export function AuditScreen({
     setDialog({ type: "none" })
   }
 
-  const outputText = current
-    ? formatAuditValue(auditOutput(current), "No return value recorded")
+  const outputText = displayed
+    ? formatAuditValue(auditOutput(displayed), "No return value recorded")
     : ""
-  const inputText = current ? formatAuditValue(auditInput(current), "No input recorded") : ""
-  const duration = current ? durationLabel(current) : ""
+  const inputText = displayed ? formatAuditValue(auditInput(displayed), "No input recorded") : ""
+  const duration = displayed ? durationLabel(displayed) : ""
   const detailHeight = width >= 110 ? "100%" : Math.max(14, Math.floor(height * 0.42))
 
   return (
@@ -277,16 +305,16 @@ export function AuditScreen({
             gap: 1,
           }}
         >
-          {current ? (
+          {displayed ? (
             <>
               <box style={{ height: 1, flexDirection: "row" }}>
-                <text fg={colors.accent} attributes={1} content={current.tool || current.event} />
+                <text fg={colors.accent} attributes={1} content={displayed.tool || displayed.event} />
                 <box style={{ flexGrow: 1 }} />
-                <text fg={entryColor(current)} attributes={1} content={statusLabel(current)} />
+                <text fg={entryColor(displayed)} attributes={1} content={statusLabel(displayed)} />
               </box>
               <text
                 fg={theme.faint}
-                content={`${new Date(current.ts * 1000).toLocaleString()} · ${current.node}${duration ? ` · ${duration}` : ""}`}
+                content={`${new Date(displayed.ts * 1000).toLocaleString()} · ${displayed.node}${duration ? ` · ${duration}` : ""}`}
               />
               <Panel title="Call result" style={{ flexGrow: 1, padding: 1 }}>
                 <scrollbox focused={false} style={{ flexGrow: 1 }} scrollY verticalScrollbarOptions={{ visible: true }}>


### PR DESCRIPTION
## Summary
- stop irreversibly truncating MCP tool arguments and results before audit storage
- keep small values inline and write large values as gzip-compressed, content-addressed JSON payloads under the state directory
- retain bounded previews in the JSONL audit index so list and filter responses stay compact
- add an authenticated audit-detail endpoint and load the complete selected record lazily in OpenTUI/WebUI
- prune payload files when their audit-log references are removed during retention trimming
- add regression coverage for full payload recovery, preview behavior, endpoint loading, and payload cleanup

## Validation
- `PYTHONPATH=src pytest -q` — 457 passed
- branch coverage — 93.9% total; `audit.py` 93.7%
- `bun test` — 25 passed
- `bun x tsc --noEmit`
- `ruff check src tests`
- secret scan: no findings
