### PR TITLE
fix(tui): contain audit record rows

### DIFF
--- a/ui/src/audit-screen.tsx
+++ b/ui/src/audit-screen.tsx
@@ -4,6 +4,7 @@ import { api, formatError } from "./api"
 import {
   AUDIT_OPERATIONS,
   auditListLayout,
+  auditStackedVisibleRows,
   auditInput,
   auditOutput,
   fitAuditColumn,
@@ -93,7 +94,11 @@ export function AuditScreen({
   const narrow = width < 70
   const horizontal = width >= 110
   const listLayout = useMemo(() => auditListLayout(entries, width), [entries, width])
-  const tableHeight = Math.max(6, height - 15)
+  const stackedDetailHeight = Math.max(14, Math.floor(height * 0.42))
+  const hasFilterSummary = Boolean(search || event || session)
+  const tableHeight = horizontal
+    ? Math.max(6, height - 15)
+    : auditStackedVisibleRows(height, stackedDetailHeight, hasFilterSummary)
   const { rows, start } = useVisibleRows(entries, selected, tableHeight)
 
   const selectIndex = useCallback((next: number | ((value: number) => number)) => {
@@ -234,7 +239,7 @@ export function AuditScreen({
     : ""
   const inputText = displayed ? formatAuditValue(auditInput(displayed), "No input recorded") : ""
   const duration = displayed ? durationLabel(displayed) : ""
-  const detailHeight = horizontal ? "100%" : Math.max(14, Math.floor(height * 0.42))
+  const detailHeight = horizontal ? "100%" : stackedDetailHeight
 
   return (
     <box style={{ flexGrow: 1, flexDirection: "column", gap: 1 }}>

--- a/ui/src/audit-utils.test.ts
+++ b/ui/src/audit-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import {
   AUDIT_OPERATIONS,
   auditListLayout,
+  auditStackedVisibleRows,
   auditInput,
   auditOutput,
   fitAuditColumn,
@@ -95,6 +96,16 @@ describe("audit wide layout", () => {
   test("preserves the minimum detail width at the horizontal breakpoint", () => {
     const layout = auditListLayout([entry("compact", 1)], 110)
     expect(110 - layout.paneWidth - 1).toBeGreaterThanOrEqual(44)
+  })
+})
+
+describe("audit stacked layout", () => {
+  test("limits records to the rows above the detail panel", () => {
+    expect(auditStackedVisibleRows(37, 15, false)).toBe(9)
+  })
+
+  test("accounts for the active filter summary", () => {
+    expect(auditStackedVisibleRows(37, 15, true)).toBe(6)
   })
 })
 

--- a/ui/src/audit-utils.ts
+++ b/ui/src/audit-utils.ts
@@ -13,6 +13,15 @@ export interface AuditListLayout {
   toolWidth: number
 }
 
+export function auditStackedVisibleRows(
+  screenHeight: number,
+  detailHeight: number,
+  hasFilterSummary: boolean,
+): number {
+  // Filters, key hints, gaps, and the list panel chrome consume 13 rows.
+  return Math.max(1, screenHeight - detailHeight - 13 - (hasFilterSummary ? 3 : 0))
+}
+
 type JsonRecord = Record<string, unknown>
 
 function isRecord(value: unknown): value is JsonRecord {


### PR DESCRIPTION
## Summary
- calculate visible Audit rows from the actual stacked list height
- account for the optional filter summary
- add regression coverage for the 72×45 layout

## Validation
- `bun test`
- `bun run typecheck`
- `bun run build`