### PR TITLE
fix(tui): show loading before initial data arrives

### DIFF
--- a/ui/src/audit-screen.tsx
+++ b/ui/src/audit-screen.tsx
@@ -8,7 +8,7 @@ import {
   formatAuditValue,
   selectionAfterRefresh,
 } from "./audit-utils"
-import { EmptyState, KeyHint, Modal, Panel, useVisibleRows } from "./components"
+import { EmptyState, KeyHint, Loading, Modal, Panel, useVisibleRows } from "./components"
 import { handleSelectionScroll } from "./mouse"
 import { clampIndex } from "./state-utils"
 import { screenTheme, theme } from "./theme"
@@ -72,7 +72,8 @@ export function AuditScreen({
   const [event, setEvent] = useState("")
   const [session, setSession] = useState("")
   const [dialog, setDialog] = useState<AuditDialog>({ type: "none" })
-  const [loading, setLoading] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [loaded, setLoaded] = useState(false)
   const [detail, setDetail] = useState<AuditEntry | null>(null)
   const refreshRequest = useRef(0)
   const refreshController = useRef<AbortController | null>(null)
@@ -138,6 +139,7 @@ export function AuditScreen({
       selectedRef.current = nextSelected
       setEntries(payload.entries)
       setSelected(nextSelected)
+      setLoaded(true)
       setStatus(`Audit: ${payload.total_matched} matching calls and events`)
     } catch (error) {
       if (requestId === refreshRequest.current && !controller.signal.aborted) {
@@ -264,8 +266,10 @@ export function AuditScreen({
         </box>
       )}
       <box style={{ flexGrow: 1, flexDirection: width >= 110 ? "row" : "column", gap: 1 }}>
-        <Panel title={`Audit records · ${entries.length}${loading ? " · syncing" : ""}`} active accent={colors.accent} activeBackground={colors.panel} style={{ flexGrow: 1, paddingTop: 1 }}>
-          {entries.length === 0 ? (
+        <Panel title={`Audit records · ${loaded ? entries.length : "—"}${loading ? " · syncing" : ""}`} active accent={colors.accent} activeBackground={colors.panel} style={{ flexGrow: 1, paddingTop: 1 }}>
+          {!loaded ? (
+            loading ? <Loading label="Loading audit records" /> : <EmptyState title="Audit unavailable" detail="Press r to try again" />
+          ) : entries.length === 0 ? (
             <EmptyState title="No matching audit records" detail="Adjust filters or wait for MCP activity" />
           ) : (
             <box
@@ -337,6 +341,8 @@ export function AuditScreen({
                 </scrollbox>
               </Panel>
             </>
+          ) : !loaded ? (
+            loading ? <Loading label="Loading audit details" /> : <EmptyState title="Audit unavailable" detail="Press r to try again" />
           ) : (
             <EmptyState title="No record selected" detail="Use j/k to inspect entries" />
           )}

--- a/ui/src/dashboard-screen.tsx
+++ b/ui/src/dashboard-screen.tsx
@@ -508,7 +508,7 @@ export function DashboardScreen({
 }) {
   const [payload, setPayload] = useState<DashboardPayload | null>(null)
   const [history, setHistory] = useState<TrendSample[]>([])
-  const [loading, setLoading] = useState(false)
+  const [loading, setLoading] = useState(true)
   const request = useRef(0)
   const controller = useRef<AbortController | null>(null)
   const layout = dashboardLayout(width, height)

--- a/ui/src/files-screen.tsx
+++ b/ui/src/files-screen.tsx
@@ -2,7 +2,7 @@ import type { OptimizedBuffer, Renderable, TextareaRenderable } from "@opentui/c
 import { useKeyboard } from "@opentui/react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { api, formatError } from "./api"
-import { EmptyState, KeyHint, MachineSidebar, Modal, Panel, formatBytes, useVisibleRows } from "./components"
+import { EmptyState, KeyHint, Loading, MachineSidebar, Modal, Panel, formatBytes, useVisibleRows } from "./components"
 import { isDoubleClick, pathBreadcrumbs, type PointerClick } from "./file-navigation"
 import { handleSelectionScroll } from "./mouse"
 import { clampIndex, nextPreviewMeasurement, payloadMatches } from "./state-utils"
@@ -203,6 +203,7 @@ export function FilesScreen({
   const [dialog, setDialog] = useState<Dialog>({ type: "none" })
   const [clipboard, setClipboard] = useState<ClipboardState | null>(null)
   const [busy, setBusy] = useState(false)
+  const [loadError, setLoadError] = useState<{ scope: string; message: string } | null>(null)
   const [narrowPane, setNarrowPane] = useState<"list" | "preview">("list")
   const [previewBounds, setPreviewBounds] = useState<{ columns: number; rows: number } | null>(null)
   const editorRef = useRef<TextareaRenderable>(null)
@@ -213,6 +214,8 @@ export function FilesScreen({
   const machineRef = useRef(machine)
   machineRef.current = machine
   const activePayload = payloadMatches(payload, machine, path) ? payload : null
+  const activeScope = `${machine}\u0000${path}`
+  const activeError = loadError?.scope === activeScope ? loadError.message : null
 
   const entries = useMemo(
     () => (activePayload?.entries || []).filter((entry) => showHidden || !entry.hidden),
@@ -241,19 +244,24 @@ export function FilesScreen({
 
   const refresh = useCallback(async () => {
     const requestId = ++refreshRequest.current
+    const requestScope = `${machine}\u0000${path}`
     refreshController.current?.abort()
     const controller = new AbortController()
     refreshController.current = controller
     setBusy(true)
+    setLoadError((current) => current?.scope === requestScope ? null : current)
     try {
       const next = await api.files(machine, path, controller.signal)
       if (requestId !== refreshRequest.current || controller.signal.aborted) return
       setPayload(next)
+      setLoadError(null)
       setSelected((value) => clampIndex(value, next.entries.length))
       setStatus(`${machine}:${path}`)
     } catch (error) {
       if (requestId === refreshRequest.current && !controller.signal.aborted) {
-        setStatus(`Files: ${formatError(error)}`)
+        const message = formatError(error)
+        setLoadError({ scope: requestScope, message })
+        setStatus(`Files: ${message}`)
       }
     } finally {
       if (requestId === refreshRequest.current) {
@@ -619,19 +627,25 @@ export function FilesScreen({
           <box style={{ flexGrow: 1, flexDirection: "row", gap: 1 }}>
             {!compact && (
               <Panel title="Parent" style={{ width: "24%", paddingTop: 1 }}>
-                <FileRows
-                  entries={parentEntries}
-                  selected={Math.max(0, parentEntries.findIndex((entry) => entry.path === path))}
-                  height={listHeight}
-                  onSelect={(entry) => {
-                    if (entry.type === "dir") setPath(entry.path)
-                  }}
-                />
+                {!activePayload ? (
+                  activeError ? <EmptyState title="Directory unavailable" detail="Press R to try again" /> : <Loading label="Loading parent directory" />
+                ) : (
+                  <FileRows
+                    entries={parentEntries}
+                    selected={Math.max(0, parentEntries.findIndex((entry) => entry.path === path))}
+                    height={listHeight}
+                    onSelect={(entry) => {
+                      if (entry.type === "dir") setPath(entry.path)
+                    }}
+                  />
+                )}
               </Panel>
             )}
             {(!narrow || narrowPane === "list") && (
               <Panel title="Current" active accent={colors.accent} activeBackground={colors.panel} style={{ width: narrow ? "100%" : compact ? "48%" : "38%", paddingTop: 1 }}>
-                {entries.length ? (
+                {!activePayload ? (
+                  activeError ? <EmptyState title="Directory unavailable" detail="Press R to try again" /> : <Loading label="Loading directory" />
+                ) : entries.length ? (
                   <FileRows
                     entries={entries}
                     selected={selected}
@@ -660,7 +674,11 @@ export function FilesScreen({
                     setPreviewBounds({ columns: measurement.columns, rows: measurement.rows })
                   }}
                 >
-                  <Preview preview={preview} entry={current} />
+                  {!activePayload ? (
+                    activeError ? <EmptyState title="Preview unavailable" detail="The directory could not be loaded" /> : <Loading label="Loading preview" />
+                  ) : (
+                    <Preview preview={preview} entry={current} />
+                  )}
                 </box>
               </Panel>
             )}

--- a/ui/src/remotes-screen.tsx
+++ b/ui/src/remotes-screen.tsx
@@ -1,7 +1,7 @@
 import { useKeyboard } from "@opentui/react"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { api, formatError } from "./api"
-import { EmptyState, KeyHint, Modal, Panel, formatAge, useVisibleRows } from "./components"
+import { EmptyState, KeyHint, Loading, Modal, Panel, formatAge, useVisibleRows } from "./components"
 import { handleSelectionScroll } from "./mouse"
 import { remoteSystemInfo, remoteVersion } from "./remotes-utils"
 import { clampIndex } from "./state-utils"
@@ -34,7 +34,8 @@ export function RemotesScreen({
   const [enabled, setEnabled] = useState(true)
   const [selected, setSelected] = useState(0)
   const [dialog, setDialog] = useState<RemoteDialog>({ type: "none" })
-  const [loading, setLoading] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [loaded, setLoaded] = useState(false)
   const refreshRequest = useRef(0)
   const refreshController = useRef<AbortController | null>(null)
   const current = machines[selected]
@@ -54,6 +55,7 @@ export function RemotesScreen({
       setMachines(payload.machines)
       setEnabled(payload.enabled !== false)
       setSelected((value) => clampIndex(value, payload.machines.length))
+      setLoaded(true)
       setStatus(
         payload.enabled === false
           ? "Remote worker support is disabled"
@@ -158,28 +160,32 @@ export function RemotesScreen({
         <Panel title="Remote status" active accent={colors.accent} activeBackground={colors.panel} style={{ height: 3, alignItems: "center", justifyContent: "center" }}>
           <text
             fg={theme.muted}
-            content={`On ${online}  │  Off ${offline}  │  Total ${machines.length}  │  ${loading ? "SYNC" : "READY"}`}
+            content={loaded
+              ? `On ${online}  │  Off ${offline}  │  Total ${machines.length}  │  ${loading ? "SYNC" : "READY"}`
+              : `On —  │  Off —  │  Total —  │  ${loading ? "SYNC" : "ERROR"}`}
           />
         </Panel>
       ) : (
         <box style={{ height: compact ? 2 : 4, flexDirection: "row", gap: 1 }}>
           <Panel title={compact ? "On" : "Online"} active accent={colors.accent} activeBackground={colors.panel} style={{ flexGrow: 1, alignItems: "center", justifyContent: "center" }}>
-            <text fg={theme.green} attributes={1} content={String(online)} />
+            <text fg={theme.green} attributes={1} content={loaded ? String(online) : "—"} />
           </Panel>
           <Panel title={compact ? "Off" : "Offline"} style={{ flexGrow: 1, alignItems: "center", justifyContent: "center" }}>
-            <text fg={offline ? theme.orange : theme.faint} attributes={1} content={String(offline)} />
+            <text fg={offline ? theme.orange : theme.faint} attributes={1} content={loaded ? String(offline) : "—"} />
           </Panel>
           <Panel title="Total" style={{ flexGrow: 1, alignItems: "center", justifyContent: "center" }}>
-            <text fg={colors.accent} attributes={1} content={String(machines.length)} />
+            <text fg={colors.accent} attributes={1} content={loaded ? String(machines.length) : "—"} />
           </Panel>
           <Panel title={compact ? "Ctl" : "Controller"} style={{ flexGrow: 1, alignItems: "center", justifyContent: "center" }}>
-            <text fg={theme.blue} content={loading ? (compact ? "SYNC" : "SYNCING") : "READY"} />
+            <text fg={theme.blue} content={loading ? (compact ? "SYNC" : "SYNCING") : loaded ? "READY" : "ERROR"} />
           </Panel>
         </box>
       )}
       <box style={{ flexGrow: 1, flexDirection: compact ? "column" : "row", gap: 1 }}>
         <Panel title="Remote nodes" active accent={colors.accent} activeBackground={colors.panel} style={{ flexGrow: 1, paddingTop: 1 }}>
-          {machines.length === 0 ? (
+          {!loaded ? (
+            loading ? <Loading label="Loading remote nodes" /> : <EmptyState title="Remotes unavailable" detail="Press r to try again" />
+          ) : machines.length === 0 ? (
             <EmptyState
               title={enabled ? "No remote nodes" : "Remote workers disabled"}
               detail={enabled ? "Press n to create a one-time join invite" : "Enable remote workers in server configuration"}
@@ -253,6 +259,8 @@ export function RemotesScreen({
               <text fg={theme.borderBright} content="\nSystem information" />
               <text fg={theme.muted} content={JSON.stringify(remoteSystemInfo(current), null, 2)} />
             </scrollbox>
+          ) : !loaded ? (
+            loading ? <Loading label="Loading node details" /> : <EmptyState title="Remotes unavailable" detail="Press r to try again" />
           ) : (
             <EmptyState title="No node selected" detail="Create an invite to attach one" />
           )}

--- a/ui/src/terminals-screen.tsx
+++ b/ui/src/terminals-screen.tsx
@@ -2,7 +2,7 @@ import type { InputRenderable, MouseEvent as OpenTUIMouseEvent } from "@opentui/
 import { useKeyboard } from "@opentui/react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { api, formatError } from "./api"
-import { EmptyState, KeyHint, MachineSidebar, Modal, Panel, formatAge } from "./components"
+import { EmptyState, KeyHint, Loading, MachineSidebar, Modal, Panel, formatAge } from "./components"
 import { clampIndex, scopedItems } from "./state-utils"
 import {
   terminalDisplayRows,
@@ -106,8 +106,11 @@ export function TerminalsScreen({
 }) {
   const [sessions, setSessions] = useState<TerminalSession[]>([])
   const [sessionsMachine, setSessionsMachine] = useState<string | null>(null)
+  const [sessionsError, setSessionsError] = useState<string | null>(null)
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null)
   const [output, setOutput] = useState("")
+  const [outputScope, setOutputScope] = useState<string | null>(null)
+  const [outputError, setOutputError] = useState<{ scope: string; message: string } | null>(null)
   const [audit, setAudit] = useState<AuditEntry[]>([])
   const [showAudit, setShowAudit] = useState(width >= 118)
   const [rawMode, setRawMode] = useState(false)
@@ -123,9 +126,13 @@ export function TerminalsScreen({
   const sessionsController = useRef<AbortController | null>(null)
   const outputController = useRef<AbortController | null>(null)
   const machineRef = useRef(machine)
+  const sessionsReady = sessionsMachine === machine
   const activeSessions = scopedItems(sessionsMachine, machine, sessions)
   const selectedSession = activeSessions.find((session) => session.session_id === selectedSessionId)
     || activeSessions[0]
+  const selectedOutputScope = selectedSession ? `${machine}\u0000${selectedSession.session_id}` : null
+  const outputReady = selectedOutputScope !== null && outputScope === selectedOutputScope
+  const selectedOutputError = outputError?.scope === selectedOutputScope ? outputError.message : null
   const selected = Math.max(0, activeSessions.findIndex((session) => session.session_id === selectedSession?.session_id))
   const selectedSessionIdRef = useRef<string | null>(selectedSession?.session_id || null)
   machineRef.current = machine
@@ -174,6 +181,7 @@ export function TerminalsScreen({
     sessionsController.current = controller
     const requestId = ++sessionsRequest.current
     const targetMachine = machine
+    setSessionsError(null)
     try {
       const payload = await api.terminals(targetMachine, controller.signal)
       if (
@@ -183,6 +191,7 @@ export function TerminalsScreen({
       ) return []
       setSessions(payload.sessions)
       setSessionsMachine(targetMachine)
+      setSessionsError(null)
       setSelectedSessionId((current) => {
         const preferred = selectedSessionIdRef.current || current
         const nextSessionId = preferred && payload.sessions.some((session) => session.session_id === preferred)
@@ -193,7 +202,11 @@ export function TerminalsScreen({
       })
       return payload.sessions
     } catch (error) {
-      if (!controller.signal.aborted) setStatus(`Terminals: ${formatError(error)}`)
+      if (!controller.signal.aborted && machineRef.current === targetMachine) {
+        const message = formatError(error)
+        setSessionsError(message)
+        setStatus(`Terminals: ${message}`)
+      }
       return []
     } finally {
       if (sessionsController.current === controller) sessionsController.current = null
@@ -211,9 +224,13 @@ export function TerminalsScreen({
     if (!targetSession) {
       outputController.current = null
       setOutput("")
+      setOutputScope(null)
+      setOutputError(null)
       setAudit([])
       return
     }
+    const targetScope = `${targetMachine}\u0000${targetSession}`
+    setOutputError((current) => current?.scope === targetScope ? null : current)
     try {
       const [terminal, records] = await Promise.all([
         api.terminalRead(
@@ -235,9 +252,15 @@ export function TerminalsScreen({
       ) return
       if (scrollOffsetRef.current > 0) pendingOutputRef.current = terminal.output
       else setOutput(terminal.output)
+      setOutputScope(targetScope)
+      setOutputError(null)
       setAudit(records.entries)
     } catch (error) {
-      if (!controller.signal.aborted) setStatus(`Terminal: ${formatError(error)}`)
+      if (!controller.signal.aborted && machineRef.current === targetMachine && selectedSessionIdRef.current === targetSession) {
+        const message = formatError(error)
+        setOutputError({ scope: targetScope, message })
+        setStatus(`Terminal: ${message}`)
+      }
     } finally {
       if (outputController.current === controller) outputController.current = null
     }
@@ -247,10 +270,13 @@ export function TerminalsScreen({
     sessionsRequest.current += 1
     outputRequest.current += 1
     setSessions([])
-    setSessionsMachine(machine)
+    setSessionsMachine(null)
+    setSessionsError(null)
     setSelectedSessionId(null)
     selectedSessionIdRef.current = null
     setOutput("")
+    setOutputScope(null)
+    setOutputError(null)
     pendingOutputRef.current = null
     scrollOffsetRef.current = 0
     setScrollOffset(0)
@@ -393,9 +419,12 @@ export function TerminalsScreen({
     const next = (index + delta + machines.length) % machines.length
     setSessions([])
     setSessionsMachine(null)
+    setSessionsError(null)
     setSelectedSessionId(null)
     selectedSessionIdRef.current = null
     setOutput("")
+    setOutputScope(null)
+    setOutputError(null)
     pendingOutputRef.current = null
     scrollOffsetRef.current = 0
     setScrollOffset(0)
@@ -490,9 +519,12 @@ export function TerminalsScreen({
               if (nextMachine === machine) return
               setSessions([])
               setSessionsMachine(null)
+              setSessionsError(null)
               setSelectedSessionId(null)
               selectedSessionIdRef.current = null
               setOutput("")
+              setOutputScope(null)
+              setOutputError(null)
               setAudit([])
               setDialog({ type: "none" })
               setRawMode(false)
@@ -506,7 +538,7 @@ export function TerminalsScreen({
             <text
               fg={selectedSession ? colors.accent : theme.faint}
               attributes={selectedSession ? 1 : 0}
-              content={selectedSession?.session_id || "no terminal"}
+              content={sessionsReady ? selectedSession?.session_id || "no terminal" : sessionsError ? "unavailable" : "loading terminals"}
             />
             <box style={{ flexGrow: 1 }} />
             {rawMode && <text fg={theme.orange} attributes={1} content="RAW INPUT  " />}
@@ -516,22 +548,36 @@ export function TerminalsScreen({
           </box>
           <box style={{ flexGrow: 1, flexDirection: "row", gap: 1 }}>
             <Panel title="Terminal" active accent={colors.accent} activeBackground={colors.panel} style={{ flexGrow: 1, padding: 1 }}>
-              {selectedSession ? (
-                <box
-                  onMouseScroll={handleOutputScroll}
-                  style={{ flexGrow: 1, flexDirection: "column" }}
-                >
-                  {visibleLines.map((line, index) => (
-                    <text key={`${index}-${line}`} fg={theme.text} wrapMode="none" content={line || " "} />
-                  ))}
-                </box>
+              {!sessionsReady ? (
+                sessionsError ? <EmptyState title="Terminals unavailable" detail="Switch machines or retry shortly" /> : <Loading label="Loading terminals" />
+              ) : selectedSession ? (
+                !outputReady ? (
+                  selectedOutputError ? <EmptyState title="Terminal output unavailable" detail="Press Alt+R to try again" /> : <Loading label="Loading terminal output" />
+                ) : (
+                  <box
+                    onMouseScroll={handleOutputScroll}
+                    style={{ flexGrow: 1, flexDirection: "column" }}
+                  >
+                    {visibleLines.map((line, index) => (
+                      <text key={`${index}-${line}`} fg={theme.text} wrapMode="none" content={line || " "} />
+                    ))}
+                  </box>
+                )
               ) : (
                 <EmptyState title="No persistent terminal" detail="Press Alt+N to create one" />
               )}
             </Panel>
             {showAudit && (
               <Panel title="MCP audit · manual input excluded" style={{ width: Math.max(30, Math.floor(width * 0.28)) }}>
-                <AuditRail entries={audit} />
+                {!sessionsReady ? (
+                  sessionsError ? <EmptyState title="Audit unavailable" detail="Terminal sessions could not be loaded" /> : <Loading label="Loading terminal activity" />
+                ) : !selectedSession ? (
+                  <EmptyState title="No terminal selected" detail="Create or select a terminal first" />
+                ) : !outputReady ? (
+                  selectedOutputError ? <EmptyState title="Audit unavailable" detail="Press Alt+R to try again" /> : <Loading label="Loading terminal activity" />
+                ) : (
+                  <AuditRail entries={audit} />
+                )}
               </Panel>
             )}
           </box>
@@ -541,7 +587,7 @@ export function TerminalsScreen({
                 key={selectedSession?.session_id || "no-session"}
                 ref={commandInputRef}
                 focused={Boolean(selectedSession) && !rawMode && dialog.type === "none"}
-                placeholder={selectedSession ? "Enter a command…" : "Create a terminal first"}
+                placeholder={!sessionsReady ? "Loading terminals…" : selectedSession ? "Enter a command…" : "Create a terminal first"}
                 onSubmit={(value: unknown) => submitCommand(typeof value === "string" ? value : "")}
               />
             </Panel>
@@ -578,7 +624,9 @@ export function TerminalsScreen({
                 />
               </box>
             ))}
-            {activeSessions.length === 0 && <text fg={theme.faint} content="No sessions" />}
+            {!sessionsReady
+              ? <text fg={sessionsError ? theme.red : theme.faint} content={sessionsError ? "Sessions unavailable" : "Loading sessions…"} />
+              : activeSessions.length === 0 && <text fg={theme.faint} content="No sessions" />}
             <box style={{ flexGrow: 1 }} />
             {selectedSession?.created && (
               <text fg={theme.faint} content={formatAge(Number(selectedSession.created))} />

--- a/ui/src/todos-screen.tsx
+++ b/ui/src/todos-screen.tsx
@@ -1,7 +1,7 @@
 import { useKeyboard } from "@opentui/react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { api, formatError } from "./api"
-import { EmptyState, KeyHint, Modal, Panel, useVisibleRows } from "./components"
+import { EmptyState, KeyHint, Loading, Modal, Panel, useVisibleRows } from "./components"
 import { handleSelectionScroll } from "./mouse"
 import { clampIndex, nextValue, updateTodo } from "./state-utils"
 import { screenTheme, theme } from "./theme"
@@ -55,6 +55,8 @@ export function TodosScreen({
   const [filter, setFilter] = useState<"all" | "open" | "completed">("all")
   const [dialog, setDialog] = useState<TodoDialog>({ type: "none" })
   const [saving, setSaving] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [loaded, setLoaded] = useState(false)
   const stateRef = useRef<{ todos: TodoItem[]; revision: number }>({ todos: [], revision: 0 })
   const mutationQueue = useRef<Promise<void>>(Promise.resolve())
   const pendingMutations = useRef(0)
@@ -89,10 +91,14 @@ export function TodosScreen({
   }, [])
 
   const load = useCallback(async () => {
+    setLoading(true)
     try {
       applyPayload(await api.todos())
+      if (mounted.current) setLoaded(true)
     } catch (error) {
       if (mounted.current) setStatus(`Todos: ${formatError(error)}`)
+    } finally {
+      if (mounted.current) setLoading(false)
     }
   }, [applyPayload, setStatus])
 
@@ -222,9 +228,9 @@ export function TodosScreen({
       {width < 76 ? (
         <Panel title="Summary" active accent={colors.accent} activeBackground={colors.panel} style={{ height: 3, alignItems: "center", justifyContent: "center" }}>
           <box style={{ flexDirection: "row" }}>
-            <text onMouseDown={() => selectFilter("all")} fg={colors.accent} content={`A:${counts.total}  `} />
-            <text onMouseDown={() => selectFilter("open")} fg={theme.yellow} content={`O:${counts.open}  `} />
-            <text onMouseDown={() => selectFilter("completed")} fg={theme.green} content={`D:${counts.completed}  `} />
+            <text onMouseDown={() => selectFilter("all")} fg={colors.accent} content={`A:${loaded ? counts.total : "—"}  `} />
+            <text onMouseDown={() => selectFilter("open")} fg={theme.yellow} content={`O:${loaded ? counts.open : "—"}  `} />
+            <text onMouseDown={() => selectFilter("completed")} fg={theme.green} content={`D:${loaded ? counts.completed : "—"}  `} />
             <text onMouseDown={cycleFilter} fg={theme.muted} content={`V:${filter.slice(0, 1).toUpperCase()}`} />
           </box>
         </Panel>
@@ -236,7 +242,7 @@ export function TodosScreen({
             { label: "Done", value: counts.completed, color: theme.green, filter: "completed" as const },
           ].map(({ label, value, color, filter: nextFilter }) => (
             <Panel key={label} title={label} onMouseDown={() => selectFilter(nextFilter)} style={{ flexGrow: 1, alignItems: "center", justifyContent: "center" }}>
-              <text fg={color} attributes={1} content={String(value)} />
+              <text fg={color} attributes={1} content={loaded ? String(value) : "—"} />
             </Panel>
           ))}
           <Panel title="View" active accent={colors.accent} activeBackground={colors.panel} onMouseDown={cycleFilter} style={{ width: Math.max(20, Math.floor(width * 0.2)), alignItems: "center", justifyContent: "center" }}>
@@ -244,8 +250,10 @@ export function TodosScreen({
           </Panel>
         </box>
       )}
-      <Panel title={`Todos · ${visible.length}`} active accent={colors.accent} activeBackground={colors.panel} style={{ flexGrow: 1, paddingTop: 1 }}>
-        {visible.length === 0 ? (
+      <Panel title={`Todos · ${loaded ? visible.length : "—"}`} active accent={colors.accent} activeBackground={colors.panel} style={{ flexGrow: 1, paddingTop: 1 }}>
+        {!loaded ? (
+          loading ? <Loading label="Loading todos" /> : <EmptyState title="Todos unavailable" detail="Press r to try again" />
+        ) : visible.length === 0 ? (
           <EmptyState title="No matching todos" detail="Press n to add an item" />
         ) : (
           <box
@@ -300,7 +308,7 @@ export function TodosScreen({
           { key: "e", label: "edit", onPress: editCurrent, disabled: footerLocked || !current },
           { key: "d", label: "delete", onPress: deleteCurrent, disabled: footerLocked || !current },
           { key: "f", label: "filter", onPress: cycleFilter, disabled: footerLocked },
-          { key: "r", label: "refresh", onPress: () => void load(), disabled: footerLocked || saving },
+          { key: "r", label: loading ? "refreshing" : "refresh", onPress: () => void load(), disabled: footerLocked || saving || loading },
         ]}
       />
       {saving && (


### PR DESCRIPTION
## Summary

- show explicit loading states on Dashboard, Files, Terminals, Todos, Audit, and Remotes before their first API response
- reserve empty-state messages and zero counts for successfully loaded empty results
- keep existing data visible during background refreshes and scope Files/Terminals readiness to the active machine, path, and session
- show retry-oriented unavailable states when an initial request fails

## Validation

- [x] `cd ui && bun run test` (62 passed; 92.55% line coverage)
- [x] `cd ui && bun run typecheck`
- [x] `cd ui && bun run build`
- [x] `./ui/dist/local-shell-mcp-tui --version`
- [x] `python scripts/ui-pty-smoke.py --tui ui/dist/local-shell-mcp-tui`
- [ ] `ruff check .` (not run; TypeScript-only change)
- [ ] `pytest -q` (not run; TypeScript-only change)
- [ ] `mkdocs build --strict` (docs unchanged)
- [ ] VS Code extension compile (extension unchanged)

## Safety checklist

- [x] No secrets, tunnel tokens, OAuth pins, private keys, or bearer file-link URLs are committed.
- [x] No MCP tools were added or changed.
- [x] Host-control, remote-worker, file-link, and credential behavior are unchanged.
- [x] Backwards compatible; this changes only transient TUI rendering before initial data loads.
