### PR TITLE
Fix UTF-8 boundary binary detection

### DIFF
--- a/src/local_shell_mcp/fs_ops.py
+++ b/src/local_shell_mcp/fs_ops.py
@@ -316,15 +316,25 @@ def glob_paths(pattern: str, cwd: str = ".", max_results: int = 500) -> list[str
     return results
 
 
-def _is_probably_binary(sample: bytes) -> bool:
+def _is_probably_binary(sample: bytes, *, continuation: bytes = b"") -> bool:
     if not sample:
         return False
     if b"\x00" in sample:
         return True
     try:
         sample.decode("utf-8")
-    except UnicodeDecodeError:
-        return True
+    except UnicodeDecodeError as exc:
+        if exc.reason != "unexpected end of data" or exc.end != len(sample):
+            return True
+
+        lead = sample[exc.start]
+        width = 2 if lead < 0xE0 else 3 if lead < 0xF0 else 4
+        missing = width - (len(sample) - exc.start)
+        sequence = sample[exc.start:] + continuation[:missing]
+        try:
+            sequence.decode("utf-8")
+        except UnicodeDecodeError:
+            return True
 
     control_bytes = 0
     for byte in sample:
@@ -362,8 +372,10 @@ def _binary_metadata(p: Path, size: int, preview: str | None = None, preview_byt
 
 def _assert_text_file(p: Path) -> None:
     with p.open("rb") as fh:
-        sample = fh.read(BINARY_CHECK_BYTES)
-    if _is_probably_binary(sample):
+        probe = fh.read(BINARY_CHECK_BYTES + 3)
+    sample = probe[:BINARY_CHECK_BYTES]
+    continuation = probe[BINARY_CHECK_BYTES:]
+    if _is_probably_binary(sample, continuation=continuation):
         raise ValueError(BINARY_MESSAGE)
 
 
@@ -378,8 +390,10 @@ def read_text(
     p = resolve_path(path, must_exist=True)
     size = p.stat().st_size
     with p.open("rb") as fh:
-        sample = fh.read(BINARY_CHECK_BYTES)
-        if _is_probably_binary(sample):
+        probe = fh.read(BINARY_CHECK_BYTES + 3)
+        sample = probe[:BINARY_CHECK_BYTES]
+        continuation = probe[BINARY_CHECK_BYTES:]
+        if _is_probably_binary(sample, continuation=continuation):
             return _binary_metadata(p, size, binary_preview, binary_preview_bytes)
         fh.seek(0)
         data = fh.read(settings.max_file_read_bytes + 1)

--- a/tests/test_fs_ops.py
+++ b/tests/test_fs_ops.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 from local_shell_mcp.fs_ops import (
+    BINARY_CHECK_BYTES,
     FileConflictError,
     delete_path,
     edit_text,
@@ -275,6 +276,31 @@ def test_read_text_handles_truncated_utf8_sequence(tmp_path, monkeypatch):
     assert result["truncated"] is True
     assert result["bytes_read"] == 4
     assert result["content"] == "你�"
+
+
+def test_read_text_allows_utf8_character_split_at_binary_sample_boundary(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    get_settings.cache_clear()
+    content = "a" * (BINARY_CHECK_BYTES - 1) + "模型"
+    (tmp_path / "utf8-boundary.txt").write_text(content, encoding="utf-8")
+
+    result = read_text("utf8-boundary.txt")
+
+    assert result["binary"] is False
+    assert result["content"] == content
+
+
+def test_read_text_rejects_invalid_utf8_after_binary_sample_boundary(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    get_settings.cache_clear()
+    payload = b"a" * (BINARY_CHECK_BYTES - 1) + b"\xe6x"
+    (tmp_path / "invalid-boundary.bin").write_bytes(payload)
+
+    result = read_text("invalid-boundary.bin")
+
+    assert result["binary"] is True
 
 
 def test_path_lock_state_and_lock_files_are_bounded(tmp_path, monkeypatch):

--- a/tests/test_storage_complete.py
+++ b/tests/test_storage_complete.py
@@ -60,6 +60,9 @@ def test_filesystem_binary_glob_context_and_limits(tmp_path, monkeypatch):
     assert fs._is_probably_binary(b"") is False
     assert fs._is_probably_binary(b"a\x00b") is True
     assert fs._is_probably_binary(b"\xff") is True
+    assert fs._is_probably_binary(b"plain\xe6") is True
+    assert fs._is_probably_binary(b"plain\xe6", continuation=b"\xa8\xa1") is False
+    assert fs._is_probably_binary(b"plain\xe6", continuation=b"x") is True
     assert fs._is_probably_binary(bytes([1, 2, 3, 65])) is True
     assert fs._is_probably_binary(b"plain\ntext") is False
 


### PR DESCRIPTION
## Summary
- avoid classifying UTF-8 text as binary when the 8192-byte probe splits a multibyte character
- validate the following bytes so genuinely malformed UTF-8 remains binary
- add regression coverage for both valid and invalid boundary cases

## Validation
- `ruff check .`
- `PYTHONPATH=src pytest -q` (524 passed)
- verified against historical `Section2.tex` from commit `b7252b3`