### PR TITLE
cleanup(ui): remove Yazi packaging and references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,6 @@ RUN LIBEVENT_CFLAGS="$(pkg-config --cflags libevent)" \
 FROM mcr.microsoft.com/playwright/python:v${PLAYWRIGHT_VERSION}-noble
 ARG PLAYWRIGHT_VERSION
 ARG TARGETARCH
-ARG YAZI_VERSION=26.5.6
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
@@ -118,18 +117,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN python3 -m venv "${VIRTUAL_ENV}"
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
-
-RUN set -eux; \
-  case "${TARGETARCH}" in \
-    amd64) yazi_target="x86_64-unknown-linux-gnu" ;; \
-    arm64) yazi_target="aarch64-unknown-linux-gnu" ;; \
-    *) echo "Unsupported Yazi architecture: ${TARGETARCH}" >&2; exit 1 ;; \
-  esac; \
-  curl -fsSL "https://github.com/sxyazi/yazi/releases/download/v${YAZI_VERSION}/yazi-${yazi_target}.zip" -o /tmp/yazi.zip; \
-  unzip -q /tmp/yazi.zip -d /tmp/yazi; \
-  install -m 0755 "/tmp/yazi/yazi-${yazi_target}/yazi" /usr/local/bin/yazi; \
-  install -m 0755 "/tmp/yazi/yazi-${yazi_target}/ya" /usr/local/bin/ya; \
-  rm -rf /tmp/yazi /tmp/yazi.zip
 
 RUN npm install -g yarn@1.22.22 pnpm@9.15.9 typescript@5.7.3 ts-node@10.9.2
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Standalone release executables embed the native OpenTUI runtime, while Docker im
 local-shell-mcp tui
 ```
 
-Files follows a Yazi-derived three-pane interaction model, renders bounded PNG/JPEG/GIF/WebP thumbnails directly in OpenTUI, and Docker images include `yazi` and `ya`. Manual actions entered through either human interface are excluded from the MCP audit log; the Audit screen and terminal audit rail show model-originated MCP activity.
+Files is an LSM-native three-pane file manager for local and remote machines. It renders bounded PNG/JPEG/GIF/WebP thumbnails directly in OpenTUI and provides consistent file operations through the shared service API. Manual actions entered through either human interface are excluded from the MCP audit log; the Audit screen and terminal audit rail show model-originated MCP activity.
 
 See the [human interface guide](https://fwerkor.github.io/local-shell-mcp/guides/human-interface/).
 

--- a/docs/guides/human-interface.md
+++ b/docs/guides/human-interface.md
@@ -66,7 +66,7 @@ local-shell-mcp tui --api-base http://127.0.0.1:9876/api/ui
 
 ### Files
 
-Files uses a Yazi-derived three-pane interaction model:
+Files is an LSM-native three-pane file manager:
 
 - The left sidebar selects `local` or any connected remote machine.
 - The parent pane shows the current directory in context.
@@ -74,7 +74,7 @@ Files uses a Yazi-derived three-pane interaction model:
 - The preview pane displays directory contents, text, or a bounded binary preview.
 - File operations include create, edit, rename, copy, move, paste, delete, hidden-file toggle, and refresh.
 
-Official Docker images also include the `yazi` and `ya` executables. The OpenTUI screen keeps the same interaction model on platforms where an external Yazi executable is unavailable.
+The same service API powers file operations on local and remote machines, so the interaction model and conflict handling remain consistent across both targets.
 
 ### Terminals
 
@@ -139,7 +139,7 @@ Each screen displays its contextual shortcuts in the footer.
 
 ## Packaging notes
 
-- Docker images include the WebUI assets, native OpenTUI runtime, and Yazi, and configure the service to use the bundled runtime directly.
+- Docker images include the WebUI assets and native OpenTUI runtime, and configure the service to use the bundled runtime directly.
 - Standalone release executables contain the WebUI assets and a compressed platform OpenTUI runtime; neither WebUI nor native TUI requires a neighboring sidecar.
 - Release archives contain one standalone executable; the OpenTUI runtime is compressed inside it and extracted into PyInstaller's temporary runtime directory when needed.
 - Python wheels include the WebUI assets. A native TUI requires a release executable or a source checkout with Bun and the UI dependencies installed.

--- a/src/local_shell_mcp/human_ui.py
+++ b/src/local_shell_mcp/human_ui.py
@@ -324,7 +324,6 @@ async def api_bootstrap(request: Request) -> Response:
             "features": {
                 "remote": settings.remote_enabled,
                 "wallpaper": settings.ui_wallpaper,
-                "yazi_available": shutil.which("yazi") is not None,
             },
         }
     )
@@ -927,9 +926,9 @@ def _spawn_tui_process(cols: int, rows: int):  # noqa: ANN201
         {
             "TERM": "xterm-256color",
             "COLORTERM": "truecolor",
-            # The browser wrapper is xterm.js with the image addon, matching the
-            # protocol surface exposed by VS Code's xterm.js terminal. Yazi uses
-            # TERM_PROGRAM to select iTerm IIP before falling back to SIXEL.
+            # The browser wrapper is xterm.js with the image addon. Advertising
+            # VS Code terminal compatibility enables the image protocol path supported
+            # by that terminal implementation.
             "TERM_PROGRAM": "vscode",
             "TERM_PROGRAM_VERSION": "local-shell-mcp",
             "LOCAL_SHELL_MCP_UI_API_BASE": f"http://127.0.0.1:{settings.port}{UI_API_PREFIX}",

--- a/tests/test_human_ui.py
+++ b/tests/test_human_ui.py
@@ -99,7 +99,7 @@ async def test_local_file_api_does_not_block_event_loop(tmp_path, monkeypatch):
     response = await task
     assert response.status_code == 200
 
-def test_human_file_api_has_yazi_style_directory_payload(tmp_path, monkeypatch):
+def test_human_file_api_has_three_pane_directory_payload(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
     (tmp_path / "folder").mkdir()
     (tmp_path / "alpha.txt").write_text("alpha", encoding="utf-8")
@@ -532,7 +532,9 @@ def test_native_tui_token_bypasses_oauth_without_weakening_browser_api(tmp_path,
     )
 
     assert response.status_code == 200
-    assert response.json()["data"]["machines"]["machines"][0]["name"] == "local"
+    payload = response.json()["data"]
+    assert payload["machines"]["machines"][0]["name"] == "local"
+    assert payload["features"] == {"remote": False, "wallpaper": "bing"}
 
 
 

--- a/ui/src/image-support.test.ts
+++ b/ui/src/image-support.test.ts
@@ -3,7 +3,7 @@ import { ImageAddon } from "@xterm/addon-image"
 import { WEB_IMAGE_ADDON_OPTIONS, createImageAddon } from "./image-support"
 
 describe("WebUI inline images", () => {
-  test("enables the protocols supported by Yazi and xterm.js", () => {
+  test("enables the image protocols used by OpenTUI and xterm.js", () => {
     expect(WEB_IMAGE_ADDON_OPTIONS.sixelSupport).toBe(true)
     expect(WEB_IMAGE_ADDON_OPTIONS.iipSupport).toBe(true)
     expect(WEB_IMAGE_ADDON_OPTIONS.enableSizeReports).toBe(true)

--- a/ui/src/tui.tsx
+++ b/ui/src/tui.tsx
@@ -47,7 +47,7 @@ function StatusLine({
   const online = bootstrap?.machines.machines.filter((machine) => machine.status === "online").length || 0
   const narrow = width < 60
   const compact = width < 90
-  const statusBudget = Math.max(8, width - (compact ? 14 : 47))
+  const statusBudget = Math.max(8, width - (compact ? 14 : 30))
   const visibleStatus = status.length > statusBudget ? `${status.slice(0, Math.max(1, statusBudget - 1))}…` : status
   return (
     <box
@@ -65,13 +65,7 @@ function StatusLine({
       <text fg={theme.faint} content={narrow ? "  " : "  │  "} />
       <text fg={theme.muted} content={visibleStatus} />
       <box style={{ flexGrow: 1 }} />
-      {!compact && (
-        <>
-          <text fg={theme.faint} content={bootstrap?.features.yazi_available ? "Yazi available" : "Yazi UX mode"} />
-          <text fg={theme.faint} content="  │  " />
-          <text fg={theme.cyan} content="local-shell-mcp" />
-        </>
-      )}
+      {!compact && <text fg={theme.cyan} content="local-shell-mcp" />}
     </box>
   )
 }

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -125,7 +125,6 @@ export interface BootstrapPayload {
   features: {
     remote: boolean
     wallpaper: "bing" | "aurora" | "none" | string
-    yazi_available: boolean
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the Yazi and `ya` download/install layer from the Docker image
- remove Yazi availability probing and the associated bootstrap feature flag
- simplify the OpenTUI status line now that there is no external file-manager mode
- describe Files consistently as the LSM-native local/remote three-pane file manager
- remove remaining Yazi wording from tests, README, and the human-interface guide

## Validation
- repository search: no remaining `yazi` or `Yazi` references
- `PYTHONPATH=src pytest -q` — 457 passed
- targeted human UI tests — 47 passed
- `bun test` — 25 passed
- `bun x tsc --noEmit`
- `ruff check src tests`
- documentation i18n check

Docker is not installed in the local execution environment, so the Dockerfile build itself is left to the repository CI matrix.
