### PR TITLE
chore: release v3.0.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "local-shell-mcp"
-version = "3.0.5"
+version = "3.0.6"
 description = "A ChatGPT-compatible OAuth MCP server that gives AI coding agents controlled shell, filesystem, remote-worker, and Playwright access inside a local container."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/local_shell_mcp/__init__.py
+++ b/src/local_shell_mcp/__init__.py
@@ -1,3 +1,3 @@
 """local-shell-mcp."""
 
-__version__ = "3.0.5"
+__version__ = "3.0.6"


### PR DESCRIPTION
## Summary

- bump the Python package version to 3.0.6
- keep the runtime `__version__` synchronized
- prepare the first stable v3 release

## Validation

- `python -m pytest tests/test_version.py tests/test_main_complete.py -q`
- `git diff --check`
- secret scan on changed files