### PR TITLE
Fix terminal output viewport and scrolling

### DIFF
--- a/scripts/ui-smoke.py
+++ b/scripts/ui-smoke.py
@@ -149,6 +149,16 @@ def wait_for_terminal_text(page: Page, needle: str, timeout_s: float = 10) -> No
     raise AssertionError(f"Terminal text did not contain {needle!r}\n{text[-5000:]}")
 
 
+def wait_for_terminal_text_absent(page: Page, needle: str, timeout_s: float = 10) -> None:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if needle not in page.locator("body").inner_text():
+            return
+        page.wait_for_timeout(100)
+    text = page.locator("body").inner_text()
+    raise AssertionError(f"Terminal text still contained {needle!r}\n{text[-5000:]}")
+
+
 def wait_for_terminal_output(
     page: Page, session_id: str, needle: str, timeout_s: float = 10
 ) -> None:
@@ -264,7 +274,8 @@ def run_browser(port: int) -> None:
             page.wait_for_timeout(500)
             assert "MCP audit · manual input excluded" in page.locator("body").inner_text()
             page.keyboard.press("F8")
-            wait_for_terminal_text(page, "F8 raw mode")
+            wait_for_terminal_text_absent(page, "RAW INPUT")
+            wait_for_terminal_text(page, "Enter a command…")
 
             page.keyboard.type(r"printf 'INPUT-CLEAR-ONE\n'")
             page.keyboard.press("Enter")

--- a/scripts/ui-smoke.py
+++ b/scripts/ui-smoke.py
@@ -290,9 +290,20 @@ def run_browser(port: int) -> None:
             page.keyboard.press("Enter")
             wait_for_terminal_output(page, second_session_id, "SCROLL-LINE-120")
             wait_for_terminal_text(page, "SCROLL-LINE-120")
+            initial_bottom_lines = visible_scroll_line_numbers(page)
+            assert 120 in initial_bottom_lines, initial_bottom_lines
             page.keyboard.press("PageUp")
             page.keyboard.press("PageUp")
-            wait_for_terminal_text(page, "SCROLL-LINE-080")
+            deadline = time.monotonic() + 8
+            while time.monotonic() < deadline:
+                older_lines = visible_scroll_line_numbers(page)
+                if older_lines and min(older_lines) < min(initial_bottom_lines) and 120 not in older_lines:
+                    break
+                page.wait_for_timeout(100)
+            else:
+                raise AssertionError(
+                    f"PageUp did not reveal older output: {initial_bottom_lines!r}"
+                )
             page.keyboard.press("PageDown")
             page.keyboard.press("PageDown")
             wait_for_terminal_text(page, "SCROLL-LINE-120")

--- a/scripts/ui-smoke.py
+++ b/scripts/ui-smoke.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import socket
 import subprocess
 import sys
@@ -11,6 +12,7 @@ import urllib.error
 import urllib.request
 from contextlib import suppress
 from pathlib import Path
+from urllib.parse import quote
 
 from playwright.sync_api import Page, sync_playwright
 
@@ -45,6 +47,14 @@ def wait_for_health(port: int, process: subprocess.Popen[str], timeout_s: float 
 
 def xterm_rows(page: Page) -> list[str]:
     return page.locator(".xterm-rows > div").all_text_contents()
+
+
+def visible_scroll_line_numbers(page: Page) -> list[int]:
+    return [
+        int(match)
+        for row in xterm_rows(page)
+        for match in re.findall(r"SCROLL-LINE-(\d+)", row)
+    ]
 
 
 def click_tui_label(page: Page, label: str, occurrence: int = 0) -> None:
@@ -137,6 +147,27 @@ def wait_for_terminal_text(page: Page, needle: str, timeout_s: float = 10) -> No
         page.wait_for_timeout(100)
     text = page.locator("body").inner_text()
     raise AssertionError(f"Terminal text did not contain {needle!r}\n{text[-5000:]}")
+
+
+def wait_for_terminal_output(
+    page: Page, session_id: str, needle: str, timeout_s: float = 10
+) -> None:
+    deadline = time.monotonic() + timeout_s
+    output = ""
+    path = (
+        "/api/ui/terminals/read?machine=local"
+        f"&session_id={quote(session_id)}&lines=500"
+    )
+    while time.monotonic() < deadline:
+        response = api_request(page, path)
+        assert response["status"] == 200, response
+        output = response["body"]["data"]["output"]
+        if needle in output:
+            return
+        page.wait_for_timeout(100)
+    raise AssertionError(
+        f"Terminal API output did not contain {needle!r}\n{output[-5000:]}"
+    )
 
 
 def run_browser(port: int) -> None:
@@ -234,6 +265,43 @@ def run_browser(port: int) -> None:
             assert "MCP audit · manual input excluded" in page.locator("body").inner_text()
             page.keyboard.press("F8")
             wait_for_terminal_text(page, "F8 raw mode")
+
+            page.keyboard.type(r"printf 'INPUT-CLEAR-ONE\n'")
+            page.keyboard.press("Enter")
+            wait_for_terminal_output(page, second_session_id, "INPUT-CLEAR-ONE")
+            wait_for_terminal_text(page, "INPUT-CLEAR-ONE")
+            page.keyboard.type(r"printf 'INPUT-CLEAR-TWO\n'")
+            page.keyboard.press("Enter")
+            wait_for_terminal_output(page, second_session_id, "INPUT-CLEAR-TWO")
+            wait_for_terminal_text(page, "INPUT-CLEAR-TWO")
+
+            page.keyboard.type("seq -f 'SCROLL-LINE-%03g' 1 120")
+            page.keyboard.press("Enter")
+            wait_for_terminal_output(page, second_session_id, "SCROLL-LINE-120")
+            wait_for_terminal_text(page, "SCROLL-LINE-120")
+            page.keyboard.press("PageUp")
+            page.keyboard.press("PageUp")
+            wait_for_terminal_text(page, "SCROLL-LINE-080")
+            page.keyboard.press("PageDown")
+            page.keyboard.press("PageDown")
+            wait_for_terminal_text(page, "SCROLL-LINE-120")
+
+            bottom_lines = visible_scroll_line_numbers(page)
+            assert 120 in bottom_lines, bottom_lines
+            click_tui_label(page, "SCROLL-LINE-115")
+            page.mouse.wheel(0, -600)
+            deadline = time.monotonic() + 8
+            while time.monotonic() < deadline:
+                wheel_lines = visible_scroll_line_numbers(page)
+                if wheel_lines and min(wheel_lines) < min(bottom_lines):
+                    break
+                page.wait_for_timeout(100)
+            else:
+                raise AssertionError(
+                    f"Terminal mouse wheel did not reveal older output: {bottom_lines!r}"
+                )
+            page.mouse.wheel(0, 600)
+            wait_for_terminal_text(page, "SCROLL-LINE-120")
 
             click_tui_label(page, "Todos")
             wait_for_terminal_text(page, "mouse todo second")

--- a/scripts/ui-smoke.py
+++ b/scripts/ui-smoke.py
@@ -304,26 +304,62 @@ def run_browser(port: int) -> None:
                 raise AssertionError(
                     f"PageUp did not reveal older output: {initial_bottom_lines!r}"
                 )
-            page.keyboard.press("PageDown")
-            page.keyboard.press("PageDown")
-            wait_for_terminal_text(page, "SCROLL-LINE-120")
 
-            bottom_lines = visible_scroll_line_numbers(page)
-            assert 120 in bottom_lines, bottom_lines
-            click_tui_label(page, "SCROLL-LINE-115")
+            click_tui_label(page, f"SCROLL-LINE-{older_lines[-1]:03d}")
             page.mouse.wheel(0, -600)
             deadline = time.monotonic() + 8
             while time.monotonic() < deadline:
                 wheel_lines = visible_scroll_line_numbers(page)
-                if wheel_lines and min(wheel_lines) < min(bottom_lines):
+                if wheel_lines and min(wheel_lines) < min(older_lines):
                     break
                 page.wait_for_timeout(100)
             else:
                 raise AssertionError(
-                    f"Terminal mouse wheel did not reveal older output: {bottom_lines!r}"
+                    f"Terminal mouse wheel did not reveal older output: {older_lines!r}"
                 )
-            page.mouse.wheel(0, 600)
+            page.keyboard.press("PageDown")
+            page.keyboard.press("PageDown")
+            page.keyboard.press("PageDown")
             wait_for_terminal_text(page, "SCROLL-LINE-120")
+
+            before_freeze_bottom = visible_scroll_line_numbers(page)
+            page.keyboard.press("PageUp")
+            page.keyboard.press("PageUp")
+            deadline = time.monotonic() + 8
+            while time.monotonic() < deadline:
+                frozen_lines = visible_scroll_line_numbers(page)
+                if (
+                    frozen_lines
+                    and before_freeze_bottom
+                    and min(frozen_lines) < min(before_freeze_bottom)
+                    and 120 not in frozen_lines
+                ):
+                    break
+                page.wait_for_timeout(100)
+            else:
+                raise AssertionError(
+                    f"PageUp did not establish a frozen history view: {before_freeze_bottom!r}"
+                )
+            repeated = api_request(
+                page,
+                "/api/ui/terminals/send",
+                "POST",
+                {
+                    "machine": "local",
+                    "session_id": second_session_id,
+                    "input_text": "for i in $(seq 1 40); do echo REPEAT-$((i % 2)); done; echo REPEAT-END",
+                    "enter": True,
+                },
+            )
+            assert repeated["status"] == 200, repeated
+            wait_for_terminal_output(page, second_session_id, "REPEAT-END")
+            page.wait_for_timeout(1_200)
+            frozen_after_output = visible_scroll_line_numbers(page)
+            assert frozen_after_output == frozen_lines, (frozen_lines, frozen_after_output)
+
+            page.keyboard.press("PageDown")
+            page.keyboard.press("PageDown")
+            wait_for_terminal_text(page, "REPEAT-END")
 
             click_tui_label(page, "Todos")
             wait_for_terminal_text(page, "mouse todo second")

--- a/ui/src/terminal-output.test.ts
+++ b/ui/src/terminal-output.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import {
-  appendedTerminalRows,
+  terminalCellWidth,
   terminalDisplayRows,
   terminalOutputLines,
   terminalScrollLimit,
@@ -27,19 +27,21 @@ describe("terminal output viewport", () => {
     expect(visibleTerminalOutput(lines, 3, 99)).toBe("line-1\nline-2\nline-3")
   })
 
-  test("wraps long rows without counting ANSI control sequences", () => {
+  test("wraps long rows and carries ANSI styles across render rows", () => {
     expect(wrapTerminalLine("abcdefgh", 3)).toEqual(["abc", "def", "gh"])
     expect(wrapTerminalLine("\x1b[31mabcdef\x1b[0m", 3)).toEqual([
-      "\x1b[31mabc",
-      "def\x1b[0m",
+      "\x1b[31mabc\x1b[0m",
+      "\x1b[31mdef\x1b[0m",
     ])
     expect(terminalDisplayRows("abcdef\nxy", 3)).toEqual(["abc", "def", "xy"])
   })
 
-  test("detects appended rows when a capped tail shifts", () => {
-    expect(appendedTerminalRows(["1", "2", "3"], ["1", "2", "3", "4"])).toBe(1)
-    expect(appendedTerminalRows(["1", "2", "3"], ["2", "3", "4"])).toBe(1)
-    expect(appendedTerminalRows(["1", "2", "3"], ["changed", "rows", "only"])).toBe(0)
+  test("counts terminal cells for CJK, combining marks, and emoji", () => {
+    expect(terminalCellWidth("a")).toBe(1)
+    expect(terminalCellWidth("e\u0301")).toBe(1)
+    expect(terminalCellWidth("界")).toBe(2)
+    expect(terminalCellWidth("👩‍💻")).toBe(2)
+    expect(wrapTerminalLine("中文ab", 4)).toEqual(["中文", "ab"])
   })
 
   test("keeps a useful viewport on common terminal heights", () => {

--- a/ui/src/terminal-output.test.ts
+++ b/ui/src/terminal-output.test.ts
@@ -33,6 +33,14 @@ describe("terminal output viewport", () => {
       "\x1b[31mabc\x1b[0m",
       "\x1b[31mdef\x1b[0m",
     ])
+    expect(wrapTerminalLine("\x1b[38;2;0;255;0mabcdef\x1b[0m", 3)).toEqual([
+      "\x1b[38;2;0;255;0mabc\x1b[0m",
+      "\x1b[38;2;0;255;0mdef\x1b[0m",
+    ])
+    expect(wrapTerminalLine("\x1b[38;5;0mabcdef\x1b[0m", 3)).toEqual([
+      "\x1b[38;5;0mabc\x1b[0m",
+      "\x1b[38;5;0mdef\x1b[0m",
+    ])
     expect(terminalDisplayRows("abcdef\nxy", 3)).toEqual(["abc", "def", "xy"])
   })
 

--- a/ui/src/terminal-output.test.ts
+++ b/ui/src/terminal-output.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test"
+import {
+  terminalOutputLines,
+  terminalScrollLimit,
+  visibleTerminalOutput,
+} from "./terminal-output"
+
+describe("terminal output viewport", () => {
+  test("removes blank pane rows after the meaningful terminal output", () => {
+    expect(terminalOutputLines("prompt\nresult\n\n   \n")).toEqual(["prompt", "result"])
+    expect(terminalOutputLines("prompt\n\x1b[0m   \n")).toEqual(["prompt"])
+  })
+
+  test("shows the newest rows without overestimating the viewport", () => {
+    const lines = Array.from({ length: 8 }, (_, index) => `line-${index + 1}`)
+    expect(visibleTerminalOutput(lines, 3, 0)).toBe("line-6\nline-7\nline-8")
+    expect(terminalScrollLimit(lines.length, 3)).toBe(5)
+  })
+
+  test("moves backward through history and clamps excessive offsets", () => {
+    const lines = Array.from({ length: 8 }, (_, index) => `line-${index + 1}`)
+    expect(visibleTerminalOutput(lines, 3, 3)).toBe("line-3\nline-4\nline-5")
+    expect(visibleTerminalOutput(lines, 3, 99)).toBe("line-1\nline-2\nline-3")
+  })
+})

--- a/ui/src/terminal-output.test.ts
+++ b/ui/src/terminal-output.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from "bun:test"
 import {
+  appendedTerminalRows,
+  terminalDisplayRows,
   terminalOutputLines,
   terminalScrollLimit,
+  terminalViewportRows,
   visibleTerminalOutput,
+  wrapTerminalLine,
 } from "./terminal-output"
 
 describe("terminal output viewport", () => {
@@ -21,5 +25,26 @@ describe("terminal output viewport", () => {
     const lines = Array.from({ length: 8 }, (_, index) => `line-${index + 1}`)
     expect(visibleTerminalOutput(lines, 3, 3)).toBe("line-3\nline-4\nline-5")
     expect(visibleTerminalOutput(lines, 3, 99)).toBe("line-1\nline-2\nline-3")
+  })
+
+  test("wraps long rows without counting ANSI control sequences", () => {
+    expect(wrapTerminalLine("abcdefgh", 3)).toEqual(["abc", "def", "gh"])
+    expect(wrapTerminalLine("\x1b[31mabcdef\x1b[0m", 3)).toEqual([
+      "\x1b[31mabc",
+      "def\x1b[0m",
+    ])
+    expect(terminalDisplayRows("abcdef\nxy", 3)).toEqual(["abc", "def", "xy"])
+  })
+
+  test("detects appended rows when a capped tail shifts", () => {
+    expect(appendedTerminalRows(["1", "2", "3"], ["1", "2", "3", "4"])).toBe(1)
+    expect(appendedTerminalRows(["1", "2", "3"], ["2", "3", "4"])).toBe(1)
+    expect(appendedTerminalRows(["1", "2", "3"], ["changed", "rows", "only"])).toBe(0)
+  })
+
+  test("keeps a useful viewport on common terminal heights", () => {
+    expect(terminalViewportRows(19)).toBe(4)
+    expect(terminalViewportRows(43)).toBe(28)
+    expect(terminalViewportRows(10)).toBe(3)
   })
 })

--- a/ui/src/terminal-output.ts
+++ b/ui/src/terminal-output.ts
@@ -1,4 +1,5 @@
 const ANSI_ESCAPE = /\x1b\[[0-?]*[ -/]*[@-~]/g
+const ANSI_ESCAPE_PREFIX = /^\x1b\[[0-?]*[ -/]*[@-~]/
 
 function isVisuallyBlank(line: string): boolean {
   return line.replace(ANSI_ESCAPE, "").trim().length === 0
@@ -10,6 +11,59 @@ export function terminalOutputLines(output: string): string[] {
     lines.pop()
   }
   return lines
+}
+
+export function wrapTerminalLine(line: string, columns: number): string[] {
+  const width = Math.max(1, columns)
+  const rows: string[] = []
+  let current = ""
+  let visibleColumns = 0
+  let index = 0
+  while (index < line.length) {
+    const remainder = line.slice(index)
+    const escape = remainder.match(ANSI_ESCAPE_PREFIX)?.[0]
+    if (escape) {
+      current += escape
+      index += escape.length
+      continue
+    }
+    if (visibleColumns >= width) {
+      rows.push(current)
+      current = ""
+      visibleColumns = 0
+    }
+    const codePoint = line.codePointAt(index)
+    if (codePoint === undefined) break
+    const character = String.fromCodePoint(codePoint)
+    current += character
+    visibleColumns += 1
+    index += character.length
+  }
+  rows.push(current)
+  return rows
+}
+
+export function terminalDisplayRows(output: string, columns: number): string[] {
+  return terminalOutputLines(output).flatMap((line) => wrapTerminalLine(line, columns))
+}
+
+export function terminalViewportRows(screenHeight: number): number {
+  return Math.max(3, screenHeight - 15)
+}
+
+export function appendedTerminalRows(previous: string[], next: string[]): number {
+  const maxOverlap = Math.min(previous.length, next.length)
+  for (let overlap = maxOverlap; overlap > 0; overlap -= 1) {
+    let matches = true
+    for (let index = 0; index < overlap; index += 1) {
+      if (previous[previous.length - overlap + index] !== next[index]) {
+        matches = false
+        break
+      }
+    }
+    if (matches) return next.length - overlap
+  }
+  return Math.max(0, next.length - previous.length)
 }
 
 export function terminalScrollLimit(lineCount: number, rows: number): number {

--- a/ui/src/terminal-output.ts
+++ b/ui/src/terminal-output.ts
@@ -1,0 +1,36 @@
+const ANSI_ESCAPE = /\x1b\[[0-?]*[ -/]*[@-~]/g
+
+function isVisuallyBlank(line: string): boolean {
+  return line.replace(ANSI_ESCAPE, "").trim().length === 0
+}
+
+export function terminalOutputLines(output: string): string[] {
+  const lines = (output || "Terminal is ready.").split(/\r?\n/)
+  while (lines.length > 1 && isVisuallyBlank(lines[lines.length - 1]!)) {
+    lines.pop()
+  }
+  return lines
+}
+
+export function terminalScrollLimit(lineCount: number, rows: number): number {
+  return Math.max(0, lineCount - Math.max(1, rows))
+}
+
+export function visibleTerminalLines(
+  lines: string[],
+  rows: number,
+  scrollOffset: number,
+): string[] {
+  const viewportRows = Math.max(1, rows)
+  const safeOffset = Math.max(0, Math.min(scrollOffset, terminalScrollLimit(lines.length, viewportRows)))
+  const end = lines.length - safeOffset
+  return lines.slice(Math.max(0, end - viewportRows), end)
+}
+
+export function visibleTerminalOutput(
+  lines: string[],
+  rows: number,
+  scrollOffset: number,
+): string {
+  return visibleTerminalLines(lines, rows, scrollOffset).join("\n")
+}

--- a/ui/src/terminal-output.ts
+++ b/ui/src/terminal-output.ts
@@ -39,11 +39,26 @@ export function terminalCellWidth(grapheme: string): number {
   return hasVisible ? 1 : 0
 }
 
+function sgrResetIndex(parameters: number[]): number {
+  let lastReset = -1
+  for (let index = 0; index < parameters.length; index += 1) {
+    const parameter = parameters[index]!
+    if (parameter === 38 || parameter === 48 || parameter === 58) {
+      const mode = parameters[index + 1]
+      if (mode === 2) index += 4
+      else if (mode === 5) index += 2
+      continue
+    }
+    if (parameter === 0) lastReset = index
+  }
+  return lastReset
+}
+
 function nextSgrState(current: string, escape: string): string {
   if (!escape.endsWith("m")) return current
   const rawParameters = escape.slice(2, -1)
   const parameters = rawParameters === "" ? [0] : rawParameters.split(";").map((value) => Number(value || 0))
-  const lastReset = parameters.lastIndexOf(0)
+  const lastReset = sgrResetIndex(parameters)
   if (lastReset < 0) return current + escape
   const remaining = parameters.slice(lastReset + 1)
   return remaining.length > 0 ? `\x1b[${remaining.join(";")}m` : ""

--- a/ui/src/terminal-output.ts
+++ b/ui/src/terminal-output.ts
@@ -1,5 +1,53 @@
 const ANSI_ESCAPE = /\x1b\[[0-?]*[ -/]*[@-~]/g
 const ANSI_ESCAPE_PREFIX = /^\x1b\[[0-?]*[ -/]*[@-~]/
+const ANSI_RESET = "\x1b[0m"
+const GRAPHEME_SEGMENTER = new Intl.Segmenter(undefined, { granularity: "grapheme" })
+const UNICODE_MARK = /^\p{Mark}+$/u
+
+function isWideCodePoint(codePoint: number): boolean {
+  return codePoint >= 0x1100 && (
+    codePoint <= 0x115f
+    || codePoint === 0x2329
+    || codePoint === 0x232a
+    || (codePoint >= 0x2e80 && codePoint <= 0xa4cf && codePoint !== 0x303f)
+    || (codePoint >= 0xac00 && codePoint <= 0xd7a3)
+    || (codePoint >= 0xf900 && codePoint <= 0xfaff)
+    || (codePoint >= 0xfe10 && codePoint <= 0xfe19)
+    || (codePoint >= 0xfe30 && codePoint <= 0xfe6f)
+    || (codePoint >= 0xff00 && codePoint <= 0xff60)
+    || (codePoint >= 0xffe0 && codePoint <= 0xffe6)
+    || (codePoint >= 0x1f1e6 && codePoint <= 0x1f1ff)
+    || (codePoint >= 0x1f300 && codePoint <= 0x1faff)
+    || (codePoint >= 0x20000 && codePoint <= 0x3fffd)
+  )
+}
+
+export function terminalCellWidth(grapheme: string): number {
+  let hasVisible = false
+  for (const character of grapheme) {
+    const codePoint = character.codePointAt(0)!
+    if (
+      codePoint === 0x200d
+      || (codePoint >= 0xfe00 && codePoint <= 0xfe0f)
+      || (codePoint >= 0xe0100 && codePoint <= 0xe01ef)
+      || UNICODE_MARK.test(character)
+    ) continue
+    if (codePoint < 0x20 || (codePoint >= 0x7f && codePoint < 0xa0)) continue
+    hasVisible = true
+    if (isWideCodePoint(codePoint)) return 2
+  }
+  return hasVisible ? 1 : 0
+}
+
+function nextSgrState(current: string, escape: string): string {
+  if (!escape.endsWith("m")) return current
+  const rawParameters = escape.slice(2, -1)
+  const parameters = rawParameters === "" ? [0] : rawParameters.split(";").map((value) => Number(value || 0))
+  const lastReset = parameters.lastIndexOf(0)
+  if (lastReset < 0) return current + escape
+  const remaining = parameters.slice(lastReset + 1)
+  return remaining.length > 0 ? `\x1b[${remaining.join(";")}m` : ""
+}
 
 function isVisuallyBlank(line: string): boolean {
   return line.replace(ANSI_ESCAPE, "").trim().length === 0
@@ -17,29 +65,41 @@ export function wrapTerminalLine(line: string, columns: number): string[] {
   const width = Math.max(1, columns)
   const rows: string[] = []
   let current = ""
+  let activeSgr = ""
   let visibleColumns = 0
   let index = 0
+
+  const emitRow = () => {
+    rows.push(activeSgr ? `${current}${ANSI_RESET}` : current)
+    current = activeSgr
+    visibleColumns = 0
+  }
+
   while (index < line.length) {
     const remainder = line.slice(index)
     const escape = remainder.match(ANSI_ESCAPE_PREFIX)?.[0]
     if (escape) {
       current += escape
+      activeSgr = nextSgrState(activeSgr, escape)
       index += escape.length
       continue
     }
-    if (visibleColumns >= width) {
-      rows.push(current)
-      current = ""
-      visibleColumns = 0
+
+    const nextEscape = remainder.indexOf("\x1b")
+    const plainText = nextEscape < 0 ? remainder : remainder.slice(0, nextEscape)
+    const segment = GRAPHEME_SEGMENTER.segment(plainText)[Symbol.iterator]().next().value?.segment
+    if (!segment) {
+      current += remainder[0] || ""
+      index += 1
+      continue
     }
-    const codePoint = line.codePointAt(index)
-    if (codePoint === undefined) break
-    const character = String.fromCodePoint(codePoint)
-    current += character
-    visibleColumns += 1
-    index += character.length
+    const cellWidth = terminalCellWidth(segment)
+    if (visibleColumns > 0 && visibleColumns + cellWidth > width) emitRow()
+    current += segment
+    visibleColumns += cellWidth
+    index += segment.length
   }
-  rows.push(current)
+  rows.push(activeSgr ? `${current}${ANSI_RESET}` : current)
   return rows
 }
 
@@ -49,21 +109,6 @@ export function terminalDisplayRows(output: string, columns: number): string[] {
 
 export function terminalViewportRows(screenHeight: number): number {
   return Math.max(3, screenHeight - 15)
-}
-
-export function appendedTerminalRows(previous: string[], next: string[]): number {
-  const maxOverlap = Math.min(previous.length, next.length)
-  for (let overlap = maxOverlap; overlap > 0; overlap -= 1) {
-    let matches = true
-    for (let index = 0; index < overlap; index += 1) {
-      if (previous[previous.length - overlap + index] !== next[index]) {
-        matches = false
-        break
-      }
-    }
-    if (matches) return next.length - overlap
-  }
-  return Math.max(0, next.length - previous.length)
 }
 
 export function terminalScrollLimit(lineCount: number, rows: number): number {

--- a/ui/src/terminals-screen.tsx
+++ b/ui/src/terminals-screen.tsx
@@ -5,7 +5,6 @@ import { api, formatError } from "./api"
 import { EmptyState, KeyHint, MachineSidebar, Modal, Panel, formatAge } from "./components"
 import { clampIndex, scopedItems } from "./state-utils"
 import {
-  appendedTerminalRows,
   terminalDisplayRows,
   terminalScrollLimit,
   terminalViewportRows,
@@ -116,7 +115,8 @@ export function TerminalsScreen({
   const [dialog, setDialog] = useState<TerminalDialog>({ type: "none" })
   const [busy, setBusy] = useState(false)
   const commandInputRef = useRef<InputRenderable | null>(null)
-  const outputRowsRef = useRef<string[]>([])
+  const scrollOffsetRef = useRef(0)
+  const pendingOutputRef = useRef<string | null>(null)
   const rawQueue = useRef<Promise<void>>(Promise.resolve())
   const sessionsRequest = useRef(0)
   const outputRequest = useRef(0)
@@ -144,7 +144,11 @@ export function TerminalsScreen({
   const visibleLines = visibleTerminalLines(outputRows, terminalRows, safeScrollOffset)
 
   const scrollOutput = useCallback((delta: number) => {
-    setScrollOffset((current) => Math.max(0, Math.min(maxScrollOffset, current + delta)))
+    setScrollOffset((current) => {
+      const next = Math.max(0, Math.min(maxScrollOffset, current + delta))
+      scrollOffsetRef.current = next
+      return next
+    })
   }, [maxScrollOffset])
 
   const handleOutputScroll = (event: OpenTUIMouseEvent) => {
@@ -229,7 +233,8 @@ export function TerminalsScreen({
         selectedSessionIdRef.current !== targetSession ||
         controller.signal.aborted
       ) return
-      setOutput(terminal.output)
+      if (scrollOffsetRef.current > 0) pendingOutputRef.current = terminal.output
+      else setOutput(terminal.output)
       setAudit(records.entries)
     } catch (error) {
       if (!controller.signal.aborted) setStatus(`Terminal: ${formatError(error)}`)
@@ -246,6 +251,9 @@ export function TerminalsScreen({
     setSelectedSessionId(null)
     selectedSessionIdRef.current = null
     setOutput("")
+    pendingOutputRef.current = null
+    scrollOffsetRef.current = 0
+    setScrollOffset(0)
     setAudit([])
     setDialog({ type: "none" })
     setRawMode(false)
@@ -290,21 +298,21 @@ export function TerminalsScreen({
   }, [rawMode, selectedSession])
 
   useEffect(() => {
+    pendingOutputRef.current = null
+    scrollOffsetRef.current = 0
     setScrollOffset(0)
-    outputRowsRef.current = outputRows
   }, [machine, selectedSession?.session_id])
 
   useEffect(() => {
-    const addedRows = appendedTerminalRows(outputRowsRef.current, outputRows)
-    if (addedRows > 0) {
-      setScrollOffset((current) => current === 0
-        ? 0
-        : Math.min(maxScrollOffset, current + addedRows))
-    } else {
-      setScrollOffset((current) => Math.min(current, maxScrollOffset))
+    const clamped = Math.min(scrollOffset, maxScrollOffset)
+    if (clamped !== scrollOffset) setScrollOffset(clamped)
+    scrollOffsetRef.current = clamped
+    if (clamped === 0 && pendingOutputRef.current !== null) {
+      const pending = pendingOutputRef.current
+      pendingOutputRef.current = null
+      setOutput(pending)
     }
-    outputRowsRef.current = outputRows
-  }, [maxScrollOffset, outputRows])
+  }, [maxScrollOffset, scrollOffset])
 
   const send = async (inputText: string, enter = true) => {
     if (!selectedSession || inputText.length === 0) return
@@ -343,6 +351,8 @@ export function TerminalsScreen({
 
   const submitCommand = (value: string) => {
     if (!selectedSession || value.length === 0) return
+    pendingOutputRef.current = null
+    scrollOffsetRef.current = 0
     setScrollOffset(0)
     if (commandInputRef.current) commandInputRef.current.value = ""
     void send(value, true)
@@ -384,6 +394,9 @@ export function TerminalsScreen({
     setSelectedSessionId(null)
     selectedSessionIdRef.current = null
     setOutput("")
+    pendingOutputRef.current = null
+    scrollOffsetRef.current = 0
+    setScrollOffset(0)
     setAudit([])
     setDialog({ type: "none" })
     setRawMode(false)

--- a/ui/src/terminals-screen.tsx
+++ b/ui/src/terminals-screen.tsx
@@ -4,7 +4,13 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { api, formatError } from "./api"
 import { EmptyState, KeyHint, MachineSidebar, Modal, Panel, formatAge } from "./components"
 import { clampIndex, scopedItems } from "./state-utils"
-import { terminalOutputLines, terminalScrollLimit, visibleTerminalLines } from "./terminal-output"
+import {
+  appendedTerminalRows,
+  terminalDisplayRows,
+  terminalScrollLimit,
+  terminalViewportRows,
+  visibleTerminalLines,
+} from "./terminal-output"
 import { screenTheme, theme } from "./theme"
 import type { AuditEntry, Machine, TerminalSession } from "./types"
 
@@ -110,7 +116,7 @@ export function TerminalsScreen({
   const [dialog, setDialog] = useState<TerminalDialog>({ type: "none" })
   const [busy, setBusy] = useState(false)
   const commandInputRef = useRef<InputRenderable | null>(null)
-  const outputLineCountRef = useRef(0)
+  const outputRowsRef = useRef<string[]>([])
   const rawQueue = useRef<Promise<void>>(Promise.resolve())
   const sessionsRequest = useRef(0)
   const outputRequest = useRef(0)
@@ -125,11 +131,17 @@ export function TerminalsScreen({
   machineRef.current = machine
   selectedSessionIdRef.current = selectedSession?.session_id || null
   const compact = width < 96
-  const terminalRows = Math.max(1, height - 20)
-  const outputLines = useMemo(() => terminalOutputLines(output), [output])
-  const maxScrollOffset = terminalScrollLimit(outputLines.length, terminalRows)
+  const sidebarColumns = compact ? 0 : 24
+  const auditColumns = showAudit ? Math.max(30, Math.floor(width * 0.28)) + 1 : 0
+  const terminalColumns = Math.max(20, width - sidebarColumns - auditColumns - 6)
+  const terminalRows = terminalViewportRows(height)
+  const outputRows = useMemo(
+    () => terminalDisplayRows(output, terminalColumns),
+    [output, terminalColumns],
+  )
+  const maxScrollOffset = terminalScrollLimit(outputRows.length, terminalRows)
   const safeScrollOffset = Math.min(scrollOffset, maxScrollOffset)
-  const visibleLines = visibleTerminalLines(outputLines, terminalRows, safeScrollOffset)
+  const visibleLines = visibleTerminalLines(outputRows, terminalRows, safeScrollOffset)
 
   const scrollOutput = useCallback((delta: number) => {
     setScrollOffset((current) => Math.max(0, Math.min(maxScrollOffset, current + delta)))
@@ -279,22 +291,20 @@ export function TerminalsScreen({
 
   useEffect(() => {
     setScrollOffset(0)
-    outputLineCountRef.current = outputLines.length
+    outputRowsRef.current = outputRows
   }, [machine, selectedSession?.session_id])
 
   useEffect(() => {
-    const previousCount = outputLineCountRef.current
-    const nextCount = outputLines.length
-    const addedLines = Math.max(0, nextCount - previousCount)
-    if (addedLines > 0) {
+    const addedRows = appendedTerminalRows(outputRowsRef.current, outputRows)
+    if (addedRows > 0) {
       setScrollOffset((current) => current === 0
         ? 0
-        : Math.min(maxScrollOffset, current + addedLines))
+        : Math.min(maxScrollOffset, current + addedRows))
     } else {
       setScrollOffset((current) => Math.min(current, maxScrollOffset))
     }
-    outputLineCountRef.current = nextCount
-  }, [maxScrollOffset, outputLines.length])
+    outputRowsRef.current = outputRows
+  }, [maxScrollOffset, outputRows])
 
   const send = async (inputText: string, enter = true) => {
     if (!selectedSession || inputText.length === 0) return
@@ -333,6 +343,7 @@ export function TerminalsScreen({
 
   const submitCommand = (value: string) => {
     if (!selectedSession || value.length === 0) return
+    setScrollOffset(0)
     if (commandInputRef.current) commandInputRef.current.value = ""
     void send(value, true)
   }

--- a/ui/src/terminals-screen.tsx
+++ b/ui/src/terminals-screen.tsx
@@ -1,8 +1,10 @@
+import type { InputRenderable, MouseEvent as OpenTUIMouseEvent } from "@opentui/core"
 import { useKeyboard } from "@opentui/react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { api, formatError } from "./api"
 import { EmptyState, KeyHint, MachineSidebar, Modal, Panel, formatAge } from "./components"
 import { clampIndex, scopedItems } from "./state-utils"
+import { terminalOutputLines, terminalScrollLimit, visibleTerminalLines } from "./terminal-output"
 import { screenTheme, theme } from "./theme"
 import type { AuditEntry, Machine, TerminalSession } from "./types"
 
@@ -104,8 +106,11 @@ export function TerminalsScreen({
   const [audit, setAudit] = useState<AuditEntry[]>([])
   const [showAudit, setShowAudit] = useState(width >= 118)
   const [rawMode, setRawMode] = useState(false)
+  const [scrollOffset, setScrollOffset] = useState(0)
   const [dialog, setDialog] = useState<TerminalDialog>({ type: "none" })
   const [busy, setBusy] = useState(false)
+  const commandInputRef = useRef<InputRenderable | null>(null)
+  const outputLineCountRef = useRef(0)
   const rawQueue = useRef<Promise<void>>(Promise.resolve())
   const sessionsRequest = useRef(0)
   const outputRequest = useRef(0)
@@ -120,6 +125,24 @@ export function TerminalsScreen({
   machineRef.current = machine
   selectedSessionIdRef.current = selectedSession?.session_id || null
   const compact = width < 96
+  const terminalRows = Math.max(1, height - 20)
+  const outputLines = useMemo(() => terminalOutputLines(output), [output])
+  const maxScrollOffset = terminalScrollLimit(outputLines.length, terminalRows)
+  const safeScrollOffset = Math.min(scrollOffset, maxScrollOffset)
+  const visibleLines = visibleTerminalLines(outputLines, terminalRows, safeScrollOffset)
+
+  const scrollOutput = useCallback((delta: number) => {
+    setScrollOffset((current) => Math.max(0, Math.min(maxScrollOffset, current + delta)))
+  }, [maxScrollOffset])
+
+  const handleOutputScroll = (event: OpenTUIMouseEvent) => {
+    const direction = event.scroll?.direction
+    if (direction !== "up" && direction !== "down") return
+    event.preventDefault()
+    event.stopPropagation()
+    const amount = Math.max(1, Math.ceil(Math.abs(event.scroll?.delta || 1))) * 3
+    scrollOutput(direction === "up" ? amount : -amount)
+  }
 
   const selectSession = useCallback((index: number) => {
     const nextIndex = clampIndex(index, activeSessions.length)
@@ -254,6 +277,25 @@ export function TerminalsScreen({
     if (!selectedSession && rawMode) setRawMode(false)
   }, [rawMode, selectedSession])
 
+  useEffect(() => {
+    setScrollOffset(0)
+    outputLineCountRef.current = outputLines.length
+  }, [machine, selectedSession?.session_id])
+
+  useEffect(() => {
+    const previousCount = outputLineCountRef.current
+    const nextCount = outputLines.length
+    const addedLines = Math.max(0, nextCount - previousCount)
+    if (addedLines > 0) {
+      setScrollOffset((current) => current === 0
+        ? 0
+        : Math.min(maxScrollOffset, current + addedLines))
+    } else {
+      setScrollOffset((current) => Math.min(current, maxScrollOffset))
+    }
+    outputLineCountRef.current = nextCount
+  }, [maxScrollOffset, outputLines.length])
+
   const send = async (inputText: string, enter = true) => {
     if (!selectedSession || inputText.length === 0) return
     setBusy(true)
@@ -287,6 +329,12 @@ export function TerminalsScreen({
         })
       })
       .catch((error) => setStatus(`Raw input: ${formatError(error)}`))
+  }
+
+  const submitCommand = (value: string) => {
+    if (!selectedSession || value.length === 0) return
+    if (commandInputRef.current) commandInputRef.current.value = ""
+    void send(value, true)
   }
 
   const startSession = async (value: string) => {
@@ -375,6 +423,14 @@ export function TerminalsScreen({
         setRawMode(true)
         setStatus("Raw input enabled · F8 to leave")
       }
+    } else if (key.name === "pageup" && selectedSession) {
+      key.preventDefault()
+      key.stopPropagation()
+      scrollOutput(terminalRows)
+    } else if (key.name === "pagedown" && selectedSession) {
+      key.preventDefault()
+      key.stopPropagation()
+      scrollOutput(-terminalRows)
     } else if ((key.option || key.meta) && key.name === "[") switchMachine(-1)
     else if ((key.option || key.meta) && key.name === "]") switchMachine(1)
     else if ((key.option || key.meta) && key.name === "left") selectSession(selected - 1)
@@ -384,10 +440,6 @@ export function TerminalsScreen({
     else if ((key.option || key.meta) && key.name === "a") setShowAudit((value) => !value)
     else if ((key.option || key.meta) && key.name === "r") void refreshOutput(true)
   })
-
-  const outputLines = useMemo(() => output.split("\n"), [output])
-  const terminalHeight = Math.max(8, height - 12)
-  const visibleOutput = outputLines.slice(-terminalHeight).join("\n")
 
   return (
     <box style={{ flexGrow: 1, flexDirection: "column" }}>
@@ -422,13 +474,21 @@ export function TerminalsScreen({
             />
             <box style={{ flexGrow: 1 }} />
             {rawMode && <text fg={theme.orange} attributes={1} content="RAW INPUT  " />}
+            {safeScrollOffset > 0 && <text fg={theme.yellow} content={`history -${safeScrollOffset}  `} />}
             {busy && <text fg={theme.yellow} content="sending  " />}
             <text fg={theme.faint} content={`${selectedSession?.backend || "—"}  `} />
           </box>
           <box style={{ flexGrow: 1, flexDirection: "row", gap: 1 }}>
             <Panel title="Terminal" active accent={colors.accent} activeBackground={colors.panel} style={{ flexGrow: 1, padding: 1 }}>
               {selectedSession ? (
-                <text fg={theme.text} content={visibleOutput || "Terminal is ready."} />
+                <box
+                  onMouseScroll={handleOutputScroll}
+                  style={{ flexGrow: 1, flexDirection: "column" }}
+                >
+                  {visibleLines.map((line, index) => (
+                    <text key={`${index}-${line}`} fg={theme.text} wrapMode="none" content={line || " "} />
+                  ))}
+                </box>
               ) : (
                 <EmptyState title="No persistent terminal" detail="Press Alt+N to create one" />
               )}
@@ -443,9 +503,10 @@ export function TerminalsScreen({
             <Panel title="Command" active={Boolean(selectedSession)} accent={colors.accent} activeBackground={colors.panel} style={{ flexGrow: 1, paddingLeft: 1, paddingRight: 1 }}>
               <input
                 key={selectedSession?.session_id || "no-session"}
+                ref={commandInputRef}
                 focused={Boolean(selectedSession) && !rawMode && dialog.type === "none"}
                 placeholder={selectedSession ? "Enter a command…" : "Create a terminal first"}
-                onSubmit={(value: unknown) => void send(typeof value === "string" ? value : "", true)}
+                onSubmit={(value: unknown) => submitCommand(typeof value === "string" ? value : "")}
               />
             </Panel>
           </box>
@@ -496,6 +557,7 @@ export function TerminalsScreen({
           ["Alt+N", "new"],
           ["Alt+W", "kill"],
           ["Alt+A", "audit"],
+          ["PgUp/PgDn", "scroll"],
           ["F8", "raw mode"],
           ["Alt+[ / ]", "machine"],
           ["Alt+R", "refresh"],

--- a/ui/src/tui.tsx
+++ b/ui/src/tui.tsx
@@ -25,7 +25,7 @@ function Help({ close }: { close: () => void }) {
       <text fg={theme.borderBright} content="\nScreen conventions" />
       <text fg={theme.muted} content="j/k or arrows move selection · Enter activates · Esc closes dialogs" />
       <text fg={theme.muted} content="[ / ] switches Files machines · Alt+[ / ] switches Terminal machines" />
-      <text fg={theme.muted} content="Terminals: Alt+N new · Alt+W kill · Alt+A audit · Alt+R refresh" />
+      <text fg={theme.muted} content="Terminals: Alt+N new · Alt+W kill · PgUp/PgDn scroll · Alt+R refresh" />
       <text fg={theme.muted} content="The footer on every screen lists its contextual commands." />
       <text fg={theme.borderBright} content="\nAudit policy" />
       <text fg={theme.muted} content="Audit contains MCP-originated operations. Actions typed by a human in this TUI or the WebUI are intentionally excluded." />


### PR DESCRIPTION
## Summary
- size the terminal output viewport to the actual available rows and trim blank tmux pane rows
- clear the command input immediately after submission without making fast typing lossy
- add PageUp/PageDown and mouse-wheel history scrolling while preserving bottom-follow behavior
- add focused viewport tests and browser regressions for newest-line visibility, command clearing, and scrolling

## Validation
- `bun run test` (28 passed, 94.84% line coverage)
- `bun run typecheck`
- `bun run build`
- `python3 scripts/ui-smoke.py`
- `python3 -m ruff check scripts/ui-smoke.py`
- `python3 -m pytest -q tests/test_human_ui.py tests/test_human_ui_complete.py` (47 passed)