### PR TITLE
fix(ui): stop file preview reload loop

### DIFF
--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -71,8 +71,14 @@ export const api = {
   files(machine: string, path: string, signal?: AbortSignal): Promise<FilesPayload> {
     return request(`/files${queryString({ machine, path })}`, { signal })
   },
-  filePreview(machine: string, path: string, columns?: number, rows?: number): Promise<FilePreview> {
-    return request(`/files/preview${queryString({ machine, path, columns, rows })}`)
+  filePreview(
+    machine: string,
+    path: string,
+    columns?: number,
+    rows?: number,
+    signal?: AbortSignal,
+  ): Promise<FilePreview> {
+    return request(`/files/preview${queryString({ machine, path, columns, rows })}`, { signal })
   },
   fileContent(machine: string, path: string): Promise<FilePreview> {
     return request(`/files/content${queryString({ machine, path })}`)

--- a/ui/src/files-screen.tsx
+++ b/ui/src/files-screen.tsx
@@ -3,7 +3,7 @@ import { useKeyboard } from "@opentui/react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { api, formatError } from "./api"
 import { EmptyState, KeyHint, MachineSidebar, Modal, Panel, formatBytes, useVisibleRows } from "./components"
-import { clampIndex, payloadMatches } from "./state-utils"
+import { clampIndex, nextPreviewMeasurement, payloadMatches } from "./state-utils"
 import { screenTheme, theme } from "./theme"
 import type { FileEntry, FilePreview, FilesPayload, Machine } from "./types"
 
@@ -196,6 +196,7 @@ export function FilesScreen({
   const editorRef = useRef<TextareaRenderable>(null)
   const refreshRequest = useRef(0)
   const refreshController = useRef<AbortController | null>(null)
+  const measuredPreviewViewport = useRef("")
   const machineRef = useRef(machine)
   machineRef.current = machine
   const activePayload = payloadMatches(payload, machine, path) ? payload : null
@@ -222,6 +223,7 @@ export function FilesScreen({
   )
   const previewColumns = previewBounds?.columns || fallbackPreviewColumns
   const previewRows = previewBounds?.rows || Math.max(4, listHeight - 3)
+  const previewViewport = `${width}x${height}:${narrow ? narrowPane : "split"}`
 
   const refresh = useCallback(async () => {
     const requestId = ++refreshRequest.current
@@ -267,22 +269,26 @@ export function FilesScreen({
   }, [refresh])
 
   useEffect(() => {
-    let cancelled = false
     setPreview(null)
-    if (!current) return
+  }, [current?.path, machine])
+
+  useEffect(() => {
+    const currentPath = current?.path
+    if (!currentPath) return
+    const controller = new AbortController()
     const timer = setTimeout(() => {
       void api
-        .filePreview(machine, current.path, previewColumns, previewRows)
+        .filePreview(machine, currentPath, previewColumns, previewRows, controller.signal)
         .then((result) => {
-          if (!cancelled) setPreview(result)
+          if (!controller.signal.aborted) setPreview(result)
         })
         .catch((error) => {
-          if (!cancelled) setStatus(`Preview: ${formatError(error)}`)
+          if (!controller.signal.aborted) setStatus(`Preview: ${formatError(error)}`)
         })
     }, 80)
     return () => {
-      cancelled = true
       clearTimeout(timer)
+      controller.abort()
     }
   }, [current?.path, machine, previewColumns, previewRows, setStatus])
 
@@ -577,15 +583,15 @@ export function FilesScreen({
                 <box
                   style={{ flexGrow: 1, flexDirection: "column" }}
                   onSizeChange={function (this: Renderable) {
-                    const next = {
-                      columns: Math.max(8, this.width),
-                      rows: Math.max(4, this.height - 1),
-                    }
-                    setPreviewBounds((currentBounds) =>
-                      currentBounds?.columns === next.columns && currentBounds.rows === next.rows
-                        ? currentBounds
-                        : next,
+                    const measurement = nextPreviewMeasurement(
+                      measuredPreviewViewport.current,
+                      previewViewport,
+                      this.width,
+                      this.height,
                     )
+                    if (!measurement) return
+                    measuredPreviewViewport.current = measurement.viewport
+                    setPreviewBounds({ columns: measurement.columns, rows: measurement.rows })
                   }}
                 >
                   <Preview preview={preview} entry={current} />

--- a/ui/src/state-utils.test.ts
+++ b/ui/src/state-utils.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "bun:test"
-import { clampIndex, nextValue, payloadMatches, scopedItems, updateTodo } from "./state-utils"
+import {
+  clampIndex,
+  nextPreviewMeasurement,
+  nextValue,
+  payloadMatches,
+  scopedItems,
+  updateTodo,
+} from "./state-utils"
 
 describe("clampIndex", () => {
   test("never produces a negative selection for an empty list", () => {
@@ -10,6 +17,25 @@ describe("clampIndex", () => {
   test("keeps selection inside a non-empty list", () => {
     expect(clampIndex(-2, 3)).toBe(0)
     expect(clampIndex(8, 3)).toBe(2)
+  })
+})
+
+describe("preview measurement", () => {
+  test("accepts only the first layout measurement for one viewport", () => {
+    expect(nextPreviewMeasurement("", "120x40:split", 42.8, 27.2)).toEqual({
+      viewport: "120x40:split",
+      columns: 42,
+      rows: 26,
+    })
+    expect(nextPreviewMeasurement("120x40:split", "120x40:split", 41, 26)).toBeNull()
+  })
+
+  test("measures again after the terminal viewport changes", () => {
+    expect(nextPreviewMeasurement("120x40:split", "121x40:split", 43, 27)).toEqual({
+      viewport: "121x40:split",
+      columns: 43,
+      rows: 26,
+    })
   })
 })
 

--- a/ui/src/state-utils.ts
+++ b/ui/src/state-utils.ts
@@ -5,6 +5,25 @@ export function clampIndex(value: number, length: number): number {
   return Math.max(0, Math.min(value, length - 1))
 }
 
+export interface PreviewMeasurement {
+  viewport: string
+  columns: number
+  rows: number
+}
+
+export function nextPreviewMeasurement(
+  measuredViewport: string,
+  viewport: string,
+  width: number,
+  height: number,
+): PreviewMeasurement | null {
+  if (measuredViewport === viewport || width <= 0 || height <= 0) return null
+  return {
+    viewport,
+    columns: Math.max(8, Math.floor(width)),
+    rows: Math.max(4, Math.floor(height) - 1),
+  }
+}
 
 export function scopedItems<T>(owner: string | null, current: string, items: T[]): T[] {
   return owner === current ? items : []


### PR DESCRIPTION
## Summary
- measure the preview pane once per terminal viewport instead of reacting to content-driven size oscillations
- keep the current preview visible during resize-only refetches
- cancel superseded preview requests
- add regression coverage for stable preview measurement

## Validation
- `bun test` (27 passed)
- `tsc --noEmit`
- `bun run build:web`
- `bun run build:tui`
- `python -m pytest -q tests/test_human_ui.py tests/test_human_ui_complete.py` (47 passed)