### PR TITLE
fix(ui): prevent Dashboard alert text overlap

### DIFF
--- a/ui/src/dashboard-screen.test.tsx
+++ b/ui/src/dashboard-screen.test.tsx
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { testRender } from "@opentui/react/test-utils"
+import { Alerts } from "./dashboard-screen"
+import type { DashboardAlert } from "./types"
+
+const renderers: Array<{ destroy: () => void }> = []
+
+afterEach(() => {
+  for (const renderer of renderers.splice(0)) renderer.destroy()
+})
+
+describe("Dashboard alerts", () => {
+  test("renders titles and details on separate terminal rows", async () => {
+    const alerts: DashboardAlert[] = [
+      {
+        severity: "warning",
+        title: "Job fixed-nju-cli-3 failed",
+        detail: "set -euo pipefail",
+      },
+      {
+        severity: "warning",
+        title: "Job fixed-nju-cli-2 failed",
+        detail: "export CARGO_HOME=/workspace/.cargo",
+      },
+      {
+        severity: "warning",
+        title: "Job fixed-nju-cli failed",
+        detail: "rustup toolchain install stable --profile minimal",
+      },
+      {
+        severity: "warning",
+        title: "1 recent MCP call failure(s)",
+        detail: "Open Audit for call inputs and returned errors",
+      },
+    ]
+    const setup = await testRender(<Alerts alerts={alerts} width={58} rows={4} />, {
+      width: 58,
+      height: 14,
+    })
+    renderers.push(setup.renderer)
+
+    const reactTestGlobal = globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    reactTestGlobal.IS_REACT_ACT_ENVIRONMENT = false
+    await setup.renderOnce()
+    const lines = setup.captureCharFrame().split("\n")
+
+    expect(lines).toContainEqual(expect.stringContaining("WARN  Job fixed-nju-cli-3 failed"))
+    expect(lines).toContainEqual(expect.stringContaining("set -euo pipefail"))
+    expect(lines).toContainEqual(expect.stringContaining("WARN  Job fixed-nju-cli-2 failed"))
+    expect(lines).toContainEqual(expect.stringContaining("export CARGO_HOME=/workspace/.cargo"))
+    expect(lines).toContainEqual(expect.stringContaining("WARN  Job fixed-nju-cli failed"))
+    expect(lines).toContainEqual(expect.stringContaining("rustup toolchain install stable --profile minimal"))
+    expect(lines).toContainEqual(expect.stringContaining("WARN  1 recent MCP call failure(s)"))
+    expect(lines).toContainEqual(expect.stringContaining("Open Audit for call inputs and returned errors"))
+  })
+})

--- a/ui/src/dashboard-screen.tsx
+++ b/ui/src/dashboard-screen.tsx
@@ -252,7 +252,7 @@ function ActiveWorkloads({ payload, width, rows }: { payload: DashboardPayload; 
   )
 }
 
-function Alerts({ alerts, width, rows }: { alerts: DashboardAlert[]; width: number; rows: number }) {
+export function Alerts({ alerts, width, rows }: { alerts: DashboardAlert[]; width: number; rows: number }) {
   const visible = alerts.slice(0, rows)
   return (
     <Panel title={`Needs attention · ${alerts.length}`} style={{ flexGrow: 1, padding: 1 }}>
@@ -262,7 +262,10 @@ function Alerts({ alerts, width, rows }: { alerts: DashboardAlert[]; width: numb
         </box>
       ) : (
         visible.map((alert, index) => (
-          <box key={`${alert.title}-${index}`} style={{ flexDirection: "column", marginBottom: 1 }}>
+          <box
+            key={`${alert.title}-${index}`}
+            style={{ height: width >= 34 ? 2 : 1, flexDirection: "column", flexShrink: 0 }}
+          >
             <box style={{ flexDirection: "row" }}>
               <text fg={severityColor(alert.severity)} attributes={1} content={`${alert.severity.toUpperCase().slice(0, 4).padEnd(5)} `} />
               <text fg={theme.text} content={truncate(alert.title, Math.max(10, width - 11))} />


### PR DESCRIPTION
## Summary
- reserve fixed terminal rows for each Dashboard alert title/detail pair
- prevent OpenTUI from collapsing nested alert rows into the same cells
- add a renderer regression test using the exact content pattern from the report

## Validation
- `bun run typecheck`
- `bun test` (63 passed)
- `bun run build`