### PR TITLE
feat(ui): add Files mouse navigation

### DIFF
--- a/ui/src/file-navigation.test.ts
+++ b/ui/src/file-navigation.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test"
+import { DOUBLE_CLICK_WINDOW_MS, isDoubleClick, pathBreadcrumbs } from "./file-navigation"
+
+describe("file pointer navigation", () => {
+  test("requires two presses on the same item within the double-click window", () => {
+    const first = { target: "src", at: 1_000 }
+    expect(isDoubleClick(first, "src", 1_000 + DOUBLE_CLICK_WINDOW_MS)).toBe(true)
+    expect(isDoubleClick(first, "tests", 1_100)).toBe(false)
+    expect(isDoubleClick(first, "src", 1_000 + DOUBLE_CLICK_WINDOW_MS + 1)).toBe(false)
+    expect(isDoubleClick(first, "src", 999)).toBe(false)
+  })
+})
+
+describe("file path breadcrumbs", () => {
+  test("builds workspace-relative breadcrumbs", () => {
+    expect(pathBreadcrumbs("src/local_shell_mcp/ui_static")).toEqual([
+      { label: ".", path: "." },
+      { label: "src", path: "src" },
+      { label: "local_shell_mcp", path: "src/local_shell_mcp" },
+      { label: "ui_static", path: "src/local_shell_mcp/ui_static" },
+    ])
+  })
+
+  test("builds absolute POSIX breadcrumbs", () => {
+    expect(pathBreadcrumbs("/var/lib/lsm")).toEqual([
+      { label: "/", path: "/" },
+      { label: "var", path: "/var" },
+      { label: "lib", path: "/var/lib" },
+      { label: "lsm", path: "/var/lib/lsm" },
+    ])
+  })
+
+  test("builds Windows drive and UNC breadcrumbs", () => {
+    expect(pathBreadcrumbs("C:\\Users\\agent")).toEqual([
+      { label: "C:\\", path: "C:\\" },
+      { label: "Users", path: "C:\\Users" },
+      { label: "agent", path: "C:\\Users\\agent" },
+    ])
+    expect(pathBreadcrumbs("\\\\server\\share\\folder")).toEqual([
+      { label: "\\\\server\\share", path: "\\\\server\\share" },
+      { label: "folder", path: "\\\\server\\share\\folder" },
+    ])
+  })
+})

--- a/ui/src/file-navigation.ts
+++ b/ui/src/file-navigation.ts
@@ -1,0 +1,76 @@
+export interface PathBreadcrumb {
+  label: string
+  path: string
+}
+
+export interface PointerClick {
+  target: string
+  at: number
+}
+
+export const DOUBLE_CLICK_WINDOW_MS = 500
+
+export function isDoubleClick(
+  previous: PointerClick | null,
+  target: string,
+  at: number,
+  windowMs = DOUBLE_CLICK_WINDOW_MS,
+): boolean {
+  return Boolean(
+    previous
+      && previous.target === target
+      && at >= previous.at
+      && at - previous.at <= windowMs,
+  )
+}
+
+export function pathBreadcrumbs(path: string): PathBreadcrumb[] {
+  if (!path || path === ".") return [{ label: ".", path: "." }]
+
+  if (path.startsWith("\\\\")) {
+    const parts = path.slice(2).split(/\\+/).filter(Boolean)
+    if (parts.length < 2) return [{ label: path, path }]
+    const root = `\\\\${parts[0]}\\${parts[1]}`
+    const crumbs: PathBreadcrumb[] = [{ label: root, path: root }]
+    let current = root
+    for (const part of parts.slice(2)) {
+      current = `${current}\\${part}`
+      crumbs.push({ label: part, path: current })
+    }
+    return crumbs
+  }
+
+  const drive = path.match(/^([A-Za-z]:)[\\/]/)
+  if (drive) {
+    const root = `${drive[1]}\\`
+    const parts = path.slice(drive[0].length).split(/[\\/]+/).filter(Boolean)
+    const crumbs: PathBreadcrumb[] = [{ label: root, path: root }]
+    let current = root
+    for (const part of parts) {
+      current = `${current.replace(/\\$/, "")}\\${part}`
+      crumbs.push({ label: part, path: current })
+    }
+    return crumbs
+  }
+
+  if (path.startsWith("/")) {
+    const parts = path.split(/\/+/).filter(Boolean)
+    const crumbs: PathBreadcrumb[] = [{ label: "/", path: "/" }]
+    let current = ""
+    for (const part of parts) {
+      current = `${current}/${part}`
+      crumbs.push({ label: part, path: current })
+    }
+    return crumbs
+  }
+
+  const separator = path.includes("\\") ? "\\" : "/"
+  const parts = path.split(/[\\/]+/).filter(Boolean)
+  const crumbs: PathBreadcrumb[] = [{ label: ".", path: "." }]
+  let current = ""
+  for (const part of parts) {
+    current = current ? `${current}${separator}${part}` : part
+    crumbs.push({ label: part, path: current })
+  }
+  return crumbs
+}

--- a/ui/src/files-screen.tsx
+++ b/ui/src/files-screen.tsx
@@ -3,6 +3,7 @@ import { useKeyboard } from "@opentui/react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { api, formatError } from "./api"
 import { EmptyState, KeyHint, MachineSidebar, Modal, Panel, formatBytes, useVisibleRows } from "./components"
+import { isDoubleClick, pathBreadcrumbs, type PointerClick } from "./file-navigation"
 import { clampIndex, nextPreviewMeasurement, payloadMatches } from "./state-utils"
 import { screenTheme, theme } from "./theme"
 import type { FileEntry, FilePreview, FilesPayload, Machine } from "./types"
@@ -66,7 +67,9 @@ function FileRows({
         return (
           <box
             key={entry.path}
-            onMouseDown={() => onSelect?.(entry, index)}
+            onMouseDown={(event) => {
+              if (event.button === 0) onSelect?.(entry, index)
+            }}
             style={{
               height: 1,
               flexDirection: "row",
@@ -197,6 +200,7 @@ export function FilesScreen({
   const refreshRequest = useRef(0)
   const refreshController = useRef<AbortController | null>(null)
   const measuredPreviewViewport = useRef("")
+  const lastCurrentClick = useRef<PointerClick | null>(null)
   const machineRef = useRef(machine)
   machineRef.current = machine
   const activePayload = payloadMatches(payload, machine, path) ? payload : null
@@ -210,6 +214,7 @@ export function FilesScreen({
     [activePayload, showHidden],
   )
   const current = entries[selected]
+  const breadcrumbs = useMemo(() => pathBreadcrumbs(path), [path])
   const listHeight = Math.max(4, height - 10)
 
   useEffect(() => {
@@ -257,6 +262,10 @@ export function FilesScreen({
     setClipboard(null)
     setNarrowPane("list")
   }, [machine])
+
+  useEffect(() => {
+    lastCurrentClick.current = null
+  }, [machine, path])
 
   useEffect(() => {
     setSelected(0)
@@ -391,9 +400,20 @@ export function FilesScreen({
     setSelected((value) => clampIndex(value + delta, entries.length))
   }
   const goToParent = () => setPath(activePayload?.parent || ".")
-  const activateCurrent = () => {
-    if (current?.type === "dir") setPath(current.path)
-    else if (current) void openEditor(current)
+  const activateEntry = (entry: FileEntry) => {
+    if (entry.type === "dir") setPath(entry.path)
+    else void openEditor(entry)
+  }
+  const activateCurrent = () => current && activateEntry(current)
+  const selectCurrent = (entry: FileEntry, index: number) => {
+    setSelected(index)
+    const at = Date.now()
+    if (isDoubleClick(lastCurrentClick.current, entry.path, at)) {
+      lastCurrentClick.current = null
+      activateEntry(entry)
+      return
+    }
+    lastCurrentClick.current = { target: entry.path, at }
   }
   const toggleNarrowPane = () => setNarrowPane((value) => (value === "list" ? "preview" : "list"))
   const createFile = () => setDialog({
@@ -530,8 +550,23 @@ export function FilesScreen({
         )}
         <box style={{ flexGrow: 1, flexDirection: "column" }}>
           <box style={{ height: 2, flexDirection: "row", alignItems: "center", paddingLeft: 1 }}>
-            <text fg={theme.faint} content={`${machine} / `} />
-            <text fg={colors.accent} attributes={1} content={path} />
+            <text fg={theme.faint} content={`${machine}  `} />
+            {breadcrumbs.map((crumb, index) => {
+              const active = crumb.path === path
+              return (
+                <box key={crumb.path} style={{ flexDirection: "row" }}>
+                  {index > 0 && <text fg={theme.faint} content=" / " />}
+                  <text
+                    onMouseDown={(event) => {
+                      if (event.button === 0 && !active && dialog.type === "none") setPath(crumb.path)
+                    }}
+                    fg={active ? colors.accent : theme.muted}
+                    attributes={active ? 1 : 0}
+                    content={crumb.label}
+                  />
+                </box>
+              )
+            })}
             <box style={{ flexGrow: 1 }} />
             {busy && <text fg={theme.yellow} content="syncing  " />}
             {clipboard && (
@@ -585,7 +620,7 @@ export function FilesScreen({
                     entries={entries}
                     selected={selected}
                     height={listHeight}
-                    onSelect={(_entry, index) => setSelected(index)}
+                    onSelect={selectCurrent}
                   />
                 ) : (
                   <EmptyState title="Empty directory" detail="n file · N directory" />

--- a/ui/src/files-screen.tsx
+++ b/ui/src/files-screen.tsx
@@ -67,7 +67,7 @@ function FileRows({
         return (
           <box
             key={entry.path}
-            onMouseDown={(event) => {
+            onMouseUp={(event) => {
               if (event.button === 0) onSelect?.(entry, index)
             }}
             style={{
@@ -557,7 +557,7 @@ export function FilesScreen({
                 <box key={crumb.path} style={{ flexDirection: "row" }}>
                   {index > 0 && <text fg={theme.faint} content=" / " />}
                   <text
-                    onMouseDown={(event) => {
+                    onMouseUp={(event) => {
                       if (event.button === 0 && !active && dialog.type === "none") setPath(crumb.path)
                     }}
                     fg={active ? colors.accent : theme.muted}


### PR DESCRIPTION
## Summary
- open Current entries by double-clicking them
- make each directory segment in the Files path clickable
- preserve single-click selection and existing keyboard activation behavior

## Validation
- `bun test` (34 passed)
- `tsc --noEmit`
- `bun run build`
- native TUI `--version` smoke test
- generated WebUI asset reproducibility check