### PR TITLE
chore: prepare PR #31 compatibility merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,12 +62,23 @@ jobs:
           with open("pyproject.toml", "rb") as f:
               version = tomllib.load(f)["project"]["version"]
 
-              release_version = tag[1:] if tag.startswith("v") else tag
-              if release_version != version:
-                  raise SystemExit(
-                      f"Release tag {tag!r} resolves to version {release_version!r}, "
-                      f"but pyproject.toml declares {version!r}"
-                  )
+          init_namespace = {}
+          with open("src/local_shell_mcp/__init__.py", encoding="utf-8") as f:
+              exec(f.read(), init_namespace)
+          package_version = init_namespace["__version__"]
+
+          if package_version != version:
+              raise SystemExit(
+                  f"src/local_shell_mcp/__init__.py declares {package_version!r}, "
+                  f"but pyproject.toml declares {version!r}"
+              )
+
+          release_version = tag[1:] if tag.startswith("v") else tag
+          if release_version != version:
+              raise SystemExit(
+                  f"Release tag {tag!r} resolves to version {release_version!r}, "
+                  f"but pyproject.toml declares {version!r}"
+              )
 
           print(f"version={version}")
           PY

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "local-shell-mcp"
-version = "3.0.4"
+version = "3.0.3"
 description = "A ChatGPT-compatible OAuth MCP server that gives AI coding agents controlled shell, filesystem, remote-worker, and Playwright access inside a local container."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/local_shell_mcp/__init__.py
+++ b/src/local_shell_mcp/__init__.py
@@ -1,3 +1,3 @@
 """local-shell-mcp."""
 
-__version__ = "3.0.4"
+__version__ = "3.0.3"


### PR DESCRIPTION
## Summary

- align the project and runtime version metadata with the current PR #31 head
- restore the release-time package version consistency validation
- make PR #31 merge cleanly without altering its branch

## Validation

- `python3 -m pytest -q tests/test_version.py`
- clean local `git merge --no-commit --no-ff origin/pr/31` probe with no resulting tree changes