### PR TITLE
fix(ui): keep dashboard alert rows aligned

### DIFF
--- a/ui/src/dashboard-screen.test.tsx
+++ b/ui/src/dashboard-screen.test.tsx
@@ -53,4 +53,46 @@ describe("Dashboard alerts", () => {
     expect(lines).toContainEqual(expect.stringContaining("WARN  1 recent MCP call failure(s)"))
     expect(lines).toContainEqual(expect.stringContaining("Open Audit for call inputs and returned errors"))
   })
+
+  test("does not let a long detail hide its title row", async () => {
+    const alerts: DashboardAlert[] = [
+      {
+        severity: "warning",
+        title: "Job package-wait active",
+        detail: "while pgrep -x apt-get >/dev/null || pgrep -x dpkg >/dev/null; do sleep 5; done",
+      },
+      {
+        severity: "warning",
+        title: "Job release-v3.0.8-watch lost",
+        detail: "job session exited without a completion record · 12h 8m",
+      },
+      {
+        severity: "warning",
+        title: "Job release-v3.0.8 lost",
+        detail: "job session exited without a completion record · 14h 20m",
+      },
+      {
+        severity: "warning",
+        title: "18 recent MCP call failure(s)",
+        detail: "Open Audit for call inputs and returned errors",
+      },
+    ]
+    const setup = await testRender(<Alerts alerts={alerts} width={58} rows={4} />, {
+      width: 58,
+      height: 14,
+    })
+    renderers.push(setup.renderer)
+
+    const reactTestGlobal = globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    reactTestGlobal.IS_REACT_ACT_ENVIRONMENT = false
+    await setup.renderOnce()
+    const lines = setup.captureCharFrame().split("\n")
+
+    expect(lines).toContainEqual(expect.stringContaining("WARN  Job package-wait active"))
+    expect(lines).toContainEqual(expect.stringContaining("while pgrep -x apt-get"))
+    expect(lines.filter((line) => line.includes("while pgrep -x apt-get"))).toHaveLength(1)
+    expect(lines).toContainEqual(expect.stringContaining("WARN  Job release-v3.0.8-watch lost"))
+    expect(lines).toContainEqual(expect.stringContaining("WARN  Job release-v3.0.8 lost"))
+    expect(lines).toContainEqual(expect.stringContaining("WARN  18 recent MCP call failure(s)"))
+  })
 })

--- a/ui/src/dashboard-screen.tsx
+++ b/ui/src/dashboard-screen.tsx
@@ -268,10 +268,14 @@ export function Alerts({ alerts, width, rows }: { alerts: DashboardAlert[]; widt
           >
             <box style={{ flexDirection: "row" }}>
               <text fg={severityColor(alert.severity)} attributes={1} content={`${alert.severity.toUpperCase().slice(0, 4).padEnd(5)} `} />
-              <text fg={theme.text} content={truncate(alert.title, Math.max(10, width - 11))} />
+              <text fg={theme.text} wrapMode="none" content={truncate(alert.title, Math.max(10, width - 11))} />
             </box>
             {width >= 34 && (
-              <text fg={theme.faint} content={truncate(`${alert.detail || ""}${alert.age_s ? ` · ${formatDuration(alert.age_s)}` : ""}`, Math.max(10, width - 3))} />
+              <text
+                fg={theme.faint}
+                wrapMode="none"
+                content={truncate(`${alert.detail || ""}${alert.age_s ? ` · ${formatDuration(alert.age_s)}` : ""}`, Math.max(10, width - 5))}
+              />
             )}
           </box>
         ))


### PR DESCRIPTION
## Summary
- prevent long alert titles/details from wrapping into neighboring rows
- reserve the actual inner panel width when truncating alert details
- add a regression test matching the reported package-wait command layout

## Validation
- `bun run typecheck`
- `bun test` (89 passed)
- `bun run build`