### PR TITLE
feat(ui): show remote LSM versions

### DIFF
--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -25,6 +25,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any
 
+from . import __version__
 from .audit import audit, suppress_audit
 from .fs_ops import (
     delete_path,
@@ -1426,6 +1427,7 @@ def worker_info(workdir: str) -> dict[str, Any]:
         "user": os.getenv("USER") or os.getenv("USERNAME") or "unknown",
         "cwd": os.getcwd(),
         "workdir": workdir,
+        "lsm_version": __version__,
         "python": sys.version.split()[0],
         "platform": sys.platform,
         "persistent_shell": persistent_shell_backend_info(),

--- a/tests/test_remote_list_machines.py
+++ b/tests/test_remote_list_machines.py
@@ -1,4 +1,5 @@
-from local_shell_mcp.remote import RemoteManager, RemoteWorker
+from local_shell_mcp import __version__
+from local_shell_mcp.remote import RemoteManager, RemoteWorker, worker_info
 from local_shell_mcp.settings import get_settings
 
 
@@ -24,6 +25,16 @@ def test_list_machines_reports_counts_and_details(tmp_path, monkeypatch):
     assert result["machines"][0]["last_seen_age_s"] == 5
     assert result["machines"][0]["queue_depth"] == 1
     assert result["machines"][1]["status"] == "offline"
+
+
+def test_worker_info_reports_runtime_version(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "local_shell_mcp.remote.persistent_shell_backend_info", lambda: {"backend": "test"}
+    )
+
+    info = worker_info(str(tmp_path))
+
+    assert info["lsm_version"] == __version__
 
 
 def test_list_machines_serializes_concurrent_registry_mutations(tmp_path, monkeypatch):

--- a/ui/src/remotes-screen.tsx
+++ b/ui/src/remotes-screen.tsx
@@ -2,6 +2,7 @@ import { useKeyboard } from "@opentui/react"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { api, formatError } from "./api"
 import { EmptyState, KeyHint, Modal, Panel, formatAge, useVisibleRows } from "./components"
+import { remoteSystemInfo, remoteVersion } from "./remotes-utils"
 import { clampIndex } from "./state-utils"
 import { screenTheme, theme } from "./theme"
 import type { InvitePayload, Machine } from "./types"
@@ -37,7 +38,7 @@ export function RemotesScreen({
   const refreshController = useRef<AbortController | null>(null)
   const current = machines[selected]
   const compact = width < 92
-  const { rows, start } = useVisibleRows(machines, selected, Math.max(5, height - (compact ? 20 : 13)))
+  const { rows, start } = useVisibleRows(machines, selected, Math.max(5, height - (compact ? 21 : 13)))
 
   const refresh = useCallback(async (force = false) => {
     if (refreshController.current && !force) return
@@ -185,7 +186,10 @@ export function RemotesScreen({
           ) : (
             <box style={{ flexDirection: "column", flexGrow: 1 }}>
               <box style={{ height: 2, flexDirection: "row", paddingLeft: 1 }}>
-                <text fg={theme.faint} content={compact ? "STATE  NAME" : "STATE  NAME                         WORKDIR"} />
+                <text
+                  fg={theme.faint}
+                  content={compact ? "STATE  NAME" : "STATE  NAME                    VERSION     WORKDIR"}
+                />
               </box>
               {rows.map((machine, offset) => {
                 const index = start + offset
@@ -207,8 +211,9 @@ export function RemotesScreen({
                     <text
                       fg={active ? theme.text : theme.muted}
                       attributes={active ? 1 : 0}
-                      content={compact ? machine.name : machine.name.padEnd(29)}
+                      content={compact ? machine.name : machine.name.slice(0, 23).padEnd(24)}
                     />
+                    {!compact && <text fg={theme.blue} content={remoteVersion(machine).slice(0, 11).padEnd(12)} />}
                     {!compact && <text fg={theme.faint} content={machine.workdir || "—"} />}
                   </box>
                 )
@@ -220,7 +225,7 @@ export function RemotesScreen({
           title="Node details"
           style={{
             width: compact ? "100%" : "34%",
-            height: compact ? 10 : "100%",
+            height: compact ? 11 : "100%",
             padding: 1,
           }}
         >
@@ -228,11 +233,12 @@ export function RemotesScreen({
             <box style={{ flexDirection: "column" }}>
               <text fg={current.status === "online" ? theme.green : theme.orange} attributes={1} content={current.name} />
               <text fg={theme.faint} content={`Status       ${current.status}`} />
+              <text fg={theme.faint} content={`LSM version  ${remoteVersion(current)}`} />
               <text fg={theme.faint} content={`Last seen    ${formatAge(current.last_seen)}`} />
               <text fg={theme.faint} content={`Workdir      ${current.workdir || "—"}`} />
               <text fg={theme.faint} content={`Capabilities ${(current.capabilities || []).join(", ") || "—"}`} />
               <text fg={theme.borderBright} content="\nSystem information" />
-              <text fg={theme.muted} content={JSON.stringify(current.info || {}, null, 2)} />
+              <text fg={theme.muted} content={JSON.stringify(remoteSystemInfo(current), null, 2)} />
             </box>
           ) : (
             <EmptyState title="No node selected" detail="Create an invite to attach one" />

--- a/ui/src/remotes-utils.test.ts
+++ b/ui/src/remotes-utils.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test"
+import { remoteSystemInfo, remoteVersion } from "./remotes-utils"
+import type { Machine } from "./types"
+
+function machine(info?: Record<string, unknown>): Machine {
+  return { name: "worker", status: "online", info }
+}
+
+describe("remote metadata", () => {
+  test("formats the worker runtime version", () => {
+    expect(remoteVersion(machine({ lsm_version: "3.0.4" }))).toBe("3.0.4")
+    expect(remoteVersion(machine())).toBe("—")
+    expect(remoteVersion(machine({ lsm_version: 304 }))).toBe("—")
+  })
+
+  test("keeps the version out of the generic system information block", () => {
+    expect(remoteSystemInfo(machine({ hostname: "node", lsm_version: "3.0.4" }))).toEqual({
+      hostname: "node",
+    })
+  })
+})

--- a/ui/src/remotes-utils.ts
+++ b/ui/src/remotes-utils.ts
@@ -1,0 +1,12 @@
+import type { Machine } from "./types"
+
+export function remoteVersion(machine: Machine): string {
+  const version = machine.info?.lsm_version
+  return typeof version === "string" && version.trim() ? version : "—"
+}
+
+export function remoteSystemInfo(machine: Machine): Record<string, unknown> {
+  const info = { ...(machine.info || {}) }
+  delete info.lsm_version
+  return info
+}


### PR DESCRIPTION
## Summary
- report the executing local-shell-mcp version from each remote worker
- show the version in the wide Remotes table and selected-node details
- keep legacy workers compatible by displaying `—` when no version is reported
- remove the structured version field from the generic system-information JSON to avoid duplication

## Tests
- `ruff check .`
- `PYTHONPATH=src pytest -q` (458 passed)
- `bun run typecheck`
- `bun test` (32 passed)
- `bun run build`