### PR TITLE
feat: support apply_patch envelopes

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -443,7 +443,7 @@ When `machine` is supplied, the call additionally requires `remote:use` and runs
 
 ### `apply_patch`
 
-Check and apply a unified diff locally or on a remote machine.
+Check and apply a standard unified diff or a `*** Begin Patch` envelope locally or on a remote machine.
 
 | Parameter | Type | Required/default | Description |
 |---|---|---|---|

--- a/src/local_shell_mcp/patch_ops.py
+++ b/src/local_shell_mcp/patch_ops.py
@@ -115,7 +115,7 @@ def _parse_envelope(patch: str, root: Path) -> list[_PatchAction]:
 
 def _normalize_patch_path(raw_path: str, root: Path) -> str:
     path = raw_path.strip()
-    if not path or "\\" in path:
+    if not path:
         raise ValueError(f"invalid patch path: {raw_path!r}")
 
     filesystem_path = Path(path)
@@ -128,10 +128,12 @@ def _normalize_patch_path(raw_path: str, root: Path) -> str:
             raise ValueError(f"invalid patch path: {raw_path!r}")
         return relative.as_posix()
 
+    if "\\" in path:
+        raise ValueError(f"invalid patch path: {raw_path!r}")
     candidate = PurePosixPath(path)
     if ".." in candidate.parts:
         raise ValueError(f"patch path must stay within cwd: {raw_path!r}")
-    if any(part in {"", "."} for part in candidate.parts):
+    if candidate == PurePosixPath("."):
         raise ValueError(f"invalid patch path: {raw_path!r}")
     return candidate.as_posix()
 

--- a/src/local_shell_mcp/patch_ops.py
+++ b/src/local_shell_mcp/patch_ops.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import difflib
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+_BEGIN_PATCH = "*** Begin Patch"
+_END_PATCH = "*** End Patch"
+_ACTION_PREFIXES = {
+    "*** Add File: ": "add",
+    "*** Update File: ": "update",
+    "*** Delete File: ": "delete",
+}
+
+
+@dataclass(frozen=True)
+class _PatchAction:
+    operation: str
+    path: str
+    body: tuple[str, ...]
+
+
+@dataclass
+class _FileState:
+    path: str
+    original: str | None
+    current: str | None
+    mode: str
+
+
+def normalize_patch_text(patch: str, cwd: str = ".") -> str:
+    """Convert an apply_patch envelope to a standard unified diff."""
+    envelope = patch.lstrip("\ufeff\r\n")
+    if not envelope.startswith(_BEGIN_PATCH):
+        return patch
+
+    root = Path(cwd).resolve()
+    actions = _parse_envelope(envelope, root)
+    states: dict[str, _FileState] = {}
+    order: list[str] = []
+
+    for action in actions:
+        state = states.get(action.path)
+        if state is None:
+            target = _resolve_target(root, action.path)
+            original = _read_existing_text(target)
+            mode = "100755" if target.exists() and target.stat().st_mode & 0o111 else "100644"
+            state = _FileState(action.path, original, original, mode)
+            states[action.path] = state
+            order.append(action.path)
+
+        if action.operation == "add":
+            if state.current is not None:
+                raise ValueError(f"cannot add existing file: {action.path}")
+            state.current = _parse_added_file(action)
+        elif action.operation == "delete":
+            if state.current is None:
+                raise ValueError(f"cannot delete missing file: {action.path}")
+            if action.body:
+                raise ValueError(f"delete action must not contain patch lines: {action.path}")
+            state.current = None
+        else:
+            if state.current is None:
+                raise ValueError(f"cannot update missing file: {action.path}")
+            state.current = _apply_update(action, state.current)
+
+    rendered = "".join(_render_file_diff(states[path]) for path in order)
+    if not rendered:
+        raise ValueError("patch does not contain any file changes")
+    return rendered
+
+
+def _parse_envelope(patch: str, root: Path) -> list[_PatchAction]:
+    lines = patch.splitlines()
+    if not lines or lines[0] != _BEGIN_PATCH:
+        raise ValueError("apply_patch envelope must begin with '*** Begin Patch'")
+
+    actions: list[_PatchAction] = []
+    index = 1
+    while index < len(lines):
+        line = lines[index]
+        if line == _END_PATCH:
+            if any(item.strip() for item in lines[index + 1 :]):
+                raise ValueError("unexpected content after '*** End Patch'")
+            if not actions:
+                raise ValueError("patch envelope contains no file actions")
+            return actions
+
+        operation = None
+        raw_path = ""
+        for prefix, candidate in _ACTION_PREFIXES.items():
+            if line.startswith(prefix):
+                operation = candidate
+                raw_path = line[len(prefix) :]
+                break
+        if operation is None:
+            raise ValueError(f"expected file action at envelope line {index + 1}: {line!r}")
+
+        path = _normalize_patch_path(raw_path, root)
+        index += 1
+        body: list[str] = []
+        while (
+            index < len(lines)
+            and lines[index] != _END_PATCH
+            and not any(lines[index].startswith(prefix) for prefix in _ACTION_PREFIXES)
+        ):
+            if lines[index].startswith("*** Move to: "):
+                raise ValueError("'*** Move to:' is not supported; use delete and add actions")
+            body.append(lines[index])
+            index += 1
+        actions.append(_PatchAction(operation, path, tuple(body)))
+
+    raise ValueError("apply_patch envelope is missing '*** End Patch'")
+
+
+def _normalize_patch_path(raw_path: str, root: Path) -> str:
+    path = raw_path.strip()
+    if not path or "\\" in path:
+        raise ValueError(f"invalid patch path: {raw_path!r}")
+
+    filesystem_path = Path(path)
+    if filesystem_path.is_absolute():
+        resolved = filesystem_path.resolve()
+        if not resolved.is_relative_to(root):
+            raise ValueError(f"patch path must stay within cwd: {raw_path!r}")
+        relative = resolved.relative_to(root)
+        if not relative.parts:
+            raise ValueError(f"invalid patch path: {raw_path!r}")
+        return relative.as_posix()
+
+    candidate = PurePosixPath(path)
+    if ".." in candidate.parts:
+        raise ValueError(f"patch path must stay within cwd: {raw_path!r}")
+    if any(part in {"", "."} for part in candidate.parts):
+        raise ValueError(f"invalid patch path: {raw_path!r}")
+    return candidate.as_posix()
+
+
+def _resolve_target(root: Path, relative_path: str) -> Path:
+    target = (root / relative_path).resolve()
+    if not target.is_relative_to(root):
+        raise ValueError(f"patch path escapes cwd: {relative_path}")
+    if target.exists() and not target.is_file():
+        raise ValueError(f"patch target is not a regular file: {relative_path}")
+    return target
+
+
+def _read_existing_text(target: Path) -> str | None:
+    if not target.exists():
+        return None
+    try:
+        return target.read_bytes().decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError(f"patch target is not UTF-8 text: {target}") from exc
+
+
+def _parse_added_file(action: _PatchAction) -> str:
+    content: list[str] = []
+    for line_number, line in enumerate(action.body, start=1):
+        if not line.startswith("+"):
+            raise ValueError(f"add action line {line_number} for {action.path} must start with '+'")
+        content.append(line[1:])
+    return "\n".join(content) + ("\n" if content else "")
+
+
+def _apply_update(action: _PatchAction, text: str) -> str:
+    hunks: list[tuple[list[str], bool]] = []
+    current: list[str] | None = None
+    end_of_file = False
+
+    for line_number, line in enumerate(action.body, start=1):
+        if line.startswith("@@"):
+            if current is not None:
+                hunks.append((current, end_of_file))
+            current = []
+            end_of_file = False
+            continue
+        if line == "*** End of File":
+            if current is None:
+                raise ValueError(f"unexpected end-of-file marker in {action.path}")
+            end_of_file = True
+            continue
+        if current is None:
+            raise ValueError(
+                f"update action line {line_number} for {action.path} must follow an '@@' hunk"
+            )
+        if not line.startswith((" ", "+", "-")):
+            raise ValueError(f"invalid hunk line {line_number} for {action.path}: {line!r}")
+        current.append(line)
+
+    if current is not None:
+        hunks.append((current, end_of_file))
+    if not hunks:
+        raise ValueError(f"update action contains no hunks: {action.path}")
+
+    newline = "\r\n" if "\r\n" in text else "\r" if "\r" in text and "\n" not in text else "\n"
+    trailing_newline = text.endswith(("\n", "\r"))
+    lines = text.splitlines()
+    cursor = 0
+
+    for hunk_number, (hunk, must_end_at_eof) in enumerate(hunks, start=1):
+        old_lines = [line[1:] for line in hunk if not line.startswith("+")]
+        new_lines = [line[1:] for line in hunk if not line.startswith("-")]
+        if old_lines == new_lines:
+            raise ValueError(f"hunk {hunk_number} for {action.path} contains no changes")
+
+        if old_lines:
+            matches = [
+                start
+                for start in range(cursor, len(lines) - len(old_lines) + 1)
+                if lines[start : start + len(old_lines)] == old_lines
+            ]
+            if not matches:
+                raise ValueError(f"hunk {hunk_number} does not match {action.path}")
+            if len(matches) > 1:
+                raise ValueError(f"hunk {hunk_number} matches multiple locations in {action.path}")
+            start = matches[0]
+        elif must_end_at_eof:
+            start = len(lines)
+        else:
+            raise ValueError(
+                f"hunk {hunk_number} for {action.path} has no context; use '*** End of File' for append"
+            )
+
+        if must_end_at_eof and start + len(old_lines) != len(lines):
+            raise ValueError(f"hunk {hunk_number} does not match the end of {action.path}")
+        lines[start : start + len(old_lines)] = new_lines
+        cursor = start + len(new_lines)
+
+    return newline.join(lines) + (newline if trailing_newline and lines else "")
+
+
+def _render_file_diff(state: _FileState) -> str:
+    if state.original == state.current:
+        return ""
+
+    path = state.path
+    old = state.original or ""
+    new = state.current or ""
+    from_file = "/dev/null" if state.original is None else f"a/{path}"
+    to_file = "/dev/null" if state.current is None else f"b/{path}"
+    output = [f"diff --git a/{path} b/{path}\n"]
+    if state.original is None:
+        output.append("new file mode 100644\n")
+    elif state.current is None:
+        output.append(f"deleted file mode {state.mode}\n")
+    diff_lines = difflib.unified_diff(
+        old.splitlines(keepends=True),
+        new.splitlines(keepends=True),
+        fromfile=from_file,
+        tofile=to_file,
+        lineterm="\n",
+    )
+    for line in diff_lines:
+        output.append(line)
+        if line.startswith((" ", "+", "-")) and not line.endswith(("\n", "\r")):
+            output.append("\n\\ No newline at end of file\n")
+    return "".join(output)

--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -908,7 +908,7 @@ async def _apply_patch_text(patch: str, cwd: str = ".") -> dict[str, Any]:
     await asyncio.to_thread(prune_temp_dir)
     patch_path = temp_dir() / f"remote-patch-{uuid.uuid4().hex}.diff"
     patch_path.parent.mkdir(parents=True, exist_ok=True)
-    await asyncio.to_thread(patch_path.write_text, normalized_patch, encoding="utf-8")
+    await asyncio.to_thread(patch_path.write_bytes, normalized_patch.encode("utf-8"))
     result = await run_shell(
         f"{quote_shell_argument(get_settings().git_bin)} apply --check "
         f"{quote_shell_argument(str(patch_path))} && "

--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -42,6 +42,7 @@ from .fs_ops import (
 )
 from .jobs import list_jobs, retry_job, start_job, stop_job, tail_job
 from .models import ok_result as _ok
+from .patch_ops import normalize_patch_text
 from .playwright_ops import browser_capture, browser_get_text, playwright_run_script
 from .search_ops import grep, tree
 from .settings import get_settings, safe_settings_dump
@@ -903,10 +904,11 @@ def _handled_remote_exception(exc: Exception) -> dict[str, Any]:
 
 async def _apply_patch_text(patch: str, cwd: str = ".") -> dict[str, Any]:
     _assert_worker_text_input_size("patch", patch)
+    normalized_patch = await asyncio.to_thread(normalize_patch_text, patch, cwd)
     await asyncio.to_thread(prune_temp_dir)
     patch_path = temp_dir() / f"remote-patch-{uuid.uuid4().hex}.diff"
     patch_path.parent.mkdir(parents=True, exist_ok=True)
-    await asyncio.to_thread(patch_path.write_text, patch, encoding="utf-8")
+    await asyncio.to_thread(patch_path.write_text, normalized_patch, encoding="utf-8")
     result = await run_shell(
         f"{quote_shell_argument(get_settings().git_bin)} apply --check "
         f"{quote_shell_argument(str(patch_path))} && "

--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -40,6 +40,7 @@ from .jobs import list_jobs, retry_job, start_job, stop_job, tail_job
 from .models import ToolResult
 from .models import ok_result as _ok
 from .oauth import ALL_OAUTH_SCOPES
+from .patch_ops import normalize_patch_text
 from .playwright_ops import browser_capture, browser_get_text, playwright_run_script
 from .remote import remote_manager
 from .remote_transfer import (
@@ -152,10 +153,11 @@ def _assert_text_input_size(label: str, text: str, limit: int | None = None) -> 
 
 async def _apply_patch_text(patch: str, cwd: str = ".") -> dict:
     _assert_text_input_size("patch", patch)
+    normalized_patch = await asyncio.to_thread(normalize_patch_text, patch, cwd)
     await asyncio.to_thread(prune_temp_dir)
     patch_path = temp_dir() / f"patch-{uuid.uuid4().hex}.diff"
     patch_path.parent.mkdir(parents=True, exist_ok=True)
-    await asyncio.to_thread(patch_path.write_text, patch, encoding="utf-8")
+    await asyncio.to_thread(patch_path.write_text, normalized_patch, encoding="utf-8")
     quoted = quote_shell_argument(str(patch_path))
     git = quote_shell_argument(get_settings().git_bin)
     result = await run_shell(
@@ -1707,7 +1709,7 @@ def _register_workspace_write_tools(mcp: FastMCP, settings: Any) -> None:
         explanation: str | None = None,
         machine: str | None = None,
     ) -> ToolResult:
-        """Check and apply a unified diff locally or on a remote machine."""
+        """Check and apply a unified diff or an apply_patch envelope locally or remotely."""
         _audit_tool_purpose("apply_patch", purpose, explanation)
         if machine:
             return await _remote_call(

--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -157,7 +157,7 @@ async def _apply_patch_text(patch: str, cwd: str = ".") -> dict:
     await asyncio.to_thread(prune_temp_dir)
     patch_path = temp_dir() / f"patch-{uuid.uuid4().hex}.diff"
     patch_path.parent.mkdir(parents=True, exist_ok=True)
-    await asyncio.to_thread(patch_path.write_text, normalized_patch, encoding="utf-8")
+    await asyncio.to_thread(patch_path.write_bytes, normalized_patch.encode("utf-8"))
     quoted = quote_shell_argument(str(patch_path))
     git = quote_shell_argument(get_settings().git_bin)
     result = await run_shell(

--- a/tests/test_patch_ops.py
+++ b/tests/test_patch_ops.py
@@ -10,7 +10,7 @@ from local_shell_mcp.patch_ops import normalize_patch_text
 
 def _git_apply(root: Path, patch: str) -> None:
     patch_path = root / "change.diff"
-    patch_path.write_text(patch, encoding="utf-8")
+    patch_path.write_bytes(patch.encode("utf-8"))
     subprocess.run(["git", "init", "-q"], cwd=root, check=True)
     subprocess.run(["git", "apply", "--check", str(patch_path)], cwd=root, check=True)
     subprocess.run(["git", "apply", str(patch_path)], cwd=root, check=True)
@@ -121,7 +121,8 @@ def test_envelope_preserves_executable_mode_on_delete(tmp_path: Path) -> None:
 """
 
     normalized = normalize_patch_text(patch, str(tmp_path))
-    assert "deleted file mode 100755" in normalized
+    expected_mode = "100755" if target.stat().st_mode & 0o111 else "100644"
+    assert f"deleted file mode {expected_mode}" in normalized
     _git_apply(tmp_path, normalized)
 
     assert not target.exists()
@@ -170,3 +171,145 @@ def test_envelope_rejects_paths_outside_cwd(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="stay within cwd"):
         normalize_patch_text(patch, str(tmp_path))
+
+
+@pytest.mark.parametrize(
+    ("patch", "message"),
+    [
+        ("*** Begin Patch\n*** End Patch\n", "no file actions"),
+        ("*** Begin Patch\n*** End Patch\nextra\n", "unexpected content"),
+        ("*** Begin Patch\n*** Rename File: x.txt\n*** End Patch\n", "expected file action"),
+        ("*** Begin Patch\n*** Add File: x.txt\n+x\n", "missing"),
+        (
+            "*** Begin Patch\n*** Update File: x.txt\n*** Move to: y.txt\n*** End Patch\n",
+            "not supported",
+        ),
+        ("*** Begin Patch\n*** Add File:   \n+x\n*** End Patch\n", "invalid patch path"),
+        ("*** Begin Patch\n*** Add File: sub\\x.txt\n+x\n*** End Patch\n", "invalid patch path"),
+        ("*** Begin Patch\n*** Add File: .\n+x\n*** End Patch\n", "invalid patch path"),
+        ("*** Begin Patch\n*** Add File: ../x.txt\n+x\n*** End Patch\n", "stay within cwd"),
+    ],
+)
+def test_envelope_rejects_malformed_input(tmp_path: Path, patch: str, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        normalize_patch_text(patch, str(tmp_path))
+
+
+def test_envelope_rejects_invalid_file_actions(tmp_path: Path) -> None:
+    (tmp_path / "existing.txt").write_text("old\n", encoding="utf-8")
+
+    cases = [
+        (
+            "*** Begin Patch\n*** Add File: existing.txt\n+new\n*** End Patch\n",
+            "cannot add existing",
+        ),
+        ("*** Begin Patch\n*** Delete File: missing.txt\n*** End Patch\n", "cannot delete missing"),
+        (
+            "*** Begin Patch\n*** Delete File: existing.txt\n-extra\n*** End Patch\n",
+            "must not contain patch lines",
+        ),
+        (
+            "*** Begin Patch\n*** Update File: missing.txt\n@@\n-old\n+new\n*** End Patch\n",
+            "cannot update missing",
+        ),
+        (
+            "*** Begin Patch\n*** Add File: bad.txt\nnot-added\n*** End Patch\n",
+            "must start with",
+        ),
+    ]
+    for patch, message in cases:
+        with pytest.raises(ValueError, match=message):
+            normalize_patch_text(patch, str(tmp_path))
+
+
+def test_envelope_rejects_invalid_hunks(tmp_path: Path) -> None:
+    (tmp_path / "sample.txt").write_text("one\ntwo\n", encoding="utf-8")
+    cases = [
+        (
+            "*** Begin Patch\n*** Update File: sample.txt\n*** End of File\n*** End Patch\n",
+            "unexpected end-of-file",
+        ),
+        (
+            "*** Begin Patch\n*** Update File: sample.txt\n-one\n+ONE\n*** End Patch\n",
+            "must follow an '@@' hunk",
+        ),
+        (
+            "*** Begin Patch\n*** Update File: sample.txt\n@@\n?one\n*** End Patch\n",
+            "invalid hunk line",
+        ),
+        (
+            "*** Begin Patch\n*** Update File: sample.txt\n*** End Patch\n",
+            "contains no hunks",
+        ),
+        (
+            "*** Begin Patch\n*** Update File: sample.txt\n@@\n one\n*** End Patch\n",
+            "contains no changes",
+        ),
+        (
+            "*** Begin Patch\n*** Update File: sample.txt\n@@\n+zero\n*** End Patch\n",
+            "has no context",
+        ),
+        (
+            "*** Begin Patch\n*** Update File: sample.txt\n@@\n one\n+extra\n*** End of File\n*** End Patch\n",
+            "does not match the end",
+        ),
+    ]
+    for patch, message in cases:
+        with pytest.raises(ValueError, match=message):
+            normalize_patch_text(patch, str(tmp_path))
+
+
+def test_envelope_rejects_invalid_targets(tmp_path: Path) -> None:
+    directory = tmp_path / "directory"
+    directory.mkdir()
+    patch = "*** Begin Patch\n*** Update File: directory\n@@\n-old\n+new\n*** End Patch\n"
+    with pytest.raises(ValueError, match="not a regular file"):
+        normalize_patch_text(patch, str(tmp_path))
+
+    binary = tmp_path / "binary.bin"
+    binary.write_bytes(b"\xff")
+    patch = "*** Begin Patch\n*** Update File: binary.bin\n@@\n-old\n+new\n*** End Patch\n"
+    with pytest.raises(ValueError, match="not UTF-8 text"):
+        normalize_patch_text(patch, str(tmp_path))
+
+    outside = tmp_path.parent / "outside.txt"
+    patch = f"*** Begin Patch\n*** Add File: {outside}\n+x\n*** End Patch\n"
+    with pytest.raises(ValueError, match="stay within cwd"):
+        normalize_patch_text(patch, str(tmp_path))
+
+    patch = f"*** Begin Patch\n*** Add File: {tmp_path}\n+x\n*** End Patch\n"
+    with pytest.raises(ValueError, match="invalid patch path"):
+        normalize_patch_text(patch, str(tmp_path))
+
+
+def test_envelope_supports_empty_files_and_detects_net_noop(tmp_path: Path) -> None:
+    add_empty = "*** Begin Patch\n*** Add File: empty.txt\n*** End Patch\n"
+    _git_apply(tmp_path, normalize_patch_text(add_empty, str(tmp_path)))
+    assert (tmp_path / "empty.txt").read_bytes() == b""
+
+    delete_empty = "*** Begin Patch\n*** Delete File: empty.txt\n*** End Patch\n"
+    _git_apply(tmp_path, normalize_patch_text(delete_empty, str(tmp_path)))
+    assert not (tmp_path / "empty.txt").exists()
+
+    noop = """*** Begin Patch
+*** Add File: transient.txt
++x
+*** Delete File: transient.txt
+*** End Patch
+"""
+    with pytest.raises(ValueError, match="does not contain any file changes"):
+        normalize_patch_text(noop, str(tmp_path))
+
+
+def test_envelope_preserves_crlf_and_cr_line_endings(tmp_path: Path) -> None:
+    crlf = tmp_path / "crlf.txt"
+    crlf.write_bytes(b"one\r\ntwo\r\n")
+    patch = "*** Begin Patch\n*** Update File: crlf.txt\n@@\n one\n-two\n+TWO\n*** End Patch\n"
+    _git_apply(tmp_path, normalize_patch_text(patch, str(tmp_path)))
+    assert crlf.read_bytes() == b"one\r\nTWO\r\n"
+
+    cr = tmp_path / "cr.txt"
+    cr.write_bytes(b"one\rtwo\r")
+    patch = "*** Begin Patch\n*** Update File: cr.txt\n@@\n one\n-two\n+TWO\n*** End Patch\n"
+    normalized = normalize_patch_text(patch, str(tmp_path))
+    assert " one\r" in normalized

--- a/tests/test_patch_ops.py
+++ b/tests/test_patch_ops.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from local_shell_mcp.patch_ops import normalize_patch_text
+
+
+def _git_apply(root: Path, patch: str) -> None:
+    patch_path = root / "change.diff"
+    patch_path.write_text(patch, encoding="utf-8")
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "apply", "--check", str(patch_path)], cwd=root, check=True)
+    subprocess.run(["git", "apply", str(patch_path)], cwd=root, check=True)
+
+
+def test_standard_unified_diff_passes_through() -> None:
+    patch = "diff --git a/a.txt b/a.txt\n--- a/a.txt\n+++ b/a.txt\n"
+    assert normalize_patch_text(patch) == patch
+
+
+def test_envelope_update_add_and_delete(tmp_path: Path) -> None:
+    (tmp_path / "existing.txt").write_text("one\ntwo\nthree\n", encoding="utf-8")
+    (tmp_path / "obsolete.txt").write_text("remove me\n", encoding="utf-8")
+    patch = """*** Begin Patch
+*** Update File: existing.txt
+@@
+ one
+-two
++TWO
+ three
+*** Add File: added.txt
++first
++second
+*** Delete File: obsolete.txt
+*** End Patch
+"""
+
+    normalized = normalize_patch_text(patch, str(tmp_path))
+    assert normalized.startswith("diff --git a/existing.txt b/existing.txt\n")
+    _git_apply(tmp_path, normalized)
+
+    assert (tmp_path / "existing.txt").read_text(encoding="utf-8") == "one\nTWO\nthree\n"
+    assert (tmp_path / "added.txt").read_text(encoding="utf-8") == "first\nsecond\n"
+    assert not (tmp_path / "obsolete.txt").exists()
+
+
+def test_envelope_supports_multiple_hunks_and_eof_append(tmp_path: Path) -> None:
+    target = tmp_path / "sample.txt"
+    target.write_text("alpha\nbeta\ngamma\n", encoding="utf-8")
+    patch = """*** Begin Patch
+*** Update File: sample.txt
+@@
+-alpha
++ALPHA
+ beta
+@@
+ gamma
++delta
+*** End of File
+*** End Patch
+"""
+
+    _git_apply(tmp_path, normalize_patch_text(patch, str(tmp_path)))
+
+    assert target.read_text(encoding="utf-8") == "ALPHA\nbeta\ngamma\ndelta\n"
+
+
+def test_envelope_rejects_ambiguous_hunk_without_touching_files(tmp_path: Path) -> None:
+    target = tmp_path / "sample.txt"
+    original = "same\nvalue\nsame\nvalue\n"
+    target.write_text(original, encoding="utf-8")
+    patch = """*** Begin Patch
+*** Update File: sample.txt
+@@
+ same
+-value
++changed
+*** End Patch
+"""
+
+    with pytest.raises(ValueError, match="multiple locations"):
+        normalize_patch_text(patch, str(tmp_path))
+
+    assert target.read_text(encoding="utf-8") == original
+
+
+def test_envelope_validates_all_actions_before_application(tmp_path: Path) -> None:
+    first = tmp_path / "first.txt"
+    second = tmp_path / "second.txt"
+    first.write_text("old\n", encoding="utf-8")
+    second.write_text("actual\n", encoding="utf-8")
+    patch = """*** Begin Patch
+*** Update File: first.txt
+@@
+-old
++new
+*** Update File: second.txt
+@@
+-missing
++replacement
+*** End Patch
+"""
+
+    with pytest.raises(ValueError, match="does not match second.txt"):
+        normalize_patch_text(patch, str(tmp_path))
+
+    assert first.read_text(encoding="utf-8") == "old\n"
+    assert second.read_text(encoding="utf-8") == "actual\n"
+
+
+def test_envelope_preserves_executable_mode_on_delete(tmp_path: Path) -> None:
+    target = tmp_path / "script.sh"
+    target.write_text("#!/bin/sh\n", encoding="utf-8")
+    target.chmod(0o755)
+    patch = """*** Begin Patch
+*** Delete File: script.sh
+*** End Patch
+"""
+
+    normalized = normalize_patch_text(patch, str(tmp_path))
+    assert "deleted file mode 100755" in normalized
+    _git_apply(tmp_path, normalized)
+
+    assert not target.exists()
+
+
+def test_envelope_updates_file_without_trailing_newline(tmp_path: Path) -> None:
+    target = tmp_path / "sample.txt"
+    target.write_bytes(b"old")
+    patch = """*** Begin Patch
+*** Update File: sample.txt
+@@
+-old
++new
+*** End Patch
+"""
+
+    normalized = normalize_patch_text(patch, str(tmp_path))
+    assert "\\ No newline at end of file" in normalized
+    _git_apply(tmp_path, normalized)
+
+    assert target.read_bytes() == b"new"
+
+
+def test_envelope_accepts_absolute_path_inside_cwd(tmp_path: Path) -> None:
+    target = tmp_path / "sample.txt"
+    target.write_text("old\n", encoding="utf-8")
+    patch = f"""*** Begin Patch
+*** Update File: {target}
+@@
+-old
++new
+*** End Patch
+"""
+
+    _git_apply(tmp_path, normalize_patch_text(patch, str(tmp_path)))
+
+    assert target.read_text(encoding="utf-8") == "new\n"
+
+
+def test_envelope_rejects_paths_outside_cwd(tmp_path: Path) -> None:
+    patch = """*** Begin Patch
+*** Add File: ../escape.txt
++bad
+*** End Patch
+"""
+
+    with pytest.raises(ValueError, match="stay within cwd"):
+        normalize_patch_text(patch, str(tmp_path))


### PR DESCRIPTION
## Summary

- accept `*** Begin Patch` envelopes in `apply_patch` while preserving standard unified diff behavior
- support add, update, and delete actions with multi-hunk matching, safe absolute paths inside `cwd`, and no-final-newline handling
- normalize locally and on remote workers before the existing atomic `git apply --check && git apply` flow
- reject ambiguous hunks, path traversal, malformed envelopes, and unsupported moves with explicit errors

## Validation

- [x] `ruff check .`
- [x] `PYTHONPATH=src pytest -q` (505 passed)
- [x] `mkdocs build --strict`
- [ ] VS Code extension compile if extension files changed (not applicable)

## Safety checklist

- [x] No secrets, tunnel tokens, OAuth pins, private keys, or bearer file-link URLs are committed.
- [x] New or changed MCP tools are documented and tested.
- [x] Host-control, remote-worker, file-link, or credential behavior is explicitly described. Remote workers use the same normalizer as local calls.
- [x] Backwards compatibility impact is noted: standard unified diffs remain unchanged; envelope input is additive.