### PR TITLE
fix: report public shell timeout limits

### DIFF
--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -46,6 +46,8 @@ from .playwright_ops import browser_capture, browser_get_text, playwright_run_sc
 from .search_ops import grep, tree
 from .settings import get_settings, safe_settings_dump
 from .shell_ops import (
+    PUBLIC_RUN_SHELL_DEFAULT_TIMEOUT_S,
+    PUBLIC_RUN_SHELL_TIMEOUT_CAP_S,
     kill_shell,
     list_shells,
     public_run_shell,
@@ -1148,6 +1150,9 @@ async def execute_worker_tool(tool: str, args: dict[str, Any]) -> Any:
 
 async def _execute_environment_worker_tool(tool: str, args: dict[str, Any]) -> Any:
     if tool == "environment_info":
+        public_settings = safe_settings_dump()
+        public_settings["default_timeout_s"] = PUBLIC_RUN_SHELL_DEFAULT_TIMEOUT_S
+        public_settings["max_timeout_s"] = PUBLIC_RUN_SHELL_TIMEOUT_CAP_S
         python = quote_shell_argument(get_settings().python_bin)
         git = quote_shell_argument(get_settings().git_bin)
         result = await run_shell(
@@ -1158,7 +1163,7 @@ async def _execute_environment_worker_tool(tool: str, args: dict[str, Any]) -> A
         )
         return {
             "version": get_version_info(),
-            "settings": safe_settings_dump(),
+            "settings": public_settings,
             "persistent_shell": persistent_shell_backend_info(),
             "probe": result.model_dump(),
         }

--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -50,6 +50,8 @@ from .remote_transfer import (
 from .search_ops import grep, tree
 from .settings import get_settings, safe_settings_dump
 from .shell_ops import (
+    PUBLIC_RUN_SHELL_DEFAULT_TIMEOUT_S,
+    PUBLIC_RUN_SHELL_TIMEOUT_CAP_S,
     PUBLIC_TOOL_WATCHDOG_TIMEOUT_S,
     kill_shell,
     list_shells,
@@ -1223,6 +1225,9 @@ def _register_environment_tools(
         if machine:
             return await _remote_call(settings, machine, "environment_info", {})
         try:
+            public_settings = safe_settings_dump(settings)
+            public_settings["default_timeout_s"] = PUBLIC_RUN_SHELL_DEFAULT_TIMEOUT_S
+            public_settings["max_timeout_s"] = PUBLIC_RUN_SHELL_TIMEOUT_CAP_S
             python = quote_shell_argument(settings.python_bin)
             git = quote_shell_argument(settings.git_bin)
             result = await run_shell(
@@ -1234,7 +1239,7 @@ def _register_environment_tools(
             return _ok(
                 {
                     "version": get_version_info(),
-                    "settings": safe_settings_dump(settings),
+                    "settings": public_settings,
                     "persistent_shell": persistent_shell_backend_info(),
                     "probe": result.model_dump(),
                 }

--- a/tests/test_mcp_chatgpt_compat.py
+++ b/tests/test_mcp_chatgpt_compat.py
@@ -114,6 +114,8 @@ async def test_mcp_metadata_for_chatgpt_developer_mode(tmp_path, monkeypatch):
     content, structured = await mcp.call_tool("environment_info", {})
     assert content
     assert structured["ok"] is True
+    assert structured["data"]["settings"]["default_timeout_s"] == 10
+    assert structured["data"]["settings"]["max_timeout_s"] == 120
 
 
 


### PR DESCRIPTION
## Summary
- make `environment_info` report the actual public `run_shell_tool` timeout defaults
- keep internal shell timeout configuration unchanged
- apply the same display fix to remote workers

## Tests
- `PYTHONPATH=src python -m ruff check src/local_shell_mcp/tools.py src/local_shell_mcp/remote.py tests/test_mcp_chatgpt_compat.py`
- `PYTHONPATH=src pytest -q` (496 passed)