### PR TITLE
docs: add multilingual FAQ for ChatGPT tool refresh and Nginx WebSockets

### DIFF
--- a/docs/faq.ar.md
+++ b/docs/faq.ar.md
@@ -1,0 +1,100 @@
+# الأسئلة الشائعة
+
+تجمع هذه الصفحة مشكلات متكررة في Client والوكيل العكسي قد تبدو كأعطال في LSM رغم أن الخادم نفسه يعمل بصورة سليمة.
+
+## لماذا لا تتوفر بعض الأدوات في ChatGPT بعد ترقية LSM؟
+
+### الأعراض
+
+- لا تظهر الأدوات الجديدة في ChatGPT.
+- يستمر ChatGPT في محاولة استدعاء أداة حُذفت أو أُعيدت تسميتها أو دُمجت.
+- تكون الأداة موجودة، لكن الاستدعاء يفشل لأن ChatGPT يرسل مخطط إدخال أقدم.
+- لا تؤدي إعادة تشغيل LSM أو بدء محادثة جديدة إلى حل المشكلة.
+
+### السبب
+
+قد يحتفظ ChatGPT بلقطة ثابتة للأدوات ومخططات الإدخال التي كانت متاحة عند فحص MCP App أو اعتمادها أو نشرها. عندما يغيّر إصدار LSM قيمة `tools/list`، لا يوجد ضمان بأن تتحدث هذه اللقطة تلقائياً. وليست ذاكرة مؤقتة قصيرة ذات مدة انتهاء موثقة.
+
+### الحل
+
+=== "وضع المطور أو اتصال شخصي"
+
+    1. افتح **ChatGPT Settings → Apps**.
+    2. افتح LSM App واستخدم **Refresh** لإعادة فحص الأدوات.
+    3. إذا لم يتوفر Refresh، احذف App القديمة وأضف نقطة MCP نفسها من جديد.
+    4. ابدأ محادثة جديدة بعد اعتماد قائمة الأدوات المحدثة.
+
+=== "App منشورة في ChatGPT Business"
+
+    لا يمكن حالياً تحديث أدوات أو بيانات App مخصصة منشورة في مكانها. يجب على مسؤول مساحة العمل إنشاء App جديدة، وفحص نقطة LSM الحالية، ونشر البديل، ثم إيقاف App القديمة.
+
+=== "ChatGPT Enterprise أو Edu"
+
+    يستطيع المسؤول فتح **Workspace Settings → Apps → LSM App → … → Action control → Refresh**، ومراجعة الفروق، وتفعيل actions الجديدة عند الحاجة.
+
+راجع [issue #70](https://github.com/fwerkor/local-shell-mcp/issues/70) و[وثائق OpenAI الخاصة بـ MCP Apps](https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt).
+
+## لماذا تستمر WebUI في إعادة الاتصال خلف Nginx؟
+
+### الأعراض
+
+- تُحمّل صفحة WebUI وتسجيل OAuth بصورة طبيعية.
+- لا تظهر TUI.
+- تتكرر الحالات `Connecting` و`Connection error` و`Reconnecting`.
+- يعمل الاتصال المباشر بالمنفذ `8765`.
+
+### السبب
+
+تعرض واجهة المتصفح TUI الأصلية عبر PTY WebSocket. نقطة الاتصال الافتراضية هي `/ui/ws`، ومع `ui_path` مخصص تصبح `${ui_path}/ws`. لا يمرر `proxy_pass` العادي في Nginx تلقائياً ترويسات hop-by-hop المطلوبة لترقية WebSocket.
+
+### الحل
+
+فعّل HTTP/1.1 ومرر ترويستي `Upgrade` و`Connection`:
+
+```nginx
+# ضع map داخل كتلة http.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 443 ssl;
+    server_name lsm.example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8765;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        proxy_buffering off;
+    }
+}
+```
+
+تحقق من الإعداد ثم أعد تحميل Nginx:
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+في Nginx Proxy Manager، فعّل **Websockets Support** في Proxy Host. إذا استمرت إعادة الاتصال، أضف ترويسات الترقية المكافئة في Advanced.
+
+### التحقق
+
+افتح أدوات المطور، وأعد تحميل WebUI، وافحص طلب `/ui/ws`. يعيد الاتصال السليم:
+
+```text
+101 Switching Protocols
+```
+
+راجع [issue #71](https://github.com/fwerkor/local-shell-mcp/issues/71).

--- a/docs/faq.de.md
+++ b/docs/faq.de.md
@@ -1,0 +1,100 @@
+# Häufig gestellte Fragen
+
+Diese Seite behandelt wiederkehrende Client- und Reverse-Proxy-Probleme, die wie LSM-Fehler wirken können, obwohl der Server selbst fehlerfrei läuft.
+
+## Warum fehlen nach einem LSM-Upgrade einige Werkzeuge in ChatGPT?
+
+### Symptome
+
+- Neue Werkzeuge werden in ChatGPT nicht angezeigt.
+- ChatGPT versucht weiterhin, ein entferntes, umbenanntes oder zusammengeführtes Werkzeug aufzurufen.
+- Das Werkzeug existiert, aber der Aufruf scheitert, weil ChatGPT ein älteres Eingabeschema sendet.
+- Ein Neustart von LSM oder eine neue Unterhaltung behebt das Problem nicht.
+
+### Ursache
+
+ChatGPT kann einen eingefrorenen Snapshot der Werkzeuge und Eingabeschemata behalten, die beim Scannen, Genehmigen oder Veröffentlichen einer MCP App verfügbar waren. Wenn eine LSM-Version `tools/list` ändert, wird dieser Snapshot nicht garantiert automatisch aktualisiert. Es handelt sich nicht um einen kurzlebigen Cache mit dokumentierter Ablaufzeit.
+
+### Lösung
+
+=== "Entwicklermodus oder persönliche Verbindung"
+
+    1. Öffnen Sie **ChatGPT Settings → Apps**.
+    2. Öffnen Sie die LSM App und führen Sie mit **Refresh** einen erneuten Scan durch.
+    3. Falls Refresh fehlt, löschen Sie die alte App und fügen denselben MCP-Endpunkt erneut hinzu.
+    4. Starten Sie nach der Übernahme der neuen Werkzeugliste eine neue Unterhaltung.
+
+=== "Veröffentlichte App in ChatGPT Business"
+
+    Eine veröffentlichte benutzerdefinierte App kann ihre Werkzeuge oder Metadaten derzeit nicht direkt aktualisieren. Ein Administrator muss eine neue App erstellen, den aktuellen LSM-Endpunkt scannen, den Ersatz veröffentlichen und die alte App außer Betrieb nehmen.
+
+=== "ChatGPT Enterprise oder Edu"
+
+    Ein Administrator kann **Workspace Settings → Apps → LSM App → … → Action control → Refresh** öffnen, die Änderungen prüfen und neue Actions bei Bedarf aktivieren.
+
+Siehe [Issue #70](https://github.com/fwerkor/local-shell-mcp/issues/70) und die [OpenAI-Dokumentation zu MCP Apps](https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt).
+
+## Warum verbindet sich die WebUI hinter Nginx ständig neu?
+
+### Symptome
+
+- WebUI und OAuth-Anmeldung werden normal geladen.
+- Die TUI erscheint nicht.
+- Der Status wechselt ständig zwischen `Connecting`, `Connection error` und `Reconnecting`.
+- Der direkte Zugriff auf Port `8765` funktioniert.
+
+### Ursache
+
+Die Browseroberfläche rendert die native TUI über einen PTY WebSocket. Der Standardendpunkt ist `/ui/ws`; bei einem benutzerdefinierten `ui_path` lautet er `${ui_path}/ws`. Ein normales Nginx-`proxy_pass` leitet die für das WebSocket-Upgrade nötigen hop-by-hop-Header nicht automatisch weiter.
+
+### Lösung
+
+Aktivieren Sie HTTP/1.1 und leiten Sie `Upgrade` und `Connection` weiter:
+
+```nginx
+# map gehört in den http-Block.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 443 ssl;
+    server_name lsm.example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8765;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        proxy_buffering off;
+    }
+}
+```
+
+Prüfen und laden Sie Nginx anschließend neu:
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+Aktivieren Sie in Nginx Proxy Manager **Websockets Support** für den Proxy Host. Bei weiteren Verbindungsversuchen ergänzen Sie die entsprechenden Header unter Advanced.
+
+### Prüfung
+
+Öffnen Sie die Browser-Entwicklertools, laden Sie WebUI neu und prüfen Sie die Anfrage `/ui/ws`. Eine funktionierende Verbindung liefert:
+
+```text
+101 Switching Protocols
+```
+
+Siehe [Issue #71](https://github.com/fwerkor/local-shell-mcp/issues/71).

--- a/docs/faq.es.md
+++ b/docs/faq.es.md
@@ -1,0 +1,100 @@
+# Preguntas frecuentes
+
+Esta página reúne problemas recurrentes de Client y proxy inverso que pueden parecer fallos de LSM aunque el servidor esté funcionando correctamente.
+
+## ¿Por qué algunas herramientas no están disponibles en ChatGPT después de actualizar LSM?
+
+### Síntomas
+
+- Las herramientas nuevas no aparecen en ChatGPT.
+- ChatGPT intenta llamar a una herramienta eliminada, renombrada o combinada.
+- La herramienta existe, pero la llamada falla porque ChatGPT envía un esquema de entrada antiguo.
+- Reiniciar LSM o abrir una conversación nueva no soluciona el problema.
+
+### Causa
+
+ChatGPT puede conservar una instantánea congelada de las herramientas y los esquemas de entrada disponibles cuando se analizó, aprobó o publicó una MCP App. Cuando una versión de LSM cambia `tools/list`, no se garantiza que esa instantánea se actualice automáticamente. No es una caché de corta duración con una caducidad documentada.
+
+### Solución
+
+=== "Modo de desarrollador o conexión personal"
+
+    1. Abra **ChatGPT Settings → Apps**.
+    2. Abra la App de LSM y use **Refresh** para volver a analizar las herramientas.
+    3. Si Refresh no está disponible, elimine la App antigua y añada de nuevo el mismo endpoint MCP.
+    4. Inicie una conversación nueva después de aceptar la lista actualizada.
+
+=== "App publicada en ChatGPT Business"
+
+    Actualmente, una App personalizada publicada no puede actualizar sus herramientas o metadatos en el mismo lugar. Un administrador debe crear otra App, analizar el endpoint actual de LSM, publicar el reemplazo y retirar la App anterior.
+
+=== "ChatGPT Enterprise o Edu"
+
+    Un administrador puede abrir **Workspace Settings → Apps → LSM App → … → Action control → Refresh**, revisar las diferencias y habilitar las acciones nuevas cuando sea necesario.
+
+Consulte el [issue #70](https://github.com/fwerkor/local-shell-mcp/issues/70) y la [documentación de MCP Apps de OpenAI](https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt).
+
+## ¿Por qué WebUI se reconecta continuamente detrás de Nginx?
+
+### Síntomas
+
+- La página WebUI y el inicio de sesión OAuth cargan correctamente.
+- La TUI nunca aparece.
+- El estado alterna entre `Connecting`, `Connection error` y `Reconnecting`.
+- La conexión directa al puerto `8765` funciona.
+
+### Causa
+
+La interfaz del navegador renderiza la TUI nativa mediante un PTY WebSocket. El endpoint predeterminado es `/ui/ws`; con un `ui_path` personalizado es `${ui_path}/ws`. Un `proxy_pass` normal de Nginx no reenvía automáticamente los encabezados hop-by-hop necesarios para actualizar a WebSocket.
+
+### Solución
+
+Active HTTP/1.1 y reenvíe los encabezados `Upgrade` y `Connection`:
+
+```nginx
+# Coloque map en el bloque http.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 443 ssl;
+    server_name lsm.example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8765;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        proxy_buffering off;
+    }
+}
+```
+
+Después, valide y recargue Nginx:
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+En Nginx Proxy Manager, active **Websockets Support** en el Proxy Host. Si continúa la reconexión, añada los encabezados equivalentes en Advanced.
+
+### Verificación
+
+Abra las herramientas de desarrollo, recargue WebUI y revise la solicitud `/ui/ws`. Una conexión correcta devuelve:
+
+```text
+101 Switching Protocols
+```
+
+Consulte el [issue #71](https://github.com/fwerkor/local-shell-mcp/issues/71).

--- a/docs/faq.fr.md
+++ b/docs/faq.fr.md
@@ -1,0 +1,100 @@
+# Questions fréquentes
+
+Cette page regroupe des problèmes récurrents de Client et de proxy inverse qui peuvent ressembler à des pannes LSM alors que le serveur fonctionne correctement.
+
+## Pourquoi certains outils ChatGPT sont-ils indisponibles après une mise à niveau de LSM ?
+
+### Symptômes
+
+- Les nouveaux outils n’apparaissent pas dans ChatGPT.
+- ChatGPT tente encore d’appeler un outil supprimé, renommé ou fusionné.
+- L’outil existe, mais l’appel échoue parce que ChatGPT envoie un ancien schéma d’entrée.
+- Redémarrer LSM ou ouvrir une nouvelle conversation ne résout pas le problème.
+
+### Cause
+
+ChatGPT peut conserver un instantané figé des outils et schémas d’entrée disponibles lors de l’analyse, de l’approbation ou de la publication d’une MCP App. Lorsqu’une version de LSM modifie `tools/list`, cet instantané n’est pas garanti d’être actualisé automatiquement. Il ne s’agit pas d’un cache de courte durée avec une expiration documentée.
+
+### Solution
+
+=== "Mode développeur ou connexion personnelle"
+
+    1. Ouvrez **ChatGPT Settings → Apps**.
+    2. Ouvrez l’App LSM et utilisez **Refresh** pour analyser à nouveau les outils.
+    3. Si Refresh n’est pas disponible, supprimez l’ancienne App et ajoutez de nouveau le même endpoint MCP.
+    4. Démarrez une nouvelle conversation après validation de la liste mise à jour.
+
+=== "App publiée dans ChatGPT Business"
+
+    Une App personnalisée publiée ne peut actuellement pas mettre à jour sur place ses outils ou métadonnées. Un administrateur doit créer une nouvelle App, analyser l’endpoint LSM actuel, publier le remplacement et retirer l’ancienne App.
+
+=== "ChatGPT Enterprise ou Edu"
+
+    Un administrateur peut ouvrir **Workspace Settings → Apps → LSM App → … → Action control → Refresh**, examiner les différences et activer les nouvelles actions si nécessaire.
+
+Voir l’[issue #70](https://github.com/fwerkor/local-shell-mcp/issues/70) et la [documentation OpenAI sur les MCP Apps](https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt).
+
+## Pourquoi WebUI se reconnecte-t-elle sans cesse derrière Nginx ?
+
+### Symptômes
+
+- La page WebUI et la connexion OAuth se chargent normalement.
+- La TUI n’apparaît jamais.
+- L’état alterne entre `Connecting`, `Connection error` et `Reconnecting`.
+- Une connexion directe au port `8765` fonctionne.
+
+### Cause
+
+L’interface du navigateur affiche la TUI native via un PTY WebSocket. L’endpoint par défaut est `/ui/ws` ; avec un `ui_path` personnalisé, il devient `${ui_path}/ws`. Un `proxy_pass` Nginx normal ne transmet pas automatiquement les en-têtes hop-by-hop nécessaires à la mise à niveau WebSocket.
+
+### Solution
+
+Activez HTTP/1.1 et transmettez les en-têtes `Upgrade` et `Connection` :
+
+```nginx
+# Placez map dans le bloc http.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 443 ssl;
+    server_name lsm.example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8765;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        proxy_buffering off;
+    }
+}
+```
+
+Validez puis rechargez Nginx :
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+Dans Nginx Proxy Manager, activez **Websockets Support** pour le Proxy Host. Si les reconnexions continuent, ajoutez les en-têtes équivalents dans Advanced.
+
+### Vérification
+
+Ouvrez les outils de développement, rechargez WebUI et inspectez la requête `/ui/ws`. Une connexion correcte renvoie :
+
+```text
+101 Switching Protocols
+```
+
+Voir l’[issue #71](https://github.com/fwerkor/local-shell-mcp/issues/71).

--- a/docs/faq.hi.md
+++ b/docs/faq.hi.md
@@ -1,0 +1,100 @@
+# अक्सर पूछे जाने वाले प्रश्न
+
+यह पृष्ठ उन बार-बार आने वाली Client और reverse proxy समस्याओं को समझाता है जो सर्वर के स्वस्थ होने पर भी LSM की विफलता जैसी दिख सकती हैं।
+
+## LSM अपग्रेड करने के बाद ChatGPT में कुछ टूल उपलब्ध क्यों नहीं हैं?
+
+### लक्षण
+
+- नए टूल ChatGPT में दिखाई नहीं देते।
+- ChatGPT हटाए गए, बदले गए नाम वाले या मिलाए गए पुराने टूल को कॉल करता रहता है।
+- टूल मौजूद है, लेकिन ChatGPT पुराना input schema भेजता है और validation विफल हो जाता है।
+- LSM को पुनः आरंभ करने या नई बातचीत खोलने से समस्या ठीक नहीं होती।
+
+### कारण
+
+ChatGPT उस समय उपलब्ध टूल और input schemas का frozen snapshot रख सकता है जब MCP App को scan, approve या publish किया गया था। LSM रिलीज़ में `tools/list` बदलने पर उस snapshot के अपने आप refresh होने की गारंटी नहीं है। यह documented expiry वाला अल्पकालिक cache नहीं है।
+
+### समाधान
+
+=== "Developer mode या व्यक्तिगत connection"
+
+    1. **ChatGPT Settings → Apps** खोलें।
+    2. LSM App खोलें और **Refresh** से टूल दोबारा scan करें।
+    3. Refresh उपलब्ध न हो तो पुरानी App हटाएँ और वही MCP endpoint फिर जोड़ें।
+    4. नई टूल सूची स्वीकार करने के बाद नई बातचीत शुरू करें।
+
+=== "ChatGPT Business में प्रकाशित App"
+
+    वर्तमान में प्रकाशित custom App अपने टूल या metadata को वहीं अपडेट नहीं कर सकती। Workspace administrator को नई App बनानी होगी, वर्तमान LSM endpoint scan करना होगा, replacement publish करना होगा और पुरानी App हटानी होगी।
+
+=== "ChatGPT Enterprise या Edu"
+
+    Administrator **Workspace Settings → Apps → LSM App → … → Action control → Refresh** खोलकर अंतर देख सकता है और आवश्यकता होने पर नई actions सक्षम कर सकता है।
+
+[Issue #70](https://github.com/fwerkor/local-shell-mcp/issues/70) और [OpenAI MCP App documentation](https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt) देखें।
+
+## Nginx के पीछे WebUI बार-बार reconnect क्यों होती है?
+
+### लक्षण
+
+- WebUI पृष्ठ और OAuth login सामान्य रूप से खुलते हैं।
+- TUI दिखाई नहीं देती।
+- स्थिति `Connecting`, `Connection error` और `Reconnecting` के बीच घूमती रहती है।
+- पोर्ट `8765` से सीधा connection काम करता है।
+
+### कारण
+
+Browser UI, PTY WebSocket के माध्यम से native TUI render करती है। Default endpoint `/ui/ws` है; custom `ui_path` के साथ यह `${ui_path}/ws` होता है। सामान्य Nginx `proxy_pass`, WebSocket upgrade के लिए जरूरी hop-by-hop headers अपने आप forward नहीं करता।
+
+### समाधान
+
+HTTP/1.1 सक्षम करें और `Upgrade` तथा `Connection` headers forward करें:
+
+```nginx
+# map को http block में रखें।
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 443 ssl;
+    server_name lsm.example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8765;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        proxy_buffering off;
+    }
+}
+```
+
+Configuration जाँचकर Nginx reload करें:
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+Nginx Proxy Manager में Proxy Host के लिए **Websockets Support** सक्षम करें। Reconnect जारी रहे तो Advanced configuration में समान upgrade headers जोड़ें।
+
+### जाँच
+
+Browser developer tools खोलें, WebUI reload करें और `/ui/ws` request देखें। सही connection यह लौटाती है:
+
+```text
+101 Switching Protocols
+```
+
+[Issue #71](https://github.com/fwerkor/local-shell-mcp/issues/71) देखें।

--- a/docs/faq.id.md
+++ b/docs/faq.id.md
@@ -1,0 +1,100 @@
+# Pertanyaan umum
+
+Halaman ini membahas masalah Client dan reverse proxy yang sering terjadi dan dapat terlihat seperti kegagalan LSM meskipun server sebenarnya sehat.
+
+## Mengapa beberapa alat tidak tersedia di ChatGPT setelah LSM ditingkatkan?
+
+### Gejala
+
+- Alat baru tidak muncul di ChatGPT.
+- ChatGPT masih mencoba memanggil alat lama yang dihapus, diganti nama, atau digabungkan.
+- Alat tersedia, tetapi panggilan gagal karena ChatGPT mengirim skema input lama.
+- Memulai ulang LSM atau membuka percakapan baru tidak menyelesaikan masalah.
+
+### Penyebab
+
+ChatGPT dapat menyimpan snapshot tetap dari alat dan skema input yang tersedia saat MCP App dipindai, disetujui, atau diterbitkan. Saat rilis LSM mengubah `tools/list`, snapshot tersebut tidak dijamin diperbarui secara otomatis. Ini bukan cache singkat dengan waktu kedaluwarsa yang terdokumentasi.
+
+### Solusi
+
+=== "Mode pengembang atau koneksi pribadi"
+
+    1. Buka **ChatGPT Settings → Apps**.
+    2. Buka LSM App dan gunakan **Refresh** untuk memindai ulang alat.
+    3. Jika Refresh tidak tersedia, hapus App lama dan tambahkan kembali endpoint MCP yang sama.
+    4. Mulai percakapan baru setelah daftar alat terbaru diterima.
+
+=== "App yang diterbitkan di ChatGPT Business"
+
+    App kustom yang sudah diterbitkan saat ini tidak dapat memperbarui alat atau metadata secara langsung. Administrator harus membuat App baru, memindai endpoint LSM saat ini, menerbitkan penggantinya, lalu menghentikan App lama.
+
+=== "ChatGPT Enterprise atau Edu"
+
+    Administrator dapat membuka **Workspace Settings → Apps → LSM App → … → Action control → Refresh**, meninjau perbedaan, dan mengaktifkan action baru bila diperlukan.
+
+Lihat [issue #70](https://github.com/fwerkor/local-shell-mcp/issues/70) dan [dokumentasi MCP App OpenAI](https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt).
+
+## Mengapa WebUI terus menyambung ulang di belakang Nginx?
+
+### Gejala
+
+- Halaman WebUI dan login OAuth dimuat normal.
+- TUI tidak pernah muncul.
+- Status terus berubah antara `Connecting`, `Connection error`, dan `Reconnecting`.
+- Koneksi langsung ke port `8765` berfungsi.
+
+### Penyebab
+
+Antarmuka browser merender TUI asli melalui PTY WebSocket. Endpoint default adalah `/ui/ws`; dengan `ui_path` kustom, endpoint menjadi `${ui_path}/ws`. `proxy_pass` Nginx biasa tidak otomatis meneruskan header hop-by-hop yang diperlukan untuk upgrade WebSocket.
+
+### Solusi
+
+Aktifkan HTTP/1.1 dan teruskan header `Upgrade` serta `Connection`:
+
+```nginx
+# Letakkan map di blok http.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 443 ssl;
+    server_name lsm.example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8765;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        proxy_buffering off;
+    }
+}
+```
+
+Validasi lalu muat ulang Nginx:
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+Di Nginx Proxy Manager, aktifkan **Websockets Support** pada Proxy Host. Jika masih menyambung ulang, tambahkan header upgrade yang setara di Advanced.
+
+### Verifikasi
+
+Buka alat pengembang browser, muat ulang WebUI, dan periksa permintaan `/ui/ws`. Koneksi yang benar mengembalikan:
+
+```text
+101 Switching Protocols
+```
+
+Lihat [issue #71](https://github.com/fwerkor/local-shell-mcp/issues/71).

--- a/docs/faq.it.md
+++ b/docs/faq.it.md
@@ -1,0 +1,100 @@
+# Domande frequenti
+
+Questa pagina raccoglie problemi ricorrenti di Client e reverse proxy che possono sembrare guasti di LSM anche quando il server funziona correttamente.
+
+## Perché alcuni strumenti non sono disponibili in ChatGPT dopo l’aggiornamento di LSM?
+
+### Sintomi
+
+- I nuovi strumenti non compaiono in ChatGPT.
+- ChatGPT tenta ancora di chiamare uno strumento rimosso, rinominato o unificato.
+- Lo strumento esiste, ma la chiamata fallisce perché ChatGPT invia un vecchio schema di input.
+- Riavviare LSM o aprire una nuova conversazione non risolve il problema.
+
+### Causa
+
+ChatGPT può conservare un’istantanea congelata degli strumenti e degli schemi di input disponibili quando una MCP App è stata analizzata, approvata o pubblicata. Se una versione di LSM modifica `tools/list`, l’aggiornamento automatico dell’istantanea non è garantito. Non è una cache breve con una scadenza documentata.
+
+### Soluzione
+
+=== "Modalità sviluppatore o connessione personale"
+
+    1. Aprire **ChatGPT Settings → Apps**.
+    2. Aprire la LSM App e usare **Refresh** per analizzare nuovamente gli strumenti.
+    3. Se Refresh non è disponibile, eliminare la vecchia App e aggiungere di nuovo lo stesso endpoint MCP.
+    4. Avviare una nuova conversazione dopo aver accettato l’elenco aggiornato.
+
+=== "App pubblicata in ChatGPT Business"
+
+    Al momento una App personalizzata pubblicata non può aggiornare strumenti o metadati sul posto. Un amministratore deve creare una nuova App, analizzare l’endpoint LSM corrente, pubblicare la sostituta e ritirare la vecchia App.
+
+=== "ChatGPT Enterprise o Edu"
+
+    Un amministratore può aprire **Workspace Settings → Apps → LSM App → … → Action control → Refresh**, esaminare le differenze e abilitare le nuove actions quando necessario.
+
+Vedere l’[issue #70](https://github.com/fwerkor/local-shell-mcp/issues/70) e la [documentazione OpenAI sulle MCP Apps](https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt).
+
+## Perché la WebUI continua a riconnettersi dietro Nginx?
+
+### Sintomi
+
+- La pagina WebUI e l’accesso OAuth vengono caricati normalmente.
+- La TUI non appare.
+- Lo stato passa ripetutamente tra `Connecting`, `Connection error` e `Reconnecting`.
+- Il collegamento diretto alla porta `8765` funziona.
+
+### Causa
+
+L’interfaccia del browser visualizza la TUI nativa tramite un PTY WebSocket. L’endpoint predefinito è `/ui/ws`; con un `ui_path` personalizzato è `${ui_path}/ws`. Un normale `proxy_pass` Nginx non inoltra automaticamente gli header hop-by-hop necessari per l’upgrade WebSocket.
+
+### Soluzione
+
+Abilitare HTTP/1.1 e inoltrare gli header `Upgrade` e `Connection`:
+
+```nginx
+# Inserire map nel blocco http.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 443 ssl;
+    server_name lsm.example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8765;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        proxy_buffering off;
+    }
+}
+```
+
+Verificare e ricaricare Nginx:
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+In Nginx Proxy Manager, abilitare **Websockets Support** sul Proxy Host. Se le riconnessioni continuano, aggiungere gli header equivalenti in Advanced.
+
+### Verifica
+
+Aprire gli strumenti di sviluppo, ricaricare WebUI e controllare la richiesta `/ui/ws`. Una connessione funzionante restituisce:
+
+```text
+101 Switching Protocols
+```
+
+Vedere l’[issue #71](https://github.com/fwerkor/local-shell-mcp/issues/71).

--- a/docs/faq.ja.md
+++ b/docs/faq.ja.md
@@ -1,0 +1,100 @@
+# よくある質問
+
+このページでは、LSM サーバー自体が正常でも障害のように見える、繰り返し発生する Client とリバースプロキシの問題をまとめます。
+
+## LSM の更新後に ChatGPT で一部のツールが使えないのはなぜですか？
+
+### 症状
+
+- 新しいツールが ChatGPT に表示されない。
+- ChatGPT が削除、名称変更、統合された古いツールを呼び出そうとする。
+- ツールは存在するが、古い入力スキーマが送信されて検証に失敗する。
+- LSM の再起動や新しい会話では解決しない。
+
+### 原因
+
+ChatGPT は、MCP App のスキャン、承認、公開時に存在したツールと入力スキーマの凍結スナップショットを保持することがあります。LSM の更新で `tools/list` が変わっても、そのスナップショットが自動更新される保証はありません。公開された有効期限を持つ短期キャッシュではありません。
+
+### 解決方法
+
+=== "開発者モードまたは個人接続"
+
+    1. **ChatGPT Settings → Apps** を開きます。
+    2. LSM App を開き、**Refresh** でツールを再スキャンします。
+    3. Refresh がない場合は古い App を削除し、同じ MCP エンドポイントを追加し直します。
+    4. 新しいツール一覧を受け入れた後、新しい会話を開始します。
+
+=== "ChatGPT Business で公開済みの App"
+
+    現在、公開済みのカスタム App はツールやメタデータをその場で更新できません。ワークスペース管理者が新しい App を作成し、現在の LSM エンドポイントをスキャンして公開し、古い App を廃止する必要があります。
+
+=== "ChatGPT Enterprise または Edu"
+
+    ワークスペース管理者は **Workspace Settings → Apps → LSM App → … → Action control → Refresh** を開き、差分を確認して必要な新しい action を有効化できます。
+
+[Issue #70](https://github.com/fwerkor/local-shell-mcp/issues/70) と [OpenAI の MCP App ドキュメント](https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt)も参照してください。
+
+## Nginx の背後で WebUI が再接続を繰り返すのはなぜですか？
+
+### 症状
+
+- WebUI ページと OAuth ログインは正常に読み込める。
+- TUI が表示されない。
+- 状態が `Connecting`、`Connection error`、`Reconnecting` の間で繰り返し変化する。
+- ポート `8765` に直接接続すると動作する。
+
+### 原因
+
+ブラウザー UI は PTY WebSocket 経由でネイティブ TUI を描画します。既定のエンドポイントは `/ui/ws` で、`ui_path` を変更した場合は `${ui_path}/ws` です。通常の Nginx `proxy_pass` は WebSocket アップグレードに必要な hop-by-hop ヘッダーを自動転送しません。
+
+### 解決方法
+
+HTTP/1.1 を有効にし、`Upgrade` と `Connection` ヘッダーを転送します。
+
+```nginx
+# map は http ブロック内に配置します。
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 443 ssl;
+    server_name lsm.example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8765;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        proxy_buffering off;
+    }
+}
+```
+
+設定後、Nginx を検証して再読み込みします。
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+Nginx Proxy Manager では Proxy Host の **Websockets Support** を有効にします。まだ再接続する場合は Advanced 設定に同等のアップグレードヘッダーを追加してください。
+
+### 確認
+
+ブラウザーの開発者ツールで WebUI を再読み込みし、`/ui/ws` リクエストを確認します。正常な接続では次が返ります。
+
+```text
+101 Switching Protocols
+```
+
+[Issue #71](https://github.com/fwerkor/local-shell-mcp/issues/71)も参照してください。

--- a/docs/faq.ko.md
+++ b/docs/faq.ko.md
@@ -1,0 +1,100 @@
+# 자주 묻는 질문
+
+이 페이지는 LSM 서버가 정상이어도 장애처럼 보일 수 있는 반복적인 Client 및 역방향 프록시 문제를 정리합니다.
+
+## LSM 업그레이드 후 ChatGPT에서 일부 도구를 사용할 수 없는 이유는 무엇입니까?
+
+### 증상
+
+- 새 도구가 ChatGPT에 표시되지 않습니다.
+- ChatGPT가 삭제, 이름 변경 또는 통합된 이전 도구를 계속 호출합니다.
+- 도구는 존재하지만 ChatGPT가 이전 입력 스키마를 보내 검증에 실패합니다.
+- LSM을 재시작하거나 새 대화를 열어도 해결되지 않습니다.
+
+### 원인
+
+ChatGPT는 MCP App이 스캔, 승인 또는 게시될 때 사용 가능했던 도구와 입력 스키마의 고정 스냅샷을 보관할 수 있습니다. LSM 릴리스에서 `tools/list`가 변경되어도 저장된 스냅샷이 자동으로 갱신된다는 보장은 없습니다. 공개된 만료 시간이 있는 단기 캐시가 아닙니다.
+
+### 해결 방법
+
+=== "개발자 모드 또는 개인 연결"
+
+    1. **ChatGPT Settings → Apps**를 엽니다.
+    2. LSM App을 열고 **Refresh**로 도구를 다시 스캔합니다.
+    3. Refresh가 없으면 기존 App을 삭제하고 동일한 MCP 엔드포인트를 다시 추가합니다.
+    4. 새 도구 목록을 승인한 후 새 대화를 시작합니다.
+
+=== "ChatGPT Business에 게시된 App"
+
+    현재 게시된 사용자 지정 App은 도구나 메타데이터를 제자리에서 갱신할 수 없습니다. 워크스페이스 관리자가 새 App을 만들고 현재 LSM 엔드포인트를 스캔하여 게시한 뒤 이전 App을 폐기해야 합니다.
+
+=== "ChatGPT Enterprise 또는 Edu"
+
+    워크스페이스 관리자는 **Workspace Settings → Apps → LSM App → … → Action control → Refresh**에서 차이를 검토하고 필요한 새 action을 활성화할 수 있습니다.
+
+[Issue #70](https://github.com/fwerkor/local-shell-mcp/issues/70)과 [OpenAI MCP App 문서](https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt)를 참고하십시오.
+
+## Nginx 뒤에서 WebUI가 계속 재연결되는 이유는 무엇입니까?
+
+### 증상
+
+- WebUI 페이지와 OAuth 로그인은 정상적으로 열립니다.
+- TUI가 나타나지 않습니다.
+- 상태가 `Connecting`, `Connection error`, `Reconnecting` 사이에서 반복됩니다.
+- 포트 `8765`에 직접 연결하면 작동합니다.
+
+### 원인
+
+브라우저 UI는 PTY WebSocket을 통해 네이티브 TUI를 렌더링합니다. 기본 엔드포인트는 `/ui/ws`이며 사용자 지정 `ui_path`를 사용하면 `${ui_path}/ws`입니다. 일반 Nginx `proxy_pass`는 WebSocket 업그레이드에 필요한 hop-by-hop 헤더를 자동으로 전달하지 않습니다.
+
+### 해결 방법
+
+HTTP/1.1을 사용하고 `Upgrade` 및 `Connection` 헤더를 전달합니다.
+
+```nginx
+# map은 http 블록에 배치합니다.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 443 ssl;
+    server_name lsm.example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8765;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        proxy_buffering off;
+    }
+}
+```
+
+설정을 수정한 후 Nginx를 검사하고 다시 로드합니다.
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+Nginx Proxy Manager에서는 Proxy Host의 **Websockets Support**를 활성화하십시오. 계속 재연결되면 Advanced 설정에 동일한 업그레이드 헤더를 추가하십시오.
+
+### 확인
+
+브라우저 개발자 도구에서 WebUI를 다시 로드하고 `/ui/ws` 요청을 확인합니다. 정상 연결은 다음을 반환합니다.
+
+```text
+101 Switching Protocols
+```
+
+[Issue #71](https://github.com/fwerkor/local-shell-mcp/issues/71)을 참고하십시오.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,100 @@
+# Frequently asked questions
+
+This page collects recurring client and reverse-proxy issues that can look like LSM failures even when the server itself is healthy.
+
+## Why are some ChatGPT tools unavailable after upgrading LSM?
+
+### Symptoms
+
+- New tools are missing in ChatGPT.
+- ChatGPT still tries to call a tool that was removed, renamed, or merged.
+- A tool exists, but calls fail because ChatGPT sends an older input schema.
+- Restarting LSM or opening a new conversation does not fix the problem.
+
+### Cause
+
+ChatGPT can keep a frozen snapshot of the tools and input schemas that were available when an MCP App was scanned, approved, or published. When an LSM release changes `tools/list`, that stored snapshot is not guaranteed to refresh automatically. This is not a short-lived cache with a documented expiration time.
+
+### Resolution
+
+=== "Developer mode or a personal connection"
+
+    1. Open **ChatGPT Settings → Apps**.
+    2. Open the LSM App and use **Refresh** to scan its tools again.
+    3. If Refresh is unavailable, delete the old App and add the same MCP endpoint again.
+    4. Start a new conversation after the updated tool list has been accepted.
+
+=== "ChatGPT Business published App"
+
+    A published custom App cannot currently update its tools or metadata in place. A workspace administrator must create a new App, scan the current LSM endpoint, publish the replacement, and retire the old App.
+
+=== "ChatGPT Enterprise or Edu"
+
+    A workspace administrator can open **Workspace Settings → Apps → the LSM App → … → Action control → Refresh**, review the differences, and enable newly discovered actions when necessary.
+
+See [issue #70](https://github.com/fwerkor/local-shell-mcp/issues/70) and the [OpenAI MCP App documentation](https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt).
+
+## Why does the WebUI keep reconnecting when LSM is behind Nginx?
+
+### Symptoms
+
+- The WebUI page and OAuth login load normally.
+- The TUI never appears.
+- The connection state repeatedly changes between `Connecting`, `Connection error`, and `Reconnecting`.
+- Connecting directly to port `8765` works.
+
+### Cause
+
+The browser UI renders the native TUI through a PTY WebSocket. Its default endpoint is `/ui/ws`; with a custom `ui_path`, it is `${ui_path}/ws`. A normal Nginx `proxy_pass` does not automatically forward the hop-by-hop headers required for a WebSocket upgrade.
+
+### Resolution
+
+Enable HTTP/1.1 and forward the `Upgrade` and `Connection` headers:
+
+```nginx
+# Put this map in the http block.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 443 ssl;
+    server_name lsm.example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8765;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        proxy_buffering off;
+    }
+}
+```
+
+After editing the configuration, validate and reload Nginx:
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+For Nginx Proxy Manager, enable **Websockets Support** on the Proxy Host. If the UI still reconnects, add the equivalent upgrade headers in the Advanced configuration.
+
+### Verification
+
+Open the browser developer tools, reload the WebUI, and inspect the `/ui/ws` request. A working connection returns:
+
+```text
+101 Switching Protocols
+```
+
+See [issue #71](https://github.com/fwerkor/local-shell-mcp/issues/71).

--- a/docs/faq.pl.md
+++ b/docs/faq.pl.md
@@ -1,0 +1,100 @@
+# Często zadawane pytania
+
+Ta strona opisuje powtarzające się problemy z Client i odwrotnym proxy, które mogą wyglądać jak awarie LSM, mimo że serwer działa prawidłowo.
+
+## Dlaczego po aktualizacji LSM niektóre narzędzia są niedostępne w ChatGPT?
+
+### Objawy
+
+- Nowe narzędzia nie pojawiają się w ChatGPT.
+- ChatGPT nadal próbuje wywołać narzędzie usunięte, przemianowane lub połączone.
+- Narzędzie istnieje, ale wywołanie kończy się błędem, ponieważ ChatGPT wysyła starszy schemat wejściowy.
+- Restart LSM lub nowa rozmowa nie rozwiązują problemu.
+
+### Przyczyna
+
+ChatGPT może zachować zamrożony snapshot narzędzi i schematów wejściowych dostępnych podczas skanowania, zatwierdzania lub publikowania MCP App. Gdy wydanie LSM zmienia `tools/list`, automatyczne odświeżenie tego snapshotu nie jest gwarantowane. Nie jest to krótkotrwały cache z udokumentowanym czasem wygaśnięcia.
+
+### Rozwiązanie
+
+=== "Tryb deweloperski lub połączenie osobiste"
+
+    1. Otwórz **ChatGPT Settings → Apps**.
+    2. Otwórz LSM App i użyj **Refresh**, aby ponownie przeskanować narzędzia.
+    3. Jeśli Refresh nie jest dostępny, usuń starą App i ponownie dodaj ten sam endpoint MCP.
+    4. Po zaakceptowaniu nowej listy narzędzi rozpocznij nową rozmowę.
+
+=== "App opublikowana w ChatGPT Business"
+
+    Opublikowana niestandardowa App nie może obecnie zaktualizować narzędzi ani metadanych w miejscu. Administrator musi utworzyć nową App, przeskanować bieżący endpoint LSM, opublikować zamiennik i wycofać starą App.
+
+=== "ChatGPT Enterprise lub Edu"
+
+    Administrator może otworzyć **Workspace Settings → Apps → LSM App → … → Action control → Refresh**, przejrzeć różnice i w razie potrzeby włączyć nowe actions.
+
+Zobacz [issue #70](https://github.com/fwerkor/local-shell-mcp/issues/70) oraz [dokumentację OpenAI dotyczącą MCP Apps](https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt).
+
+## Dlaczego WebUI za Nginx stale łączy się ponownie?
+
+### Objawy
+
+- Strona WebUI i logowanie OAuth ładują się prawidłowo.
+- TUI nie pojawia się.
+- Stan przełącza się między `Connecting`, `Connection error` i `Reconnecting`.
+- Bezpośrednie połączenie z portem `8765` działa.
+
+### Przyczyna
+
+Interfejs przeglądarki renderuje natywne TUI przez PTY WebSocket. Domyślny endpoint to `/ui/ws`; przy niestandardowym `ui_path` jest to `${ui_path}/ws`. Zwykły `proxy_pass` Nginx nie przekazuje automatycznie nagłówków hop-by-hop wymaganych do aktualizacji WebSocket.
+
+### Rozwiązanie
+
+Włącz HTTP/1.1 i przekaż nagłówki `Upgrade` oraz `Connection`:
+
+```nginx
+# Umieść map w bloku http.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 443 ssl;
+    server_name lsm.example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8765;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        proxy_buffering off;
+    }
+}
+```
+
+Sprawdź konfigurację i przeładuj Nginx:
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+W Nginx Proxy Manager włącz **Websockets Support** dla Proxy Host. Jeśli ponowne łączenie trwa nadal, dodaj równoważne nagłówki w Advanced.
+
+### Weryfikacja
+
+Otwórz narzędzia deweloperskie, przeładuj WebUI i sprawdź żądanie `/ui/ws`. Działające połączenie zwraca:
+
+```text
+101 Switching Protocols
+```
+
+Zobacz [issue #71](https://github.com/fwerkor/local-shell-mcp/issues/71).

--- a/docs/faq.pt-BR.md
+++ b/docs/faq.pt-BR.md
@@ -1,0 +1,100 @@
+# Perguntas frequentes
+
+Esta página reúne problemas recorrentes de Client e proxy reverso que podem parecer falhas do LSM mesmo quando o servidor está saudável.
+
+## Por que algumas ferramentas ficam indisponíveis no ChatGPT após atualizar o LSM?
+
+### Sintomas
+
+- Ferramentas novas não aparecem no ChatGPT.
+- O ChatGPT ainda tenta chamar uma ferramenta removida, renomeada ou unificada.
+- A ferramenta existe, mas a chamada falha porque o ChatGPT envia um esquema de entrada antigo.
+- Reiniciar o LSM ou abrir uma nova conversa não resolve.
+
+### Causa
+
+O ChatGPT pode manter um instantâneo congelado das ferramentas e dos esquemas de entrada disponíveis quando uma MCP App foi verificada, aprovada ou publicada. Quando uma versão do LSM altera `tools/list`, não há garantia de atualização automática desse instantâneo. Não é um cache de curta duração com prazo de expiração documentado.
+
+### Solução
+
+=== "Modo de desenvolvedor ou conexão pessoal"
+
+    1. Abra **ChatGPT Settings → Apps**.
+    2. Abra a App do LSM e use **Refresh** para verificar as ferramentas novamente.
+    3. Se Refresh não estiver disponível, exclua a App antiga e adicione novamente o mesmo endpoint MCP.
+    4. Inicie uma nova conversa depois de aceitar a lista atualizada.
+
+=== "App publicada no ChatGPT Business"
+
+    Uma App personalizada publicada não pode atualizar ferramentas ou metadados no local atualmente. Um administrador deve criar uma nova App, verificar o endpoint atual do LSM, publicar a substituta e desativar a App antiga.
+
+=== "ChatGPT Enterprise ou Edu"
+
+    Um administrador pode abrir **Workspace Settings → Apps → LSM App → … → Action control → Refresh**, revisar as diferenças e habilitar novas actions quando necessário.
+
+Consulte a [issue #70](https://github.com/fwerkor/local-shell-mcp/issues/70) e a [documentação da OpenAI sobre MCP Apps](https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt).
+
+## Por que a WebUI continua reconectando atrás do Nginx?
+
+### Sintomas
+
+- A página WebUI e o login OAuth carregam normalmente.
+- A TUI nunca aparece.
+- O estado alterna entre `Connecting`, `Connection error` e `Reconnecting`.
+- O acesso direto à porta `8765` funciona.
+
+### Causa
+
+A interface do navegador renderiza a TUI nativa por meio de um PTY WebSocket. O endpoint padrão é `/ui/ws`; com um `ui_path` personalizado, ele é `${ui_path}/ws`. Um `proxy_pass` comum do Nginx não encaminha automaticamente os cabeçalhos hop-by-hop necessários para o upgrade de WebSocket.
+
+### Solução
+
+Ative HTTP/1.1 e encaminhe os cabeçalhos `Upgrade` e `Connection`:
+
+```nginx
+# Coloque map no bloco http.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 443 ssl;
+    server_name lsm.example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8765;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        proxy_buffering off;
+    }
+}
+```
+
+Valide e recarregue o Nginx:
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+No Nginx Proxy Manager, ative **Websockets Support** no Proxy Host. Se a reconexão continuar, adicione os cabeçalhos equivalentes em Advanced.
+
+### Verificação
+
+Abra as ferramentas de desenvolvedor, recarregue a WebUI e inspecione a solicitação `/ui/ws`. Uma conexão funcional retorna:
+
+```text
+101 Switching Protocols
+```
+
+Consulte a [issue #71](https://github.com/fwerkor/local-shell-mcp/issues/71).

--- a/docs/faq.ru.md
+++ b/docs/faq.ru.md
@@ -1,0 +1,100 @@
+# Часто задаваемые вопросы
+
+На этой странице собраны повторяющиеся проблемы Client и обратного прокси, которые могут выглядеть как сбои LSM, хотя сам сервер работает нормально.
+
+## Почему после обновления LSM некоторые инструменты недоступны в ChatGPT?
+
+### Симптомы
+
+- Новые инструменты не появляются в ChatGPT.
+- ChatGPT продолжает вызывать удалённый, переименованный или объединённый инструмент.
+- Инструмент существует, но вызов завершается ошибкой из-за старой схемы входных данных.
+- Перезапуск LSM или новая беседа не помогают.
+
+### Причина
+
+ChatGPT может сохранять зафиксированный снимок инструментов и входных схем, доступных во время сканирования, одобрения или публикации MCP App. Если новая версия LSM изменяет `tools/list`, автоматическое обновление этого снимка не гарантируется. Это не кратковременный кэш с документированным сроком действия.
+
+### Решение
+
+=== "Режим разработчика или личное подключение"
+
+    1. Откройте **ChatGPT Settings → Apps**.
+    2. Откройте LSM App и нажмите **Refresh**, чтобы повторно просканировать инструменты.
+    3. Если Refresh недоступен, удалите старую App и снова добавьте тот же MCP endpoint.
+    4. После принятия нового списка инструментов начните новую беседу.
+
+=== "Опубликованная App в ChatGPT Business"
+
+    Опубликованная пользовательская App пока не может обновить инструменты или метаданные на месте. Администратор должен создать новую App, просканировать текущий endpoint LSM, опубликовать замену и вывести старую App из использования.
+
+=== "ChatGPT Enterprise или Edu"
+
+    Администратор может открыть **Workspace Settings → Apps → LSM App → … → Action control → Refresh**, проверить изменения и при необходимости включить новые actions.
+
+См. [issue #70](https://github.com/fwerkor/local-shell-mcp/issues/70) и [документацию OpenAI по MCP Apps](https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt).
+
+## Почему WebUI постоянно переподключается за Nginx?
+
+### Симптомы
+
+- Страница WebUI и вход OAuth загружаются нормально.
+- TUI не появляется.
+- Состояние циклически меняется между `Connecting`, `Connection error` и `Reconnecting`.
+- Прямое подключение к порту `8765` работает.
+
+### Причина
+
+Интерфейс браузера отображает нативную TUI через PTY WebSocket. Endpoint по умолчанию — `/ui/ws`; при пользовательском `ui_path` используется `${ui_path}/ws`. Обычный `proxy_pass` Nginx не передаёт автоматически hop-by-hop заголовки, необходимые для обновления протокола WebSocket.
+
+### Решение
+
+Включите HTTP/1.1 и передавайте заголовки `Upgrade` и `Connection`:
+
+```nginx
+# Разместите map в блоке http.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 443 ssl;
+    server_name lsm.example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8765;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        proxy_buffering off;
+    }
+}
+```
+
+Проверьте конфигурацию и перезагрузите Nginx:
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+В Nginx Proxy Manager включите **Websockets Support** для Proxy Host. Если переподключения продолжаются, добавьте эквивалентные заголовки в Advanced.
+
+### Проверка
+
+Откройте инструменты разработчика браузера, перезагрузите WebUI и проверьте запрос `/ui/ws`. Рабочее подключение возвращает:
+
+```text
+101 Switching Protocols
+```
+
+См. [issue #71](https://github.com/fwerkor/local-shell-mcp/issues/71).

--- a/docs/faq.tr.md
+++ b/docs/faq.tr.md
@@ -1,0 +1,100 @@
+# Sık sorulan sorular
+
+Bu sayfa, sunucu sağlıklı olsa bile LSM arızası gibi görünebilen yaygın Client ve ters proxy sorunlarını açıklar.
+
+## LSM yükseltmesinden sonra bazı araçlar neden ChatGPT'de kullanılamıyor?
+
+### Belirtiler
+
+- Yeni araçlar ChatGPT'de görünmez.
+- ChatGPT kaldırılmış, yeniden adlandırılmış veya birleştirilmiş eski bir aracı çağırmaya devam eder.
+- Araç vardır ancak ChatGPT eski bir girdi şeması gönderdiği için çağrı doğrulaması başarısız olur.
+- LSM'yi yeniden başlatmak veya yeni bir konuşma açmak sorunu çözmez.
+
+### Neden
+
+ChatGPT, bir MCP App tarandığında, onaylandığında veya yayımlandığında mevcut olan araçların ve girdi şemalarının dondurulmuş anlık görüntüsünü saklayabilir. LSM sürümü `tools/list` değerini değiştirdiğinde bu görüntünün otomatik yenilenmesi garanti edilmez. Belgelenmiş bir sona erme süresine sahip kısa süreli bir önbellek değildir.
+
+### Çözüm
+
+=== "Geliştirici modu veya kişisel bağlantı"
+
+    1. **ChatGPT Settings → Apps** bölümünü açın.
+    2. LSM App'i açın ve araçları yeniden taramak için **Refresh** kullanın.
+    3. Refresh yoksa eski App'i silin ve aynı MCP endpoint'i yeniden ekleyin.
+    4. Güncel araç listesi kabul edildikten sonra yeni bir konuşma başlatın.
+
+=== "ChatGPT Business'ta yayımlanmış App"
+
+    Yayımlanmış özel bir App şu anda araçlarını veya metadata'sını yerinde güncelleyemez. Bir yönetici yeni App oluşturmalı, mevcut LSM endpoint'ini taramalı, yerine geçeni yayımlamalı ve eski App'i kullanımdan kaldırmalıdır.
+
+=== "ChatGPT Enterprise veya Edu"
+
+    Yönetici **Workspace Settings → Apps → LSM App → … → Action control → Refresh** bölümünü açabilir, farkları inceleyebilir ve gerektiğinde yeni action'ları etkinleştirebilir.
+
+[Issue #70](https://github.com/fwerkor/local-shell-mcp/issues/70) ve [OpenAI MCP App belgelerine](https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt) bakın.
+
+## WebUI Nginx arkasında neden sürekli yeniden bağlanıyor?
+
+### Belirtiler
+
+- WebUI sayfası ve OAuth girişi normal yüklenir.
+- TUI görünmez.
+- Durum `Connecting`, `Connection error` ve `Reconnecting` arasında tekrar eder.
+- `8765` portuna doğrudan bağlantı çalışır.
+
+### Neden
+
+Tarayıcı arayüzü yerel TUI'yi PTY WebSocket üzerinden işler. Varsayılan endpoint `/ui/ws`'dir; özel `ui_path` kullanıldığında `${ui_path}/ws` olur. Normal Nginx `proxy_pass`, WebSocket yükseltmesi için gereken hop-by-hop başlıklarını otomatik iletmez.
+
+### Çözüm
+
+HTTP/1.1'i etkinleştirin ve `Upgrade` ile `Connection` başlıklarını iletin:
+
+```nginx
+# map yönergesini http bloğuna yerleştirin.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 443 ssl;
+    server_name lsm.example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8765;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        proxy_buffering off;
+    }
+}
+```
+
+Yapılandırmayı doğrulayın ve Nginx'i yeniden yükleyin:
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+Nginx Proxy Manager'da Proxy Host için **Websockets Support** seçeneğini etkinleştirin. Yeniden bağlanma sürerse Advanced bölümüne eşdeğer yükseltme başlıklarını ekleyin.
+
+### Doğrulama
+
+Tarayıcı geliştirici araçlarını açın, WebUI'yi yeniden yükleyin ve `/ui/ws` isteğini inceleyin. Çalışan bağlantı şunu döndürür:
+
+```text
+101 Switching Protocols
+```
+
+[Issue #71](https://github.com/fwerkor/local-shell-mcp/issues/71) bölümüne bakın.

--- a/docs/faq.vi.md
+++ b/docs/faq.vi.md
@@ -1,0 +1,100 @@
+# Câu hỏi thường gặp
+
+Trang này tổng hợp các vấn đề Client và reverse proxy thường gặp có thể trông giống lỗi LSM dù máy chủ vẫn hoạt động bình thường.
+
+## Vì sao một số công cụ không khả dụng trong ChatGPT sau khi nâng cấp LSM?
+
+### Triệu chứng
+
+- Công cụ mới không xuất hiện trong ChatGPT.
+- ChatGPT vẫn cố gọi công cụ cũ đã bị xóa, đổi tên hoặc hợp nhất.
+- Công cụ tồn tại nhưng lời gọi thất bại vì ChatGPT gửi schema đầu vào cũ.
+- Khởi động lại LSM hoặc mở cuộc trò chuyện mới không khắc phục được.
+
+### Nguyên nhân
+
+ChatGPT có thể giữ snapshot cố định của các công cụ và schema đầu vào có tại thời điểm MCP App được quét, phê duyệt hoặc xuất bản. Khi bản phát hành LSM thay đổi `tools/list`, snapshot đó không được bảo đảm tự động làm mới. Đây không phải cache ngắn hạn có thời gian hết hạn được công bố.
+
+### Cách khắc phục
+
+=== "Developer mode hoặc kết nối cá nhân"
+
+    1. Mở **ChatGPT Settings → Apps**.
+    2. Mở LSM App và dùng **Refresh** để quét lại công cụ.
+    3. Nếu không có Refresh, hãy xóa App cũ và thêm lại cùng MCP endpoint.
+    4. Bắt đầu cuộc trò chuyện mới sau khi danh sách công cụ mới được chấp nhận.
+
+=== "App đã xuất bản trong ChatGPT Business"
+
+    Hiện tại App tùy chỉnh đã xuất bản không thể cập nhật công cụ hoặc metadata tại chỗ. Quản trị viên phải tạo App mới, quét endpoint LSM hiện tại, xuất bản bản thay thế và ngừng App cũ.
+
+=== "ChatGPT Enterprise hoặc Edu"
+
+    Quản trị viên có thể mở **Workspace Settings → Apps → LSM App → … → Action control → Refresh**, xem khác biệt và bật các action mới khi cần.
+
+Xem [issue #70](https://github.com/fwerkor/local-shell-mcp/issues/70) và [tài liệu MCP App của OpenAI](https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt).
+
+## Vì sao WebUI liên tục kết nối lại khi đặt sau Nginx?
+
+### Triệu chứng
+
+- Trang WebUI và đăng nhập OAuth tải bình thường.
+- TUI không xuất hiện.
+- Trạng thái lặp giữa `Connecting`, `Connection error` và `Reconnecting`.
+- Kết nối trực tiếp đến cổng `8765` hoạt động.
+
+### Nguyên nhân
+
+Giao diện trình duyệt hiển thị TUI gốc qua PTY WebSocket. Endpoint mặc định là `/ui/ws`; với `ui_path` tùy chỉnh, endpoint là `${ui_path}/ws`. `proxy_pass` Nginx thông thường không tự chuyển tiếp các header hop-by-hop cần cho việc nâng cấp WebSocket.
+
+### Cách khắc phục
+
+Bật HTTP/1.1 và chuyển tiếp header `Upgrade` cùng `Connection`:
+
+```nginx
+# Đặt map trong khối http.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 443 ssl;
+    server_name lsm.example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8765;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        proxy_buffering off;
+    }
+}
+```
+
+Kiểm tra rồi tải lại Nginx:
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+Trong Nginx Proxy Manager, bật **Websockets Support** cho Proxy Host. Nếu vẫn kết nối lại, thêm các header nâng cấp tương đương trong Advanced.
+
+### Xác minh
+
+Mở công cụ nhà phát triển, tải lại WebUI và kiểm tra yêu cầu `/ui/ws`. Kết nối đúng trả về:
+
+```text
+101 Switching Protocols
+```
+
+Xem [issue #71](https://github.com/fwerkor/local-shell-mcp/issues/71).

--- a/docs/faq.zh-Hant.md
+++ b/docs/faq.zh-Hant.md
@@ -1,0 +1,100 @@
+# 常見問題
+
+本頁整理一些反覆出現的 Client 與反向代理問題。這些問題看起來像 LSM 服務故障，但服務端本身通常正常。
+
+## 為什麼升級 LSM 後，ChatGPT 中有些工具無法使用？
+
+### 現象
+
+- ChatGPT 中看不到新增工具。
+- ChatGPT 仍嘗試呼叫已刪除、重新命名或合併的舊工具。
+- 工具仍存在，但 ChatGPT 使用舊參數結構，導致呼叫驗證失敗。
+- 重新啟動 LSM 或建立新對話後問題仍存在。
+
+### 原因
+
+ChatGPT 可能會保存 MCP App 在掃描、核准或發佈時的工具與輸入參數凍結快照。LSM 新版本修改 `tools/list` 後，這份已保存的快照不保證自動重新整理。這不是一個有明確到期時間的短期快取。
+
+### 解決方法
+
+=== "開發者模式或個人連線"
+
+    1. 開啟 **ChatGPT 設定 → Apps**。
+    2. 進入 LSM App，使用 **Refresh** 重新掃描工具。
+    3. 如果沒有 Refresh，刪除舊 App，再使用同一個 MCP 位址重新加入。
+    4. 接受新工具清單後，建立新對話再使用 LSM。
+
+=== "ChatGPT Business 已發佈 App"
+
+    目前已發佈的自訂 App 無法原地更新工具或中繼資料。工作區管理員需要建立新 App、掃描目前的 LSM 位址、發佈替代版本，然後停用舊 App。
+
+=== "ChatGPT Enterprise 或 Edu"
+
+    工作區管理員可以進入 **Workspace Settings → Apps → LSM App → … → Action control → Refresh**，審查差異，並視需要啟用新發現的 action。
+
+請參閱 [Issue #70](https://github.com/fwerkor/local-shell-mcp/issues/70) 與 [OpenAI MCP App 文件](https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt)。
+
+## 為什麼透過 Nginx 反向代理 LSM 後，WebUI 一直重新連線？
+
+### 現象
+
+- WebUI 頁面與 OAuth 登入都能正常開啟。
+- TUI 始終不顯示。
+- 連線狀態不斷在 `Connecting`、`Connection error` 與 `Reconnecting` 之間變化。
+- 直接連線 `8765` 連接埠時一切正常。
+
+### 原因
+
+瀏覽器介面透過 PTY WebSocket 呈現原生 TUI。預設端點是 `/ui/ws`；若自訂 `ui_path`，端點就是 `${ui_path}/ws`。一般的 Nginx `proxy_pass` 不會自動轉送 WebSocket 協定升級所需的 hop-by-hop 標頭。
+
+### 解決方法
+
+啟用 HTTP/1.1，並轉送 `Upgrade` 與 `Connection` 標頭：
+
+```nginx
+# 將 map 放在 http 區塊中。
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 443 ssl;
+    server_name lsm.example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8765;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        proxy_buffering off;
+    }
+}
+```
+
+修改設定後，檢查並重新載入 Nginx：
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+若使用 Nginx Proxy Manager，請在對應的 Proxy Host 啟用 **Websockets Support**。若仍不斷重新連線，請在 Advanced 設定中加入等效的協定升級標頭。
+
+### 驗證
+
+開啟瀏覽器開發者工具，重新載入 WebUI，並檢查 `/ui/ws` 請求。正常連線應回傳：
+
+```text
+101 Switching Protocols
+```
+
+請參閱 [Issue #71](https://github.com/fwerkor/local-shell-mcp/issues/71)。

--- a/docs/faq.zh.md
+++ b/docs/faq.zh.md
@@ -1,0 +1,100 @@
+# 常见问题
+
+本页汇总一些反复出现的 Client 与反向代理问题。这些问题看起来像 LSM 服务故障，但服务端本身通常是正常的。
+
+## 为什么升级 LSM 后，ChatGPT 中有些工具不可用？
+
+### 表现
+
+- ChatGPT 中看不到新增工具。
+- ChatGPT 仍尝试调用已经删除、重命名或合并的旧工具。
+- 工具仍存在，但 ChatGPT 使用旧参数结构，导致调用校验失败。
+- 重启 LSM 或新建对话后问题仍然存在。
+
+### 原因
+
+ChatGPT 可能会保存 MCP App 在扫描、批准或发布时的工具及输入参数冻结快照。LSM 新版本修改 `tools/list` 后，这份已保存的快照并不保证自动刷新。这不是一个有明确过期时间的短期缓存。
+
+### 解决方法
+
+=== "开发者模式或个人连接"
+
+    1. 打开 **ChatGPT 设置 → Apps**。
+    2. 进入 LSM App，使用 **Refresh** 重新扫描工具。
+    3. 如果没有 Refresh，删除旧 App，再用同一个 MCP 地址重新添加。
+    4. 接受新工具列表后，新建一个对话再使用 LSM。
+
+=== "ChatGPT Business 已发布 App"
+
+    当前已发布的自定义 App 无法原地更新工具或元数据。工作区管理员需要新建 App，扫描当前 LSM 地址，发布替代版本，然后停用旧 App。
+
+=== "ChatGPT Enterprise 或 Edu"
+
+    工作区管理员可以进入 **Workspace Settings → Apps → LSM App → … → Action control → Refresh**，审核差异，并按需启用新发现的 action。
+
+参见 [Issue #70](https://github.com/fwerkor/local-shell-mcp/issues/70) 和 [OpenAI MCP App 文档](https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt)。
+
+## 为什么通过 Nginx 反代 LSM 后，WebUI 一直重连？
+
+### 表现
+
+- WebUI 页面和 OAuth 登录都能正常打开。
+- TUI 始终不显示。
+- 连接状态不断在 `Connecting`、`Connection error` 和 `Reconnecting` 之间变化。
+- 直接连接 `8765` 端口时一切正常。
+
+### 原因
+
+浏览器界面通过 PTY WebSocket 渲染原生 TUI。默认端点是 `/ui/ws`；如果自定义了 `ui_path`，端点就是 `${ui_path}/ws`。普通的 Nginx `proxy_pass` 不会自动转发 WebSocket 协议升级所需的 hop-by-hop 请求头。
+
+### 解决方法
+
+启用 HTTP/1.1，并转发 `Upgrade` 和 `Connection` 请求头：
+
+```nginx
+# 将 map 放在 http 块中。
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 443 ssl;
+    server_name lsm.example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8765;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        proxy_buffering off;
+    }
+}
+```
+
+修改配置后，检查并重新加载 Nginx：
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+如果使用 Nginx Proxy Manager，请在对应 Proxy Host 中启用 **Websockets Support**。如果仍然重连，在 Advanced 配置中补充等价的协议升级请求头。
+
+### 验证
+
+打开浏览器开发者工具，重新加载 WebUI，并检查 `/ui/ws` 请求。正常连接应返回：
+
+```text
+101 Switching Protocols
+```
+
+参见 [Issue #71](https://github.com/fwerkor/local-shell-mcp/issues/71)。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
       - Configuration: reference/configuration.md
       - REST API: reference/rest-api.md
   - Security: security.md
+  - FAQ: faq.md
   - Troubleshooting: troubleshooting.md
 markdown_extensions:
   - admonition
@@ -93,6 +94,7 @@ plugins:
             Configuration: 配置
             REST API: REST API
             Security: 安全
+            FAQ: FAQ
             Troubleshooting: 故障排查
         - locale: zh-Hant
           name: 繁體中文
@@ -127,6 +129,7 @@ plugins:
             Configuration: 設定
             REST API: REST API
             Security: 安全
+            FAQ: FAQ
             Troubleshooting: 疑難排解
         - locale: ja
           name: 日本語
@@ -161,6 +164,7 @@ plugins:
             Configuration: 設定
             REST API: REST API
             Security: セキュリティ
+            FAQ: FAQ
             Troubleshooting: トラブルシューティング
         - locale: ko
           name: 한국어
@@ -195,6 +199,7 @@ plugins:
             Configuration: 설정
             REST API: REST API
             Security: 보안
+            FAQ: FAQ
             Troubleshooting: 문제 해결
         - locale: es
           name: Español
@@ -229,6 +234,7 @@ plugins:
             Configuration: Configuración
             REST API: REST API
             Security: Seguridad
+            FAQ: FAQ
             Troubleshooting: Solución de problemas
         - locale: fr
           name: Français
@@ -263,6 +269,7 @@ plugins:
             Configuration: Configuration
             REST API: REST API
             Security: Sécurité
+            FAQ: FAQ
             Troubleshooting: Dépannage
         - locale: de
           name: Deutsch
@@ -297,6 +304,7 @@ plugins:
             Configuration: Konfiguration
             REST API: REST API
             Security: Sicherheit
+            FAQ: FAQ
             Troubleshooting: Fehlerbehebung
         - locale: ru
           name: Русский
@@ -331,6 +339,7 @@ plugins:
             Configuration: Конфигурация
             REST API: REST API
             Security: Безопасность
+            FAQ: FAQ
             Troubleshooting: Диагностика
         - locale: pt-BR
           name: Português
@@ -365,6 +374,7 @@ plugins:
             Configuration: Configuração
             REST API: REST API
             Security: Segurança
+            FAQ: FAQ
             Troubleshooting: Solução de problemas
         - locale: it
           name: Italiano
@@ -399,6 +409,7 @@ plugins:
             Configuration: Configurazione
             REST API: REST API
             Security: Sicurezza
+            FAQ: FAQ
             Troubleshooting: Risoluzione dei problemi
         - locale: ar
           name: العربية
@@ -433,6 +444,7 @@ plugins:
             Configuration: الإعدادات
             REST API: REST API
             Security: الأمان
+            FAQ: FAQ
             Troubleshooting: استكشاف الأخطاء
         - locale: hi
           name: हिन्दी
@@ -467,6 +479,7 @@ plugins:
             Configuration: कॉन्फ़िगरेशन
             REST API: REST API
             Security: सुरक्षा
+            FAQ: FAQ
             Troubleshooting: समस्या निवारण
         - locale: id
           name: Bahasa Indonesia
@@ -501,6 +514,7 @@ plugins:
             Configuration: Konfigurasi
             REST API: REST API
             Security: Keamanan
+            FAQ: FAQ
             Troubleshooting: Pemecahan masalah
         - locale: vi
           name: Tiếng Việt
@@ -535,6 +549,7 @@ plugins:
             Configuration: Cấu hình
             REST API: REST API
             Security: Bảo mật
+            FAQ: FAQ
             Troubleshooting: Xử lý sự cố
         - locale: tr
           name: Türkçe
@@ -569,6 +584,7 @@ plugins:
             Configuration: Yapılandırma
             REST API: REST API
             Security: Güvenlik
+            FAQ: FAQ
             Troubleshooting: Sorun giderme
         - locale: pl
           name: Polski
@@ -603,6 +619,7 @@ plugins:
             Configuration: Konfiguracja
             REST API: REST API
             Security: Bezpieczeństwo
+            FAQ: FAQ
             Troubleshooting: Rozwiązywanie problemów
 theme:
   name: material


### PR DESCRIPTION
## Summary

- add a top-level FAQ page in all 17 documentation languages
- explain ChatGPT MCP tool snapshots and the required refresh/republication steps
- document Nginx WebSocket proxy configuration for the WebUI PTY endpoint
- link the detailed resolved issues #70 and #71

## Validation

- `python3 scripts/check-doc-i18n.py`
- `python3 -m mkdocs build --strict --site-dir /tmp/lsm-faq-site`
- multilingual content checks for both issue links, `/ui/ws`, and `101 Switching Protocols`