### PR TITLE
fix(remote): keep heartbeat active while submitting results

### DIFF
--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -1704,6 +1704,49 @@ async def _execute_worker_job_with_heartbeat(
         await asyncio.gather(heartbeat, return_exceptions=True)
 
 
+async def _submit_worker_result_with_heartbeat(
+    result: dict[str, Any],
+    server: str,
+    headers: dict[str, str],
+    heartbeat_interval_s: float,
+) -> dict[str, Any]:
+    submission = asyncio.create_task(
+        _worker_post_json_forever(
+            f"{server}{REMOTE_API_PREFIX}/result",
+            result,
+            headers,
+            30,
+            "submit result",
+        )
+    )
+
+    async def heartbeat_loop() -> None:
+        interval = max(0.01, heartbeat_interval_s)
+        while not submission.done():
+            await asyncio.sleep(interval)
+            if submission.done():
+                return
+            try:
+                await asyncio.to_thread(
+                    _worker_post_json,
+                    f"{server}{REMOTE_API_PREFIX}/heartbeat",
+                    {},
+                    headers,
+                    30,
+                )
+            except Exception as exc:  # noqa: BLE001
+                if not _worker_error_is_retryable(exc):
+                    return
+                _worker_log_retry("heartbeat", exc, interval)
+
+    heartbeat = asyncio.create_task(heartbeat_loop())
+    try:
+        return await submission
+    finally:
+        heartbeat.cancel()
+        await asyncio.gather(heartbeat, return_exceptions=True)
+
+
 async def run_worker(
     server: str,
     invite: str,
@@ -1779,8 +1822,8 @@ async def run_worker(
                 "error": "TimeoutError",
                 "message": "remote job expired before execution",
             }
-            await _worker_post_json_forever(
-                f"{server}{REMOTE_API_PREFIX}/result", out, headers, 30, "submit result"
+            await _submit_worker_result_with_heartbeat(
+                out, server, headers, heartbeat_interval_s
             )
             continue
         try:
@@ -1790,9 +1833,7 @@ async def run_worker(
             out = {"job_id": job["id"], "ok": True, "data": result}
         except Exception as exc:  # noqa: BLE001
             out = {"job_id": job.get("id"), **_handled_remote_exception(exc)}
-        await _worker_post_json_forever(
-            f"{server}{REMOTE_API_PREFIX}/result", out, headers, 30, "submit result"
-        )
+        await _submit_worker_result_with_heartbeat(out, server, headers, heartbeat_interval_s)
 
 
 def run_worker_cli(argv: list[str] | None = None) -> None:

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -356,6 +356,47 @@ async def test_worker_job_sends_heartbeats_while_running(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_worker_result_submission_sends_heartbeats_while_retrying(monkeypatch):
+    result_attempts = 0
+    heartbeat_calls = []
+    result = {"job_id": "job-1", "ok": True, "data": {"done": True}}
+    headers = {"Authorization": "Bearer token"}
+
+    def fake_post(url, payload, request_headers=None, timeout=None):
+        nonlocal result_attempts
+        assert request_headers == headers
+        assert timeout == 30
+        if url.endswith("/result"):
+            assert payload == result
+            result_attempts += 1
+            if result_attempts < 3:
+                raise RuntimeError(f"temporary result failure {result_attempts}")
+            return {"ok": True, "data": {"accepted": True}}
+        assert url.endswith("/heartbeat")
+        assert payload == {}
+        heartbeat_calls.append(url)
+        return {"ok": True, "data": {"accepted": True}}
+
+    monkeypatch.setattr(remote, "_worker_post_json", fake_post)
+    monkeypatch.setattr(remote, "_WORKER_RETRY_INITIAL_DELAY_S", 0.02)
+    monkeypatch.setattr(remote, "_WORKER_RETRY_MAX_DELAY_S", 0.02)
+
+    response = await remote._submit_worker_result_with_heartbeat(  # noqa: SLF001
+        result,
+        "https://example.test",
+        headers,
+        0.005,
+    )
+
+    assert response == {"ok": True, "data": {"accepted": True}}
+    assert result_attempts == 3
+    assert heartbeat_calls
+    heartbeat_count = len(heartbeat_calls)
+    await asyncio.sleep(0.02)
+    assert len(heartbeat_calls) == heartbeat_count
+
+
+@pytest.mark.asyncio
 async def test_remote_result_must_come_from_assigned_worker(tmp_path, monkeypatch):
     monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
     monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(tmp_path / ".state"))


### PR DESCRIPTION
## Summary

- keep the remote worker heartbeat running while `/remote/result` is retried
- use the same submission path for normal and already-expired jobs
- add regression coverage for transient result submission failures

## Validation

- `ruff check .`
- `pytest -q` — 496 passed
- branch coverage — 93.8%

Closes #76
