### PR TITLE
chore: release v3.0.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "local-shell-mcp"
-version = "3.0.7"
+version = "3.0.8"
 description = "A ChatGPT-compatible OAuth MCP server that gives AI coding agents controlled shell, filesystem, remote-worker, and Playwright access inside a local container."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/local_shell_mcp/__init__.py
+++ b/src/local_shell_mcp/__init__.py
@@ -1,3 +1,3 @@
 """local-shell-mcp."""
 
-__version__ = "3.0.7"
+__version__ = "3.0.8"


### PR DESCRIPTION
## Summary

- bump the Python package version to `3.0.8`
- align `local_shell_mcp.__version__` with the release tag
- include the remote result-upload heartbeat fix from PR #77
- include visible WebUI TUI transparency from PR #79

## Release mode

- stable GitHub release
- publish Docker Hub and GHCR tags `v3.0.8`, `3.0.8`, and `latest`
