### PR TITLE
Make TUI footer shortcuts clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Open the WebUI on the service origin:
 http://127.0.0.1:8765/ui
 ```
 
-The WebUI uses the same OAuth flow as MCP. Its responsive terminal frame supports mouse interaction on the actual OpenTUI top bar, automatic PTY resizing, reconnects, fullscreen mode, and a cached Bing background with an animated fallback.
+The WebUI uses the same OAuth flow as MCP. Its responsive terminal frame supports mouse interaction on the actual OpenTUI top bar and contextual footer actions, automatic PTY resizing, reconnects, fullscreen mode, and a cached Bing background with an animated fallback.
 
 Standalone release executables embed the native OpenTUI runtime, while Docker images provide it inside the image. Start the service, then launch it without a human login prompt:
 

--- a/docs/guides/human-interface.md
+++ b/docs/guides/human-interface.md
@@ -112,7 +112,7 @@ Remotes displays online and offline remote workers, capabilities, work directori
 
 ## Navigation
 
-The top category bar can be clicked with a mouse in both native terminals and the WebUI. Keyboard navigation is also available:
+The top category bar and contextual footer actions can be clicked with a mouse in both native terminals and the WebUI. Keyboard navigation is also available:
 
 | Keys | Action |
 |---|---|
@@ -124,7 +124,7 @@ The top category bar can be clicked with a mouse in both native terminals and th
 
 Terminals uses `Alt+N` for a new session, `Alt+W` to kill the selected session, `Alt+A` to toggle its audit rail, `Alt+R` to refresh, and `Alt+Left/Right` to switch sessions. The WebUI intercepts these chords before browser-level navigation or menu handling.
 
-Each screen displays its contextual shortcuts in the footer.
+Each screen displays its contextual shortcuts in the footer. Available actions are clickable, while unavailable actions are dimmed and ignore mouse input.
 
 ## Configuration
 

--- a/ui/src/audit-screen.tsx
+++ b/ui/src/audit-screen.tsx
@@ -96,6 +96,14 @@ export function AuditScreen({
   const cycleOperation = () => setOperationIndex((value) => (value + 1) % AUDIT_OPERATIONS.length)
   const cycleTime = () => setTimeIndex((value) => (value + 1) % TIME_RANGES.length)
   const toggleSort = () => setSort((value) => (value === "desc" ? "asc" : "desc"))
+  const clearFilters = () => {
+    setSearch("")
+    setEvent("")
+    setSession("")
+    setNodeIndex(0)
+    setOperationIndex(0)
+    setTimeIndex(2)
+  }
 
   const refresh = useCallback(async (force = false) => {
     if (refreshController.current && !force) return
@@ -173,16 +181,11 @@ export function AuditScreen({
     else if (key.name === "/") setDialog({ type: "search" })
     else if (key.name === "e") setDialog({ type: "event" })
     else if (key.name === "i") setDialog({ type: "session" })
-    else if (key.name === "c") {
-      setSearch("")
-      setEvent("")
-      setSession("")
-      setNodeIndex(0)
-      setOperationIndex(0)
-      setTimeIndex(2)
-    } else if (key.name === "r") void refresh(true)
+    else if (key.name === "c") clearFilters()
+    else if (key.name === "r") void refresh(true)
   })
 
+  const footerLocked = !keyboardEnabled || dialog.type !== "none"
   const applyDialog = (value: unknown) => {
     const submitted = typeof value === "string" ? value : ""
     if (dialog.type === "search") setSearch(submitted.trim())
@@ -307,14 +310,17 @@ export function AuditScreen({
       <KeyHint
         accent={colors.accent}
         items={[
-          ["j/k", "move"],
-          ["n", "node"],
-          ["o", "operation"],
-          ["t", "time"],
-          ["s", "sort"],
-          ["/", "search"],
-          ["e/i", "event/session"],
-          ["c", "clear"],
+          { key: "j", label: "down", onPress: () => selectIndex((value) => clampIndex(value + 1, entries.length)), disabled: footerLocked || entries.length === 0 },
+          { key: "k", label: "up", onPress: () => selectIndex((value) => Math.max(0, value - 1)), disabled: footerLocked || entries.length === 0 },
+          { key: "n", label: "node", onPress: cycleNode, disabled: footerLocked },
+          { key: "o", label: "operation", onPress: cycleOperation, disabled: footerLocked },
+          { key: "t", label: "time", onPress: cycleTime, disabled: footerLocked },
+          { key: "s", label: "sort", onPress: toggleSort, disabled: footerLocked },
+          { key: "/", label: "search", onPress: () => setDialog({ type: "search" }), disabled: footerLocked },
+          { key: "e", label: "event", onPress: () => setDialog({ type: "event" }), disabled: footerLocked },
+          { key: "i", label: "session", onPress: () => setDialog({ type: "session" }), disabled: footerLocked },
+          { key: "c", label: "clear", onPress: clearFilters, disabled: footerLocked },
+          { key: "r", label: "refresh", onPress: () => void refresh(true), disabled: footerLocked || loading },
         ]}
       />
       {dialog.type !== "none" && (

--- a/ui/src/components.tsx
+++ b/ui/src/components.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react"
 import { useMemo } from "react"
 import { useTerminalDimensions } from "@opentui/react"
+import { layoutKeyHints } from "./key-hints"
+import type { KeyHintItem } from "./key-hints"
 import { clampIndex } from "./state-utils"
 import type { Machine, ScreenName } from "./types"
 import { screenTheme, theme } from "./theme"
@@ -154,21 +156,9 @@ export function Panel({
   )
 }
 
-export function KeyHint({ items, accent = theme.cyan }: { items: Array<[string, string]>; accent?: string }) {
+export function KeyHint({ items, accent = theme.cyan }: { items: KeyHintItem[]; accent?: string }) {
   const { width } = useTerminalDimensions()
-  const keysOnly = width < 60
-  const compact = width < 92
-  const budget = Math.max(8, width - 4)
-  const visible: Array<[string, string]> = []
-  let used = 0
-  for (const [key, label] of items) {
-    const nextLabel = keysOnly ? "" : compact ? label.slice(0, 7) : label
-    const segmentLength = key.length + (nextLabel ? nextLabel.length + 1 : 0) + (visible.length ? 2 : 0)
-    if (used + segmentLength > budget - 2) break
-    visible.push([key, nextLabel])
-    used += segmentLength
-  }
-  const clipped = visible.length < items.length
+  const { items: visible, clipped, keysOnly } = layoutKeyHints(items, width)
   return (
     <box
       style={{
@@ -180,12 +170,25 @@ export function KeyHint({ items, accent = theme.cyan }: { items: Array<[string, 
         backgroundColor: theme.panelAlt,
       }}
     >
-      {visible.map(([key, label]) => (
-        <box key={`${key}-${label}`} style={{ flexDirection: "row", marginRight: keysOnly ? 1 : 2 }}>
-          <text fg={accent} attributes={1} content={key} />
-          {label && <text fg={theme.muted} content={` ${label}`} />}
-        </box>
-      ))}
+      {visible.map(({ key, label, onPress, disabled }) => {
+        const clickable = Boolean(onPress) && !disabled
+        return (
+          <box
+            key={`${key}-${label}`}
+            onMouseDown={clickable ? onPress : undefined}
+            style={{
+              flexDirection: "row",
+              marginRight: keysOnly ? 1 : 2,
+              paddingLeft: onPress ? 1 : 0,
+              paddingRight: onPress ? 1 : 0,
+              backgroundColor: clickable ? theme.panelSoft : undefined,
+            }}
+          >
+            <text fg={disabled ? theme.faint : accent} attributes={disabled ? 0 : 1} content={key} />
+            {label && <text fg={disabled ? theme.faint : theme.muted} content={` ${label}`} />}
+          </box>
+        )
+      })}
       {clipped && <text fg={theme.faint} content="…" />}
     </box>
   )

--- a/ui/src/files-screen.tsx
+++ b/ui/src/files-screen.tsx
@@ -381,6 +381,46 @@ export function FilesScreen({
     onMachine(machines[next]!.name)
   }
 
+  const moveSelection = (delta: number) => {
+    setSelected((value) => clampIndex(value + delta, entries.length))
+  }
+  const goToParent = () => setPath(activePayload?.parent || ".")
+  const activateCurrent = () => {
+    if (current?.type === "dir") setPath(current.path)
+    else if (current) void openEditor(current)
+  }
+  const toggleNarrowPane = () => setNarrowPane((value) => (value === "list" ? "preview" : "list"))
+  const createFile = () => setDialog({
+    type: "input",
+    action: "new-file",
+    title: "New file",
+    value: "",
+    machine,
+    directory: path,
+  })
+  const createDirectory = () => setDialog({
+    type: "input",
+    action: "new-dir",
+    title: "New directory",
+    value: "",
+    machine,
+    directory: path,
+  })
+  const renameCurrent = () => current && setDialog({
+    type: "input",
+    action: "rename",
+    title: "Rename",
+    value: current.name,
+    machine,
+    directory: path,
+    entry: current,
+  })
+  const editCurrent = () => current && current.type !== "dir" && void openEditor(current)
+  const copyCurrent = () => current && setClipboard({ mode: "copy", machine, path: current.path })
+  const moveCurrent = () => current && setClipboard({ mode: "move", machine, path: current.path })
+  const deleteCurrent = () => current && setDialog({ type: "confirm-delete", machine, entry: current })
+  const footerLocked = !keyboardEnabled || dialog.type !== "none"
+
   useKeyboard((key) => {
     if (!keyboardEnabled) return
     if (dialog.type !== "none" && dialog.machine !== machine) {
@@ -439,49 +479,23 @@ export function FilesScreen({
 
     if (narrow && key.name === "tab") {
       key.preventDefault()
-      setNarrowPane((value) => (value === "list" ? "preview" : "list"))
+      toggleNarrowPane()
       return
     }
-    if (key.name === "j" || key.name === "down") {
-      setSelected((value) => clampIndex(value + 1, entries.length))
-    }
-    else if (key.name === "k" || key.name === "up") setSelected((value) => Math.max(0, value - 1))
+    if (key.name === "j" || key.name === "down") moveSelection(1)
+    else if (key.name === "k" || key.name === "up") moveSelection(-1)
     else if (key.name === "g" && key.shift) setSelected(Math.max(0, entries.length - 1))
     else if (key.name === "g") setSelected(0)
-    else if (key.name === "h" || key.name === "left" || key.name === "backspace") setPath(activePayload?.parent || ".")
-    else if (key.name === "l" || key.name === "right" || key.name === "return") {
-      if (current?.type === "dir") setPath(current.path)
-      else if (current) void openEditor(current)
-    } else if (key.name === "." || key.name === "period") setShowHidden((value) => !value)
-    else if (key.name === "r" && !key.shift) current && setDialog({
-      type: "input",
-      action: "rename",
-      title: "Rename",
-      value: current.name,
-      machine,
-      directory: path,
-      entry: current,
-    })
-    else if (key.name === "n" && key.shift) setDialog({
-      type: "input",
-      action: "new-dir",
-      title: "New directory",
-      value: "",
-      machine,
-      directory: path,
-    })
-    else if (key.name === "n") setDialog({
-      type: "input",
-      action: "new-file",
-      title: "New file",
-      value: "",
-      machine,
-      directory: path,
-    })
-    else if (key.name === "d") current && setDialog({ type: "confirm-delete", machine, entry: current })
-    else if (key.name === "e") current && current.type !== "dir" && void openEditor(current)
-    else if (key.name === "y") current && setClipboard({ mode: "copy", machine, path: current.path })
-    else if (key.name === "x") current && setClipboard({ mode: "move", machine, path: current.path })
+    else if (key.name === "h" || key.name === "left" || key.name === "backspace") goToParent()
+    else if (key.name === "l" || key.name === "right" || key.name === "return") activateCurrent()
+    else if (key.name === "." || key.name === "period") setShowHidden((value) => !value)
+    else if (key.name === "r" && !key.shift) renameCurrent()
+    else if (key.name === "n" && key.shift) createDirectory()
+    else if (key.name === "n") createFile()
+    else if (key.name === "d") deleteCurrent()
+    else if (key.name === "e") editCurrent()
+    else if (key.name === "y") copyCurrent()
+    else if (key.name === "x") moveCurrent()
     else if (key.name === "p") void pasteClipboard()
     else if (key.name === "[") switchMachine(-1)
     else if (key.name === "]") switchMachine(1)
@@ -598,15 +612,20 @@ export function FilesScreen({
       <KeyHint
         accent={colors.accent}
         items={[
-          ...(narrow ? ([['Tab', 'list/preview']] as Array<[string, string]>) : []),
-          ["j/k", "move"],
-          ["h/l", "parent/open"],
-          ["n/N", "new"],
-          ["r", "rename"],
-          ["e", "edit"],
-          ["y/x/p", "copy/move/paste"],
-          ["d", "delete"],
-          [".", "hidden"],
+          ...(narrow ? [{ key: "Tab", label: "switch pane", onPress: toggleNarrowPane, disabled: footerLocked }] : []),
+          { key: "j", label: "down", onPress: () => moveSelection(1), disabled: footerLocked || entries.length === 0 },
+          { key: "k", label: "up", onPress: () => moveSelection(-1), disabled: footerLocked || entries.length === 0 },
+          { key: "h", label: "parent", onPress: goToParent, disabled: footerLocked },
+          { key: "l", label: "open", onPress: activateCurrent, disabled: footerLocked || !current },
+          { key: "n", label: "new file", onPress: createFile, disabled: footerLocked },
+          { key: "N", label: "new dir", onPress: createDirectory, disabled: footerLocked },
+          { key: "r", label: "rename", onPress: renameCurrent, disabled: footerLocked || !current },
+          { key: "e", label: "edit", onPress: editCurrent, disabled: footerLocked || !current || current.type === "dir" },
+          { key: "y", label: "copy", onPress: copyCurrent, disabled: footerLocked || !current },
+          { key: "x", label: "move", onPress: moveCurrent, disabled: footerLocked || !current },
+          { key: "p", label: "paste", onPress: () => void pasteClipboard(), disabled: footerLocked || !clipboard },
+          { key: "d", label: "delete", onPress: deleteCurrent, disabled: footerLocked || !current },
+          { key: ".", label: "hidden", onPress: () => setShowHidden((value) => !value), disabled: footerLocked },
         ]}
       />
       {dialog.type === "input" && (

--- a/ui/src/key-hints.test.ts
+++ b/ui/src/key-hints.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test"
+import { layoutKeyHints } from "./key-hints"
+
+describe("layoutKeyHints", () => {
+  test("keeps actions and disabled state while compacting labels", () => {
+    const action = () => undefined
+    const layout = layoutKeyHints([
+      { key: "n", label: "new terminal", onPress: action },
+      { key: "d", label: "delete", onPress: action, disabled: true },
+    ], 70)
+
+    expect(layout.items).toEqual([
+      { key: "n", label: "new ter", onPress: action },
+      { key: "d", label: "delete", onPress: action, disabled: true },
+    ])
+    expect(layout.clipped).toBe(false)
+  })
+
+  test("falls back to key-only buttons before clipping actions", () => {
+    const layout = layoutKeyHints([
+      { key: "n", label: "new terminal", onPress: () => undefined },
+      { key: "w", label: "kill terminal", onPress: () => undefined },
+      { key: "a", label: "toggle audit", onPress: () => undefined },
+      { key: "r", label: "refresh output", onPress: () => undefined },
+    ], 30)
+
+    expect(layout.keysOnly).toBe(true)
+    expect(layout.items.map((item) => item.key)).toEqual(["n", "w", "a", "r"])
+    expect(layout.clipped).toBe(false)
+  })
+
+  test("shows keys only on narrow terminals and clips whole buttons", () => {
+    const layout = layoutKeyHints([
+      { key: "Alt+Left", label: "previous terminal", onPress: () => undefined },
+      { key: "Alt+Right", label: "next terminal", onPress: () => undefined },
+    ], 20)
+
+    expect(layout.keysOnly).toBe(true)
+    expect(layout.items.map((item) => [item.key, item.label])).toEqual([["Alt+Left", ""]])
+    expect(layout.clipped).toBe(true)
+  })
+})

--- a/ui/src/key-hints.ts
+++ b/ui/src/key-hints.ts
@@ -1,0 +1,42 @@
+export interface KeyHintItem {
+  key: string
+  label: string
+  onPress?: () => void
+  disabled?: boolean
+}
+
+export interface KeyHintLayout {
+  items: KeyHintItem[]
+  clipped: boolean
+  keysOnly: boolean
+}
+
+function fitKeyHints(items: KeyHintItem[], width: number, keysOnly: boolean, compact: boolean): KeyHintLayout {
+  const budget = Math.max(8, width - 4)
+  const visible: KeyHintItem[] = []
+  let used = 0
+
+  for (const item of items) {
+    const label = keysOnly ? "" : compact ? item.label.slice(0, 7) : item.label
+    const buttonPadding = item.onPress ? 2 : 0
+    const gap = visible.length ? (keysOnly ? 1 : 2) : 0
+    const segmentLength = item.key.length + (label ? label.length + 1 : 0) + buttonPadding + gap
+    if (used + segmentLength > budget - 2) break
+    visible.push({ ...item, label })
+    used += segmentLength
+  }
+
+  return {
+    items: visible,
+    clipped: visible.length < items.length,
+    keysOnly,
+  }
+}
+
+export function layoutKeyHints(items: KeyHintItem[], width: number): KeyHintLayout {
+  const preferredKeysOnly = width < 60
+  const preferred = fitKeyHints(items, width, preferredKeysOnly, width < 92)
+  if (!preferred.clipped || preferredKeysOnly) return preferred
+
+  return fitKeyHints(items, width, true, false)
+}

--- a/ui/src/remotes-screen.tsx
+++ b/ui/src/remotes-screen.tsx
@@ -108,6 +108,14 @@ export function RemotesScreen({
     }
   }
 
+  const moveSelection = (delta: number) => {
+    setSelected((value) => clampIndex(value + delta, machines.length))
+  }
+  const createRemoteInvite = () => enabled && setDialog({ type: "invite" })
+  const renameCurrent = () => current && enabled && setDialog({ type: "rename", machine: current })
+  const revokeCurrent = () => current && enabled && setDialog({ type: "revoke", machine: current })
+  const footerLocked = !keyboardEnabled || dialog.type !== "none"
+
   useKeyboard((key) => {
     if (!keyboardEnabled) return
     if (dialog.type === "invite" || dialog.type === "rename") {
@@ -131,13 +139,11 @@ export function RemotesScreen({
       }
       return
     }
-    if (key.name === "j" || key.name === "down") {
-      setSelected((value) => clampIndex(value + 1, machines.length))
-    }
-    else if (key.name === "k" || key.name === "up") setSelected((value) => Math.max(0, value - 1))
-    else if (key.name === "n" && enabled) setDialog({ type: "invite" })
-    else if (key.name === "e" && current && enabled) setDialog({ type: "rename", machine: current })
-    else if (key.name === "d" && current && enabled) setDialog({ type: "revoke", machine: current })
+    if (key.name === "j" || key.name === "down") moveSelection(1)
+    else if (key.name === "k" || key.name === "up") moveSelection(-1)
+    else if (key.name === "n") createRemoteInvite()
+    else if (key.name === "e") renameCurrent()
+    else if (key.name === "d") revokeCurrent()
     else if (key.name === "r") void refresh(true)
   })
 
@@ -233,7 +239,17 @@ export function RemotesScreen({
           )}
         </Panel>
       </box>
-      <KeyHint accent={colors.accent} items={[["j/k", "move"], ["n", "new invite"], ["e", "rename"], ["d", "revoke"], ["r", "refresh"]]} />
+      <KeyHint
+        accent={colors.accent}
+        items={[
+          { key: "j", label: "down", onPress: () => moveSelection(1), disabled: footerLocked || machines.length === 0 },
+          { key: "k", label: "up", onPress: () => moveSelection(-1), disabled: footerLocked || machines.length === 0 },
+          { key: "n", label: "new invite", onPress: createRemoteInvite, disabled: footerLocked || !enabled },
+          { key: "e", label: "rename", onPress: renameCurrent, disabled: footerLocked || !enabled || !current },
+          { key: "d", label: "revoke", onPress: revokeCurrent, disabled: footerLocked || !enabled || !current },
+          { key: "r", label: "refresh", onPress: () => void refresh(true), disabled: footerLocked || loading },
+        ]}
+      />
       {dialog.type === "invite" && (
         <Modal title="Create remote invite" height={8}>
           <text fg={theme.muted} content="Enter: optional-name [optional-workdir]" />

--- a/ui/src/terminals-screen.tsx
+++ b/ui/src/terminals-screen.tsx
@@ -331,6 +331,21 @@ export function TerminalsScreen({
     onMachine(machines[next]!.name)
   }
 
+  const startTerminal = () => setDialog({ type: "start", machine, name: "", cwd: "." })
+  const killTerminal = () => selectedSession && setDialog({ type: "kill", machine, session: selectedSession })
+  const toggleAudit = () => setShowAudit((value) => !value)
+  const toggleRawMode = () => {
+    if (rawMode) {
+      setRawMode(false)
+      setStatus("Raw input disabled")
+    } else if (selectedSession) {
+      setRawMode(true)
+      setStatus("Raw input enabled · F8 to leave")
+    }
+  }
+  const footerLocked = !keyboardEnabled || dialog.type !== "none"
+  const standardFooterLocked = footerLocked || rawMode
+
   useKeyboard((key) => {
     if (!keyboardEnabled) return
     if (dialog.type !== "none" && dialog.machine !== machine) {
@@ -361,8 +376,7 @@ export function TerminalsScreen({
       key.preventDefault()
       key.stopPropagation()
       if (key.name === "f8") {
-        setRawMode(false)
-        setStatus("Raw input disabled")
+        toggleRawMode()
         return
       }
       const encoded = encodeRawKey(key)
@@ -370,18 +384,14 @@ export function TerminalsScreen({
       return
     }
 
-    if (key.name === "f8") {
-      if (selectedSession) {
-        setRawMode(true)
-        setStatus("Raw input enabled · F8 to leave")
-      }
-    } else if ((key.option || key.meta) && key.name === "[") switchMachine(-1)
+    if (key.name === "f8") toggleRawMode()
+    else if ((key.option || key.meta) && key.name === "[") switchMachine(-1)
     else if ((key.option || key.meta) && key.name === "]") switchMachine(1)
     else if ((key.option || key.meta) && key.name === "left") selectSession(selected - 1)
     else if ((key.option || key.meta) && key.name === "right") selectSession(selected + 1)
-    else if ((key.option || key.meta) && key.name === "n") setDialog({ type: "start", machine, name: "", cwd: "." })
-    else if ((key.option || key.meta) && key.name === "w" && selectedSession) setDialog({ type: "kill", machine, session: selectedSession })
-    else if ((key.option || key.meta) && key.name === "a") setShowAudit((value) => !value)
+    else if ((key.option || key.meta) && key.name === "n") startTerminal()
+    else if ((key.option || key.meta) && key.name === "w") killTerminal()
+    else if ((key.option || key.meta) && key.name === "a") toggleAudit()
     else if ((key.option || key.meta) && key.name === "r") void refreshOutput(true)
   })
 
@@ -492,13 +502,15 @@ export function TerminalsScreen({
       <KeyHint
         accent={colors.accent}
         items={[
-          ["Alt+←/→", "terminal"],
-          ["Alt+N", "new"],
-          ["Alt+W", "kill"],
-          ["Alt+A", "audit"],
-          ["F8", "raw mode"],
-          ["Alt+[ / ]", "machine"],
-          ["Alt+R", "refresh"],
+          { key: "Alt+←", label: "previous", onPress: () => selectSession(selected - 1), disabled: standardFooterLocked || activeSessions.length < 2 },
+          { key: "Alt+→", label: "next", onPress: () => selectSession(selected + 1), disabled: standardFooterLocked || activeSessions.length < 2 },
+          { key: "Alt+N", label: "new", onPress: startTerminal, disabled: standardFooterLocked },
+          { key: "Alt+W", label: "kill", onPress: killTerminal, disabled: standardFooterLocked || !selectedSession },
+          { key: "Alt+A", label: "audit", onPress: toggleAudit, disabled: standardFooterLocked },
+          { key: "F8", label: rawMode ? "leave raw" : "raw mode", onPress: toggleRawMode, disabled: footerLocked || !selectedSession },
+          { key: "Alt+[", label: "prev machine", onPress: () => switchMachine(-1), disabled: standardFooterLocked || machines.length < 2 },
+          { key: "Alt+]", label: "next machine", onPress: () => switchMachine(1), disabled: standardFooterLocked || machines.length < 2 },
+          { key: "Alt+R", label: "refresh", onPress: () => void refreshOutput(true), disabled: standardFooterLocked || !selectedSession },
         ]}
       />
       {dialog.type === "start" && (

--- a/ui/src/todos-screen.tsx
+++ b/ui/src/todos-screen.tsx
@@ -168,6 +168,22 @@ export function TodosScreen({
     replaceItem(id, { content: trimmed })
   }
 
+  const moveSelection = (delta: number) => {
+    setSelected((value) => clampIndex(value + delta, visible.length))
+  }
+  const addCurrent = () => setDialog({ type: "add" })
+  const editCurrent = () => current && setDialog({ type: "edit", item: current })
+  const deleteCurrent = () => current && setDialog({ type: "delete", item: current })
+  const cycleStatus = () => current && replaceItem(
+    current.id,
+    (todo) => ({ status: nextValue(todo.status, STATUS_ORDER) }),
+  )
+  const cyclePriority = () => current && replaceItem(
+    current.id,
+    (todo) => ({ priority: nextValue(todo.priority, PRIORITY_ORDER) }),
+  )
+  const footerLocked = !keyboardEnabled || dialog.type !== "none"
+
   useKeyboard((key) => {
     if (!keyboardEnabled) return
     if (dialog.type === "add" || dialog.type === "edit") {
@@ -183,20 +199,15 @@ export function TodosScreen({
       }
       return
     }
-    if (key.name === "j" || key.name === "down") {
-      setSelected((value) => clampIndex(value + 1, visible.length))
-    } else if (key.name === "k" || key.name === "up") {
-      setSelected((value) => clampIndex(value - 1, visible.length))
-    } else if (key.name === "n") setDialog({ type: "add" })
-    else if (key.name === "e" && current) setDialog({ type: "edit", item: current })
-    else if (key.name === "d" && current) setDialog({ type: "delete", item: current })
-    else if ((key.name === "return" || key.name === "space") && current) {
-      replaceItem(current.id, (todo) => ({ status: nextValue(todo.status, STATUS_ORDER) }))
-    } else if (key.name === "p" && current) {
-      replaceItem(current.id, (todo) => ({ priority: nextValue(todo.priority, PRIORITY_ORDER) }))
-    } else if (key.name === "f") {
-      cycleFilter()
-    } else if (key.name === "r" && pendingMutations.current === 0) void load()
+    if (key.name === "j" || key.name === "down") moveSelection(1)
+    else if (key.name === "k" || key.name === "up") moveSelection(-1)
+    else if (key.name === "n") addCurrent()
+    else if (key.name === "e") editCurrent()
+    else if (key.name === "d") deleteCurrent()
+    else if (key.name === "return" || key.name === "space") cycleStatus()
+    else if (key.name === "p") cyclePriority()
+    else if (key.name === "f") cycleFilter()
+    else if (key.name === "r" && pendingMutations.current === 0) void load()
   })
 
   const counts = {
@@ -274,14 +285,15 @@ export function TodosScreen({
       <KeyHint
         accent={colors.accent}
         items={[
-          ["j/k", "move"],
-          ["Enter", "status"],
-          ["p", "priority"],
-          ["n", "add"],
-          ["e", "edit"],
-          ["d", "delete"],
-          ["f", "filter"],
-          ["r", "refresh"],
+          { key: "j", label: "down", onPress: () => moveSelection(1), disabled: footerLocked || visible.length === 0 },
+          { key: "k", label: "up", onPress: () => moveSelection(-1), disabled: footerLocked || visible.length === 0 },
+          { key: "Enter", label: "status", onPress: cycleStatus, disabled: footerLocked || !current },
+          { key: "p", label: "priority", onPress: cyclePriority, disabled: footerLocked || !current },
+          { key: "n", label: "add", onPress: addCurrent, disabled: footerLocked },
+          { key: "e", label: "edit", onPress: editCurrent, disabled: footerLocked || !current },
+          { key: "d", label: "delete", onPress: deleteCurrent, disabled: footerLocked || !current },
+          { key: "f", label: "filter", onPress: cycleFilter, disabled: footerLocked },
+          { key: "r", label: "refresh", onPress: () => void load(), disabled: footerLocked || saving },
         ]}
       />
       {saving && (


### PR DESCRIPTION
## Summary

- make contextual TUI footer shortcuts clickable in native terminals and the WebUI
- route mouse clicks and keyboard shortcuts through the same screen actions
- split ambiguous combined hints into individual controls, dim unavailable actions, and preserve controls on narrow terminals with a key-only fallback
- document footer mouse interaction

## Validation

- [x] `ruff check .`
- [x] `PYTHONPATH=src pytest -q` (457 passed)
- [ ] `mkdocs build --strict` if docs changed (MkDocs is not installed in this environment; `python scripts/check-doc-i18n.py` passed)
- [x] UI tests: `cd ui && bun run test` (28 passed)
- [x] UI typecheck: `cd ui && bun run typecheck`
- [x] Native TUI build and startup: `cd ui && bun run build:tui && ./dist/local-shell-mcp-tui --version`
- [x] PTY smoke test: `python scripts/ui-pty-smoke.py --tui ui/dist/local-shell-mcp-tui`
- [ ] VS Code extension compile if extension files changed (not applicable)

## Safety checklist

- [x] No secrets, tunnel tokens, OAuth pins, private keys, or bearer file-link URLs are committed.
- [x] New or changed MCP tools are documented and tested. (No MCP tool changes.)
- [x] Host-control, remote-worker, file-link, or credential behavior is explicitly described. (No behavior changes in these areas.)
- [x] Backwards compatibility impact is noted. Existing keyboard shortcuts remain unchanged; this only adds mouse activation and disabled-state presentation.
