### PR TITLE
Render view_image results in TUI audit

### DIFF
--- a/src/local_shell_mcp/human_ui.py
+++ b/src/local_shell_mcp/human_ui.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import binascii
 import contextlib
 import json
 import logging
@@ -36,7 +37,7 @@ from .fs_ops import (
     resolve_path,
     write_text,
 )
-from .image_ops import make_image_preview
+from .image_ops import ImageFile, assert_view_image_size, detect_image_type, make_image_preview
 from .jobs import list_jobs
 from .oauth import ALL_OAUTH_SCOPES
 from .remote import remote_manager
@@ -361,6 +362,81 @@ def _audit_detail_scopes(entry: dict[str, Any]) -> tuple[str, ...]:
     if operation == "other":
         required.update(UI_FULL_SCOPES)
     return tuple(scope for scope in UI_FULL_SCOPES if scope in required)
+
+
+def _audit_view_image_detail(
+    entry: dict[str, Any],
+    *,
+    columns: int,
+    rows: int,
+    cell_aspect: float,
+) -> dict[str, Any]:
+    if str(entry.get("tool") or "") != "view_image":
+        return entry
+    output = entry.get("output")
+    if not isinstance(output, dict):
+        return entry
+    content = output.get("content")
+    if not isinstance(content, list):
+        return entry
+
+    image_index = next(
+        (
+            index
+            for index, item in enumerate(content)
+            if isinstance(item, dict)
+            and item.get("type") == "image"
+            and isinstance(item.get("data"), str)
+        ),
+        None,
+    )
+    if image_index is None:
+        return entry
+
+    source_item = content[image_index]
+    assert isinstance(source_item, dict)
+    sanitized_item = {name: value for name, value in source_item.items() if name != "data"}
+    sanitized_content = list(content)
+    sanitized_content[image_index] = sanitized_item
+    detail = {**entry, "output": {**output, "content": sanitized_content}}
+
+    try:
+        raw = base64.b64decode(str(source_item["data"]), validate=True)
+        assert_view_image_size(len(raw))
+        image_format, mime_type = detect_image_type(raw[:16])
+        structured = output.get("structuredContent")
+        if not isinstance(structured, dict):
+            structured = output.get("structured_content")
+        path = (
+            str(structured.get("path") or "image result")
+            if isinstance(structured, dict)
+            else "image result"
+        )
+        image = ImageFile(
+            path=path,
+            data=raw,
+            format=image_format,
+            mime_type=mime_type,
+            size=len(raw),
+        )
+        rendered = make_image_preview(image, columns, rows, cell_aspect)
+        sanitized_item["bytes"] = image.size
+        detail["image_preview"] = {
+            "kind": "image",
+            "path": path,
+            "bytes": image.size,
+            "mime_type": image.mime_type,
+            "rgba": base64.b64encode(rendered.rgba).decode("ascii"),
+            "width": rendered.width,
+            "height": rendered.height,
+            "cell_width": rendered.cell_width,
+            "cell_height": rendered.cell_height,
+            "original_width": rendered.original_width,
+            "original_height": rendered.original_height,
+        }
+    except (ValueError, OSError, binascii.Error) as exc:
+        detail["image_preview_error"] = str(exc)
+    return detail
 
 
 def _bounded_int(
@@ -1125,7 +1201,37 @@ async def api_audit_detail(request: Request) -> Response:
         entry_id = str(request.query_params.get("id") or "")
         preview = await asyncio.to_thread(get_audit_entry, entry_id, full=False)
         _require_ui_scopes(request, *_audit_detail_scopes(preview))
-        return _json_ok(await asyncio.to_thread(get_audit_entry, entry_id))
+        detail = await asyncio.to_thread(get_audit_entry, entry_id)
+        columns = _bounded_int(
+            request.query_params.get("columns"),
+            default=96,
+            minimum=8,
+            maximum=200,
+            label="columns",
+        )
+        rows = _bounded_int(
+            request.query_params.get("rows"),
+            default=32,
+            minimum=4,
+            maximum=100,
+            label="rows",
+        )
+        cell_aspect = _bounded_float(
+            request.query_params.get("cell_aspect"),
+            default=2.0,
+            minimum=0.5,
+            maximum=5.0,
+            label="cell_aspect",
+        )
+        return _json_ok(
+            await asyncio.to_thread(
+                _audit_view_image_detail,
+                detail,
+                columns=columns,
+                rows=rows,
+                cell_aspect=cell_aspect,
+            )
+        )
     except ValueError as exc:
         return _json_error(exc, status_code=404)
     except Exception as exc:

--- a/tests/test_human_ui_complete.py
+++ b/tests/test_human_ui_complete.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import os
 import signal
@@ -140,6 +141,87 @@ def test_audit_detail_requires_scopes_before_materializing_payloads(tmp_path, mo
     assert set(ui._audit_detail_scopes({"operation": "other", "node": "worker"})) == set(
         ui.UI_FULL_SCOPES
     )
+
+
+def test_audit_detail_renders_view_image_without_returning_raw_data(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    encoded = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+    )
+    preview = {
+        "id": "call:image",
+        "tool": "view_image",
+        "operation": "files",
+        "node": "local",
+    }
+    detail = {
+        **preview,
+        "output": {
+            "content": [
+                {"type": "image", "data": encoded, "mimeType": "image/png"},
+                {"type": "text", "text": "pixel.png (image/png, 68 bytes)"},
+            ],
+            "structuredContent": {
+                "ok": True,
+                "path": "pixel.png",
+                "mime_type": "image/png",
+                "bytes": len(base64.b64decode(encoded)),
+            },
+            "isError": False,
+        },
+    }
+
+    def fake_get_audit_entry(entry_id: str, *, full: bool = True):
+        assert entry_id == "call:image"
+        return dict(detail if full else preview)
+
+    monkeypatch.setattr(ui, "get_audit_entry", fake_get_audit_entry)
+    request = _request(
+        "/api/ui/audit/detail",
+        query=b"id=call%3Aimage&columns=20&rows=10&cell_aspect=2",
+    )
+    request.state.principal = Principal(
+        email=None,
+        subject="reader",
+        claims={"scope": "shell:read"},
+    )
+
+    response = asyncio.run(ui.api_audit_detail(request))
+    payload = json.loads(response.body)["data"]
+
+    assert response.status_code == 200
+    assert payload["image_preview"]["kind"] == "image"
+    assert payload["image_preview"]["path"] == "pixel.png"
+    assert base64.b64decode(payload["image_preview"]["rgba"])
+    assert "data" not in payload["output"]["content"][0]
+    assert payload["output"]["content"][0]["bytes"] == len(base64.b64decode(encoded))
+    assert encoded not in response.body.decode()
+
+
+def test_audit_view_image_detail_keeps_non_images_and_sanitizes_invalid_data():
+    ordinary = {"tool": "read_file", "output": {"content": []}}
+    assert ui._audit_view_image_detail(ordinary, columns=20, rows=10, cell_aspect=2) is ordinary
+
+    for incomplete in (
+        {"tool": "view_image"},
+        {"tool": "view_image", "output": "invalid"},
+        {"tool": "view_image", "output": {"content": "invalid"}},
+        {"tool": "view_image", "output": {"content": [{"type": "text", "text": "none"}]}},
+    ):
+        assert ui._audit_view_image_detail(incomplete, columns=20, rows=10, cell_aspect=2) is incomplete
+
+    invalid = {
+        "tool": "view_image",
+        "output": {
+            "content": [{"type": "image", "data": "not-base64", "mimeType": "image/png"}],
+            "structured_content": {"path": "broken.png"},
+        },
+    }
+    result = ui._audit_view_image_detail(invalid, columns=20, rows=10, cell_aspect=2)
+
+    assert "data" not in result["output"]["content"][0]
+    assert result["image_preview_error"]
+    assert "image_preview" not in result
 
 
 def test_index_assets_principal_and_basic_helpers(tmp_path, monkeypatch):

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -122,8 +122,14 @@ export const api = {
   audit(filters: Record<string, string | number | boolean | null | undefined>, signal?: AbortSignal): Promise<AuditPayload> {
     return request(`/audit${queryString(filters)}`, { signal })
   },
-  auditDetail(id: string, signal?: AbortSignal): Promise<AuditEntry> {
-    return request(`/audit/detail${queryString({ id })}`, { signal })
+  auditDetail(
+    id: string,
+    columns?: number,
+    rows?: number,
+    cellAspect?: number,
+    signal?: AbortSignal,
+  ): Promise<AuditEntry> {
+    return request(`/audit/detail${queryString({ id, columns, rows, cell_aspect: cellAspect })}`, { signal })
   },
   remotes(signal?: AbortSignal): Promise<MachinePayload> {
     return request("/remotes", { signal })

--- a/ui/src/audit-screen.tsx
+++ b/ui/src/audit-screen.tsx
@@ -12,13 +12,16 @@ import {
   selectionAfterRefresh,
 } from "./audit-utils"
 import { EmptyState, KeyHint, Loading, Modal, Panel, useVisibleRows } from "./components"
+import { ImagePreviewView } from "./image-preview-view"
 import { handleSelectionScroll } from "./mouse"
 import { clampIndex } from "./state-utils"
 import { HighlightedText } from "./syntax-highlight"
+import { parseTerminalCellAspect } from "./terminal-geometry"
 import { screenTheme, theme } from "./theme"
 import type { AuditEntry, Machine } from "./types"
 
 const colors = screenTheme.Audit
+const terminalCellAspect = parseTerminalCellAspect(process.env.LOCAL_SHELL_MCP_UI_CELL_ASPECT)
 
 type AuditDialog = { type: "none" } | { type: "search" } | { type: "event" } | { type: "session" }
 
@@ -101,6 +104,14 @@ export function AuditScreen({
     ? Math.max(6, height - 15)
     : auditStackedVisibleRows(height, stackedDetailHeight, hasFilterSummary)
   const { rows, start } = useVisibleRows(entries, selected, tableHeight)
+  const previewColumns = Math.max(
+    8,
+    Math.min(200, horizontal ? width - listLayout.paneWidth - 8 : width - 8),
+  )
+  const previewRows = Math.max(
+    4,
+    Math.min(100, Math.floor((horizontal ? height - 12 : stackedDetailHeight - 8) / 2)),
+  )
 
   const selectIndex = useCallback((next: number | ((value: number) => number)) => {
     const resolved = typeof next === "function" ? next(selectedRef.current) : next
@@ -179,7 +190,7 @@ export function AuditScreen({
     setDetail(null)
     if (!current?.id) return () => controller.abort()
     void api
-      .auditDetail(current.id, controller.signal)
+      .auditDetail(current.id, previewColumns, previewRows, terminalCellAspect, controller.signal)
       .then((entry) => {
         if (requestId === detailRequest.current && !controller.signal.aborted) setDetail(entry)
       })
@@ -193,7 +204,7 @@ export function AuditScreen({
       controller.abort()
       if (detailController.current === controller) detailController.current = null
     }
-  }, [current?.id, current?.paired, current?.status, setStatus])
+  }, [current?.id, current?.paired, current?.status, previewColumns, previewRows, setStatus])
 
   useEffect(() => {
     onInteractionLockChange(dialog.type !== "none")
@@ -353,9 +364,16 @@ export function AuditScreen({
                 content={`${new Date(displayed.ts * 1000).toLocaleString()} · ${displayed.node}${duration ? ` · ${duration}` : ""}`}
               />
               <Panel title="Call result" style={{ flexGrow: 1, padding: 1 }}>
-                <scrollbox focused={false} style={{ flexGrow: 1 }} scrollY verticalScrollbarOptions={{ visible: true }}>
-                  <HighlightedText content={outputText} baseColor={theme.muted} />
-                </scrollbox>
+                {displayed.image_preview?.kind === "image" ? (
+                  <ImagePreviewView
+                    preview={displayed.image_preview}
+                    title={String(displayed.image_preview.path || "Image result")}
+                  />
+                ) : (
+                  <scrollbox focused={false} style={{ flexGrow: 1 }} scrollY verticalScrollbarOptions={{ visible: true }}>
+                    <HighlightedText content={outputText} baseColor={theme.muted} />
+                  </scrollbox>
+                )}
               </Panel>
               <Panel title="Call input" style={{ flexGrow: 1, padding: 1 }}>
                 <scrollbox focused={false} style={{ flexGrow: 1 }} scrollY verticalScrollbarOptions={{ visible: true }}>

--- a/ui/src/files-screen.tsx
+++ b/ui/src/files-screen.tsx
@@ -1,4 +1,4 @@
-import type { OptimizedBuffer, Renderable, TextareaRenderable } from "@opentui/core"
+import type { Renderable, TextareaRenderable } from "@opentui/core"
 import { useKeyboard } from "@opentui/react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { api, formatError } from "./api"
@@ -13,7 +13,7 @@ import { calculateFilesLayout } from "./files-layout"
 import { handleSelectionScroll } from "./mouse"
 import { clampIndex, nextPreviewMeasurement, payloadMatches } from "./state-utils"
 import { HighlightedText } from "./syntax-highlight"
-import { drawClippedSuperSampleBuffer } from "./image-preview"
+import { ImagePreviewView } from "./image-preview-view"
 import { parseTerminalCellAspect } from "./terminal-geometry"
 import { screenTheme, theme } from "./theme"
 import type { FileEntry, FilePreview, FilesPayload, Machine } from "./types"
@@ -111,39 +111,6 @@ function FileRows({
   )
 }
 
-function ImagePreview({ preview, entry }: { preview: FilePreview; entry: FileEntry }) {
-  const pixelWidth = Number(preview.width || 0)
-  const pixelHeight = Number(preview.height || 0)
-  const cellWidth = Number(preview.cell_width || pixelWidth * 2)
-  const cellHeight = Number(preview.cell_height || Math.ceil(pixelHeight / 2))
-  let pixels: Uint8Array
-  try {
-    pixels = Uint8Array.from(Buffer.from(String(preview.rgba || ""), "base64"))
-  } catch {
-    return <EmptyState title={entry.name} detail="Invalid image preview data" />
-  }
-  if (!pixelWidth || !pixelHeight || pixels.byteLength !== pixelWidth * pixelHeight * 4) {
-    return <EmptyState title={entry.name} detail="Invalid image preview dimensions" />
-  }
-  const sourceWidth = Number(preview.original_width || pixelWidth)
-  const sourceHeight = Number(preview.original_height || pixelHeight)
-  const drawPixels = function (this: Renderable, buffer: OptimizedBuffer) {
-    drawClippedSuperSampleBuffer(buffer, this, pixels, pixelWidth)
-  }
-  return (
-    <box style={{ flexGrow: 1, flexDirection: "column", alignItems: "center", justifyContent: "center" }}>
-      <box
-        style={{ width: cellWidth, height: cellHeight, flexShrink: 0 }}
-        renderAfter={drawPixels}
-      />
-      <text
-        fg={theme.faint}
-        content={`${sourceWidth}×${sourceHeight} · ${formatBytes(Number(preview.bytes || entry.size || 0))}`}
-      />
-    </box>
-  )
-}
-
 function Preview({
   preview,
   entry,
@@ -190,7 +157,7 @@ function Preview({
           ))}
         </scrollbox>
       ) : preview.kind === "image" ? (
-        <ImagePreview preview={preview} entry={entry} />
+        <ImagePreviewView preview={preview} title={entry.name} fallbackBytes={Number(entry.size || 0)} />
       ) : (
         <scrollbox
           focused={false}

--- a/ui/src/image-preview-view.tsx
+++ b/ui/src/image-preview-view.tsx
@@ -1,0 +1,48 @@
+import type { OptimizedBuffer, Renderable } from "@opentui/core"
+import { EmptyState, formatBytes } from "./components"
+import { drawClippedSuperSampleBuffer } from "./image-preview"
+import { theme } from "./theme"
+import type { FilePreview } from "./types"
+
+export function ImagePreviewView({
+  preview,
+  title,
+  fallbackBytes = 0,
+}: {
+  preview: FilePreview
+  title: string
+  fallbackBytes?: number
+}) {
+  const pixelWidth = Number(preview.width || 0)
+  const pixelHeight = Number(preview.height || 0)
+  const cellWidth = Number(preview.cell_width || pixelWidth * 2)
+  const cellHeight = Number(preview.cell_height || Math.ceil(pixelHeight / 2))
+  let pixels: Uint8Array
+  try {
+    pixels = Uint8Array.from(Buffer.from(String(preview.rgba || ""), "base64"))
+  } catch {
+    return <EmptyState title={title} detail="Invalid image preview data" />
+  }
+  if (!pixelWidth || !pixelHeight || pixels.byteLength !== pixelWidth * pixelHeight * 4) {
+    return <EmptyState title={title} detail="Invalid image preview dimensions" />
+  }
+
+  const sourceWidth = Number(preview.original_width || pixelWidth)
+  const sourceHeight = Number(preview.original_height || pixelHeight)
+  const drawPixels = function (this: Renderable, buffer: OptimizedBuffer) {
+    drawClippedSuperSampleBuffer(buffer, this, pixels, pixelWidth)
+  }
+
+  return (
+    <box style={{ flexGrow: 1, flexDirection: "column", alignItems: "center", justifyContent: "center" }}>
+      <box
+        style={{ width: cellWidth, height: cellHeight, flexShrink: 0 }}
+        renderAfter={drawPixels}
+      />
+      <text
+        fg={theme.faint}
+        content={`${sourceWidth}×${sourceHeight} · ${formatBytes(Number(preview.bytes || fallbackBytes))}`}
+      />
+    </box>
+  )
+}

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -47,6 +47,7 @@ export interface FilePreview {
   original_height?: number
   entries?: FileEntry[]
   size?: number
+  bytes?: number
   path?: string
   truncated?: boolean
   sha256?: string | null
@@ -99,6 +100,8 @@ export interface AuditEntry {
   arguments?: unknown
   error?: string
   error_type?: string
+  image_preview?: FilePreview
+  image_preview_error?: string
   [key: string]: unknown
 }
 


### PR DESCRIPTION
## Summary
- render `view_image` call results as native image previews in the TUI Audit screen
- remove the raw base64 `data` field from Audit detail responses
- reuse the Files image renderer and size previews to the Call result panel
- retain compact metadata/text fallback for invalid image payloads

## Validation
- `ruff check .`
- `python -m pytest -q` — 522 passed
- `bun test` — 143 passed
- `bun run typecheck`
- `bun run build`
- `bash scripts/run-coverage.sh` — 94.36% combined coverage, all modules >= 90%
- PTY and browser Human UI smoke tests
- real audit payload reduced from ~719 KB to ~14 KB (98.04%)
