### PR TITLE
fix(packaging): ship OpenTUI runtime in Python wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,6 +407,9 @@ jobs:
           - label: wheel linux-aarch64
             artifact: wheel-linux-aarch64
             runner: ubuntu-24.04-arm
+          - label: wheel macos-x86_64
+            artifact: wheel-macos-x86_64
+            runner: macos-15-intel
           - label: wheel macos-aarch64
             artifact: wheel-macos-aarch64
             runner: macos-15
@@ -423,10 +426,26 @@ jobs:
           python-version: "3.12"
           cache: pip
 
-      - name: Build wheel and source distribution
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Build OpenTUI runtime and embedded WebUI
+        working-directory: ui
+        run: |
+          bun install --frozen-lockfile
+          bun run typecheck
+          bun run build
+
+      - name: Build platform wheel
         run: |
           python -m pip install --upgrade pip build
-          python -m build
+          python -m build --wheel
+
+      - name: Build source distribution
+        if: matrix.artifact == 'wheel-linux-x86_64'
+        run: python -m build --sdist
 
       - name: Install wheel in clean virtualenv and smoke test CLI
         if: runner.os != 'Windows'
@@ -438,6 +457,8 @@ jobs:
           /tmp/local-shell-mcp-wheel-venv/bin/python -m pip install dist/*.whl
           /tmp/local-shell-mcp-wheel-venv/bin/local-shell-mcp --version
           /tmp/local-shell-mcp-wheel-venv/bin/local-shell-mcp version
+          /tmp/local-shell-mcp-wheel-venv/bin/python scripts/standalone-ui-smoke.py \
+            --server /tmp/local-shell-mcp-wheel-venv/bin/local-shell-mcp
 
       - name: Install wheel in clean virtualenv and smoke test CLI
         if: runner.os == 'Windows'
@@ -448,6 +469,8 @@ jobs:
           & $env:TEMP\local-shell-mcp-wheel-venv\Scripts\python.exe -m pip install (Get-Item dist\*.whl).FullName
           & $env:TEMP\local-shell-mcp-wheel-venv\Scripts\local-shell-mcp.exe --version
           & $env:TEMP\local-shell-mcp-wheel-venv\Scripts\local-shell-mcp.exe version
+          & $env:TEMP\local-shell-mcp-wheel-venv\Scripts\python.exe scripts/standalone-ui-smoke.py `
+            --server $env:TEMP\local-shell-mcp-wheel-venv\Scripts\local-shell-mcp.exe
 
       - name: Upload package artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,9 +109,28 @@ jobs:
           PY
 
   build-python-package:
-    name: Build Python package
-    runs-on: ubuntu-latest
+    name: Build Python package (${{ matrix.artifact }})
+    runs-on: ${{ matrix.runner }}
     needs: validate-release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - artifact: linux-x86_64
+            runner: ubuntu-latest
+            build_sdist: true
+          - artifact: linux-aarch64
+            runner: ubuntu-24.04-arm
+            build_sdist: false
+          - artifact: macos-x86_64
+            runner: macos-15-intel
+            build_sdist: false
+          - artifact: macos-aarch64
+            runner: macos-15
+            build_sdist: false
+          - artifact: windows-x86_64
+            runner: windows-latest
+            build_sdist: false
     steps:
       - uses: actions/checkout@v6
 
@@ -124,20 +143,48 @@ jobs:
         with:
           bun-version: ${{ env.BUN_VERSION }}
 
-      - name: Build embedded WebUI assets
+      - name: Build OpenTUI runtime and embedded WebUI
         working-directory: ui
         run: |
           bun install --frozen-lockfile
-          bun run build:web
+          bun run typecheck
+          bun run build
 
-      - name: Build wheel and source distribution
+      - name: Build platform wheel
         run: |
           python -m pip install --upgrade pip build
-          python -m build
+          python -m build --wheel
+
+      - name: Build source distribution
+        if: matrix.build_sdist
+        run: python -m build --sdist
+
+      - name: Install wheel and smoke test packaged UI
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          python -m venv /tmp/local-shell-mcp-wheel-venv
+          /tmp/local-shell-mcp-wheel-venv/bin/python -m pip install --upgrade pip
+          /tmp/local-shell-mcp-wheel-venv/bin/python -m pip install dist/*.whl
+          /tmp/local-shell-mcp-wheel-venv/bin/local-shell-mcp --version
+          /tmp/local-shell-mcp-wheel-venv/bin/python scripts/standalone-ui-smoke.py \
+            --server /tmp/local-shell-mcp-wheel-venv/bin/local-shell-mcp
+
+      - name: Install wheel and smoke test packaged UI
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          python -m venv $env:TEMP\local-shell-mcp-wheel-venv
+          & $env:TEMP\local-shell-mcp-wheel-venv\Scripts\python.exe -m pip install --upgrade pip
+          & $env:TEMP\local-shell-mcp-wheel-venv\Scripts\python.exe -m pip install (Get-Item dist\*.whl).FullName
+          & $env:TEMP\local-shell-mcp-wheel-venv\Scripts\local-shell-mcp.exe --version
+          & $env:TEMP\local-shell-mcp-wheel-venv\Scripts\python.exe scripts/standalone-ui-smoke.py `
+            --server $env:TEMP\local-shell-mcp-wheel-venv\Scripts\local-shell-mcp.exe
 
       - uses: actions/upload-artifact@v7
         with:
-          name: python-dist
+          name: python-dist-${{ matrix.artifact }}
           path: dist/*
           if-no-files-found: error
 
@@ -432,8 +479,9 @@ jobs:
       - name: Download Python package artifacts
         uses: actions/download-artifact@v8
         with:
-          name: python-dist
+          pattern: python-dist-*
           path: dist
+          merge-multiple: true
 
       - name: Download binary artifacts
         uses: actions/download-artifact@v8

--- a/Dockerfile
+++ b/Dockerfile
@@ -121,7 +121,7 @@ ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 RUN npm install -g yarn@1.22.22 pnpm@9.15.9 typescript@5.7.3 ts-node@10.9.2
 
 WORKDIR /app
-COPY requirements-agent.txt pyproject.toml README.md LICENSE /app/
+COPY requirements-agent.txt pyproject.toml hatch_build.py README.md LICENSE /app/
 RUN pip install --no-cache-dir -r requirements-agent.txt
 COPY src /app/src
 COPY --from=tmux-builder /out/tmux /tmp/local-shell-mcp-tmux

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+from packaging.tags import sys_tags
+
+
+class CustomBuildHook(BuildHookInterface):
+    """Include a generated, platform-native TUI runtime in wheel builds."""
+
+    def initialize(self, version: str, build_data: dict[str, object]) -> None:
+        if self.target_name != "wheel":
+            return
+
+        executable_name = "local-shell-mcp-tui.exe" if os.name == "nt" else "local-shell-mcp-tui"
+        payload = (
+            Path(self.root)
+            / "src"
+            / "local_shell_mcp"
+            / "ui_runtime"
+            / f"{executable_name}.gz"
+        )
+        if not payload.is_file():
+            # Source-only and sdist builds remain possible without Bun. Official wheel
+            # workflows compile the runtime before invoking the wheel builder.
+            return
+
+        platform_tag = next(
+            tag.platform
+            for tag in sys_tags()
+            if "manylinux" not in tag.platform and "musllinux" not in tag.platform
+        )
+        build_data["tag"] = f"py3-none-{platform_tag}"
+        build_data["pure_python"] = False
+        build_data["force_include"][str(payload)] = (
+            f"local_shell_mcp/ui_runtime/{payload.name}"
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,9 @@ local-shell-mcp = "local_shell_mcp.main:main"
 [tool.hatch.build.targets.wheel]
 packages = ["src/local_shell_mcp"]
 
+[tool.hatch.build.hooks.custom]
+path = "hatch_build.py"
+
 [tool.ruff]
 line-length = 100
 target-version = "py311"

--- a/scripts/check-release-matrix.py
+++ b/scripts/check-release-matrix.py
@@ -7,6 +7,7 @@ import yaml
 
 REPO = Path(__file__).resolve().parents[1]
 RELEASE = REPO / ".github" / "workflows" / "release.yml"
+DOCKERFILE = REPO / "Dockerfile"
 EXPECTED_BINARY_ARTIFACTS = {
     "linux-x86_64",
     "linux-aarch64",
@@ -33,6 +34,11 @@ def step_script(job: dict, name: str) -> str:
 def main() -> int:
     workflow = yaml.safe_load(RELEASE.read_text(encoding="utf-8"))
     jobs = workflow.get("jobs", {})
+
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    if "COPY requirements-agent.txt pyproject.toml hatch_build.py README.md LICENSE /app/" not in dockerfile:
+        print("Docker builds must copy hatch_build.py before installing the project.")
+        return 1
 
     python_job = jobs.get("build-python-package", {})
     python_artifacts = matrix_values(python_job, "artifact")

--- a/scripts/check-release-matrix.py
+++ b/scripts/check-release-matrix.py
@@ -14,6 +14,7 @@ EXPECTED_BINARY_ARTIFACTS = {
     "macos-aarch64",
     "windows-x86_64",
 }
+EXPECTED_PYTHON_ARTIFACTS = EXPECTED_BINARY_ARTIFACTS
 EXPECTED_DOCKER_PLATFORMS = {"linux/amd64", "linux/arm64"}
 
 
@@ -32,6 +33,31 @@ def step_script(job: dict, name: str) -> str:
 def main() -> int:
     workflow = yaml.safe_load(RELEASE.read_text(encoding="utf-8"))
     jobs = workflow.get("jobs", {})
+
+    python_job = jobs.get("build-python-package", {})
+    python_artifacts = matrix_values(python_job, "artifact")
+    missing_python = sorted(EXPECTED_PYTHON_ARTIFACTS - python_artifacts)
+    extra_python = sorted(python_artifacts - EXPECTED_PYTHON_ARTIFACTS)
+    if missing_python or extra_python:
+        print("Release Python wheel matrix mismatch.")
+        print(f"missing: {missing_python}")
+        print(f"extra: {extra_python}")
+        return 1
+
+    ui_build_script = step_script(python_job, "Build OpenTUI runtime and embedded WebUI")
+    if "bun run build" not in ui_build_script:
+        print("Release wheels must compile the platform-native OpenTUI runtime.")
+        return 1
+
+    wheel_build_script = step_script(python_job, "Build platform wheel")
+    if "python -m build --wheel" not in wheel_build_script:
+        print("Release wheels must be built directly from the platform checkout.")
+        return 1
+
+    wheel_smoke_script = step_script(python_job, "Install wheel and smoke test packaged UI")
+    if "standalone-ui-smoke.py" not in wheel_smoke_script:
+        print("Release wheels must exercise their packaged OpenTUI runtime.")
+        return 1
 
     binary_job = jobs.get("build-binary", {})
     binary_artifacts = matrix_values(binary_job, "artifact")
@@ -67,7 +93,7 @@ def main() -> int:
         return 1
 
     print(
-        "Release build matrices and single-executable packaging checks passed for all expected platforms."
+        "Release build matrices, platform wheels, and single-executable packaging checks passed for all expected platforms."
     )
     return 0
 

--- a/src/local_shell_mcp/human_ui.py
+++ b/src/local_shell_mcp/human_ui.py
@@ -43,6 +43,7 @@ from .remote import remote_manager
 from .settings import get_settings
 from .shell_ops import kill_shell, list_shells, read_shell, resize_shell, send_shell, start_shell
 from .todo_ops import TodoConflictError, todo_read, todo_write
+from .tui_runtime import materialize_embedded_tui
 from .ui_security import UI_LOCAL_TOKEN_ENV, get_or_create_ui_local_token
 from .version import version_info
 
@@ -1255,6 +1256,10 @@ def resolve_tui_command() -> list[str]:
     for candidate in sidecar_candidates:
         if candidate.is_file():
             return [str(candidate)]
+
+    embedded = materialize_embedded_tui(settings.state_dir)
+    if embedded is not None:
+        return [str(embedded)]
 
     source = _tui_source_path()
     bun = shutil.which("bun")

--- a/src/local_shell_mcp/human_ui.py
+++ b/src/local_shell_mcp/human_ui.py
@@ -1257,7 +1257,10 @@ def resolve_tui_command() -> list[str]:
         if candidate.is_file():
             return [str(candidate)]
 
-    embedded = materialize_embedded_tui(settings.state_dir)
+    try:
+        embedded = materialize_embedded_tui(settings.state_dir)
+    except (OSError, EOFError) as exc:
+        raise RuntimeError(f"Unable to prepare embedded OpenTUI runtime: {exc}") from exc
     if embedded is not None:
         return [str(embedded)]
 

--- a/src/local_shell_mcp/tui_runtime.py
+++ b/src/local_shell_mcp/tui_runtime.py
@@ -51,7 +51,14 @@ def materialize_embedded_tui(
                 | stat.S_IXGRP
                 | stat.S_IXOTH
             )
-        os.replace(temporary, target)
+        try:
+            os.replace(temporary, target)
+        except PermissionError:
+            # Windows can reject replacing a target that another concurrent
+            # materializer has just completed. Accept that winner only after
+            # confirming the fully written target now exists.
+            if not target.is_file():
+                raise
     finally:
         with contextlib.suppress(OSError):
             temporary.unlink()

--- a/src/local_shell_mcp/tui_runtime.py
+++ b/src/local_shell_mcp/tui_runtime.py
@@ -45,12 +45,7 @@ def materialize_embedded_tui(
             shutil.copyfileobj(source, destination)
     try:
         if os.name != "nt":
-            temporary.chmod(
-                temporary.stat().st_mode
-                | stat.S_IXUSR
-                | stat.S_IXGRP
-                | stat.S_IXOTH
-            )
+            temporary.chmod(temporary.stat().st_mode | stat.S_IXUSR)
         try:
             os.replace(temporary, target)
         except PermissionError:

--- a/src/local_shell_mcp/tui_runtime.py
+++ b/src/local_shell_mcp/tui_runtime.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import contextlib
+import gzip
+import os
+import shutil
+import stat
+import tempfile
+from pathlib import Path
+
+from . import __version__
+
+
+def embedded_tui_payload() -> Path | None:
+    executable_name = "local-shell-mcp-tui.exe" if os.name == "nt" else "local-shell-mcp-tui"
+    payload = Path(__file__).resolve().parent / "ui_runtime" / f"{executable_name}.gz"
+    return payload if payload.is_file() else None
+
+
+def materialize_embedded_tui(
+    state_dir: Path,
+    *,
+    payload: Path | None = None,
+) -> Path | None:
+    payload = embedded_tui_payload() if payload is None else payload
+    if payload is None or not payload.is_file():
+        return None
+
+    executable_name = payload.name.removesuffix(".gz")
+    target_dir = state_dir / "ui-runtime" / __version__
+    target = target_dir / executable_name
+    if target.is_file():
+        return target
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode="wb",
+        dir=target_dir,
+        prefix=f".{executable_name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as destination:
+        temporary = Path(destination.name)
+        with gzip.open(payload, "rb") as source:
+            shutil.copyfileobj(source, destination)
+    try:
+        if os.name != "nt":
+            temporary.chmod(
+                temporary.stat().st_mode
+                | stat.S_IXUSR
+                | stat.S_IXGRP
+                | stat.S_IXOTH
+            )
+        os.replace(temporary, target)
+    finally:
+        with contextlib.suppress(OSError):
+            temporary.unlink()
+    return target

--- a/tests/test_human_ui_complete.py
+++ b/tests/test_human_ui_complete.py
@@ -462,6 +462,15 @@ def test_resolve_spawn_and_tui_cli_branches(tmp_path, monkeypatch):
     assert ui.resolve_tui_command() == [str(candidate)]
     candidate.unlink()
 
+    def fail_materialize(_state_dir):
+        raise PermissionError("denied")
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(ui.Path, "is_file", lambda self: False)
+        scoped.setattr(ui, "materialize_embedded_tui", fail_materialize)
+        with pytest.raises(RuntimeError, match="Unable to prepare embedded OpenTUI runtime"):
+            ui.resolve_tui_command()
+
     source = tmp_path / "tui.tsx"
     source.write_text("x", encoding="utf-8")
     with monkeypatch.context() as scoped:

--- a/tests/test_tui_runtime.py
+++ b/tests/test_tui_runtime.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import gzip
+import os
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from local_shell_mcp import tui_runtime
+
+
+def test_materialize_embedded_tui(tmp_path: Path) -> None:
+    payload = tmp_path / ("local-shell-mcp-tui.exe.gz" if os.name == "nt" else "local-shell-mcp-tui.gz")
+    with gzip.open(payload, "wb") as archive:
+        archive.write(b"runtime")
+
+    state_dir = tmp_path / "state"
+    target = tui_runtime.materialize_embedded_tui(state_dir, payload=payload)
+
+    assert target is not None
+    assert target.read_bytes() == b"runtime"
+    if os.name != "nt":
+        assert os.access(target, os.X_OK)
+    assert tui_runtime.materialize_embedded_tui(state_dir, payload=payload) == target
+
+
+def test_materialize_embedded_tui_returns_none_without_payload(tmp_path: Path) -> None:
+    assert tui_runtime.materialize_embedded_tui(
+        tmp_path / "state", payload=tmp_path / "missing.gz"
+    ) is None
+
+
+def test_materialize_embedded_tui_is_concurrency_safe(tmp_path: Path) -> None:
+    payload = tmp_path / "local-shell-mcp-tui.gz"
+    with gzip.open(payload, "wb") as archive:
+        archive.write(b"runtime" * 1024)
+
+    state_dir = tmp_path / "state"
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        targets = list(
+            executor.map(
+                lambda _: tui_runtime.materialize_embedded_tui(state_dir, payload=payload),
+                range(16),
+            )
+        )
+
+    assert targets[0] is not None
+    assert all(target == targets[0] for target in targets)
+    assert targets[0].read_bytes() == b"runtime" * 1024
+    assert not list(targets[0].parent.glob("*.tmp"))

--- a/tests/test_tui_runtime.py
+++ b/tests/test_tui_runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import gzip
 import os
+import stat
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -9,9 +10,11 @@ import pytest
 
 from local_shell_mcp import tui_runtime
 
+PAYLOAD_NAME = "local-shell-mcp-tui.exe.gz" if os.name == "nt" else "local-shell-mcp-tui.gz"
+
 
 def test_materialize_embedded_tui(tmp_path: Path) -> None:
-    payload = tmp_path / ("local-shell-mcp-tui.exe.gz" if os.name == "nt" else "local-shell-mcp-tui.gz")
+    payload = tmp_path / PAYLOAD_NAME
     with gzip.open(payload, "wb") as archive:
         archive.write(b"runtime")
 
@@ -22,6 +25,7 @@ def test_materialize_embedded_tui(tmp_path: Path) -> None:
     assert target.read_bytes() == b"runtime"
     if os.name != "nt":
         assert os.access(target, os.X_OK)
+        assert target.stat().st_mode & (stat.S_IXGRP | stat.S_IXOTH) == 0
     assert tui_runtime.materialize_embedded_tui(state_dir, payload=payload) == target
 
 
@@ -32,7 +36,7 @@ def test_materialize_embedded_tui_returns_none_without_payload(tmp_path: Path) -
 
 
 def test_materialize_embedded_tui_is_concurrency_safe(tmp_path: Path) -> None:
-    payload = tmp_path / "local-shell-mcp-tui.gz"
+    payload = tmp_path / PAYLOAD_NAME
     with gzip.open(payload, "wb") as archive:
         archive.write(b"runtime" * 1024)
 
@@ -54,7 +58,7 @@ def test_materialize_embedded_tui_is_concurrency_safe(tmp_path: Path) -> None:
 def test_materialize_embedded_tui_accepts_completed_windows_race(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    payload = tmp_path / "local-shell-mcp-tui.gz"
+    payload = tmp_path / PAYLOAD_NAME
     with gzip.open(payload, "wb") as archive:
         archive.write(b"runtime")
 
@@ -75,7 +79,7 @@ def test_materialize_embedded_tui_accepts_completed_windows_race(
 def test_materialize_embedded_tui_propagates_replace_failure_without_winner(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    payload = tmp_path / "local-shell-mcp-tui.gz"
+    payload = tmp_path / PAYLOAD_NAME
     with gzip.open(payload, "wb") as archive:
         archive.write(b"runtime")
 

--- a/tests/test_tui_runtime.py
+++ b/tests/test_tui_runtime.py
@@ -5,6 +5,8 @@ import os
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
+import pytest
+
 from local_shell_mcp import tui_runtime
 
 
@@ -47,3 +49,42 @@ def test_materialize_embedded_tui_is_concurrency_safe(tmp_path: Path) -> None:
     assert all(target == targets[0] for target in targets)
     assert targets[0].read_bytes() == b"runtime" * 1024
     assert not list(targets[0].parent.glob("*.tmp"))
+
+
+def test_materialize_embedded_tui_accepts_completed_windows_race(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = tmp_path / "local-shell-mcp-tui.gz"
+    with gzip.open(payload, "wb") as archive:
+        archive.write(b"runtime")
+
+    real_replace = tui_runtime.os.replace
+
+    def replace_then_report_windows_race(source: Path, target: Path) -> None:
+        real_replace(source, target)
+        raise PermissionError("simulated Windows replace race")
+
+    monkeypatch.setattr(tui_runtime.os, "replace", replace_then_report_windows_race)
+    target = tui_runtime.materialize_embedded_tui(tmp_path / "state", payload=payload)
+
+    assert target is not None
+    assert target.read_bytes() == b"runtime"
+    assert not list(target.parent.glob("*.tmp"))
+
+
+def test_materialize_embedded_tui_propagates_replace_failure_without_winner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = tmp_path / "local-shell-mcp-tui.gz"
+    with gzip.open(payload, "wb") as archive:
+        archive.write(b"runtime")
+
+    def fail_replace(_source: Path, _target: Path) -> None:
+        raise PermissionError("simulated access failure")
+
+    monkeypatch.setattr(tui_runtime.os, "replace", fail_replace)
+    with pytest.raises(PermissionError, match="simulated access failure"):
+        tui_runtime.materialize_embedded_tui(tmp_path / "state", payload=payload)
+
+    target_dir = tmp_path / "state" / "ui-runtime" / tui_runtime.__version__
+    assert not list(target_dir.glob("*.tmp"))


### PR DESCRIPTION
## Summary

- build platform-specific Python wheels that include the compressed OpenTUI runtime
- materialize the packaged runtime atomically into the versioned state directory on first use
- extend CI and release matrices to build and smoke-test wheel-installed WebSocket UI sessions on every supported platform

The v3.0.6 `py3-none-any` wheel contains the WebUI assets but no OpenTUI executable. A wheel-based installation can therefore serve `/ui` and accept `/ui/ws`, then fail while spawning the terminal with:

```text
OpenTUI runtime not found; install a release bundle or run `cd ui && bun run compile:tui`
```

This change keeps explicit `LOCAL_SHELL_MCP_UI_TUI_COMMAND` values and adjacent development/release sidecars at higher precedence. Standalone PyInstaller downloads remain single-file executables.

## Validation

- [x] `ruff check .`
- [x] `pytest -q` — 493 passed
- [x] branch coverage — 93.9%
- [x] built `local_shell_mcp-3.0.6-py3-none-linux_x86_64.whl` and verified its non-pure platform tag and compressed runtime payload
- [x] installed the wheel into a clean virtual environment and passed `scripts/standalone-ui-smoke.py`
- [x] verified isolated first-use materialization at `state/ui-runtime/3.0.6/local-shell-mcp-tui`
- [x] `scripts/ui-smoke.py` — browser smoke passed
- [x] release matrix validation and workflow YAML parsing passed
- [ ] `mkdocs build --strict` — docs unchanged
- [ ] VS Code extension compile — extension unchanged

## Safety checklist

- [x] No secrets, tunnel tokens, OAuth pins, private keys, or bearer file-link URLs are committed.
- [x] No MCP tools or host-control surfaces are added or changed.
- [x] Authentication, remote-worker, file-link, and credential behavior are unchanged.
- [x] Backwards compatibility impact is noted below.

## Backwards compatibility

Official Python release wheels become platform-specific for Linux x86_64/aarch64, macOS x86_64/aarch64, and Windows x86_64 because they now carry a native executable. The source distribution remains available for source builds. Standalone release archives remain single-executable bundles, and existing configured or adjacent TUI runtimes continue to take precedence.
