### PR TITLE
fix: make apply_patch context handling reliable

### DIFF
--- a/src/local_shell_mcp/patch_ops.py
+++ b/src/local_shell_mcp/patch_ops.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import difflib
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 
@@ -26,6 +27,34 @@ class _FileState:
     original: str | None
     current: str | None
     mode: str
+
+
+def git_apply_prefix(git_bin: str, cwd: str) -> str | None:
+    try:
+        result = subprocess.run(
+            [git_bin, "rev-parse", "--show-prefix"],
+            cwd=Path(cwd).resolve(),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    prefix = result.stdout.rstrip("\r\n")
+    return prefix.removesuffix("/") or None
+
+
+def git_apply_command(
+    quoted_git: str,
+    quoted_patch: str,
+    quoted_prefix: str | None = None,
+) -> str:
+    directory = f" --directory={quoted_prefix}" if quoted_prefix else ""
+    check = f"{quoted_git} apply --check{directory} {quoted_patch}"
+    apply = f"{quoted_git} apply{directory} {quoted_patch}"
+    return f"{check} && {apply}"
 
 
 def normalize_patch_text(patch: str, cwd: str = ".") -> str:
@@ -199,12 +228,11 @@ def _apply_update(action: _PatchAction, text: str) -> str:
     trailing_newline = text.endswith(("\n", "\r"))
     lines = text.splitlines()
     cursor = 0
+    changed = False
 
     for hunk_number, (hunk, must_end_at_eof) in enumerate(hunks, start=1):
         old_lines = [line[1:] for line in hunk if not line.startswith("+")]
         new_lines = [line[1:] for line in hunk if not line.startswith("-")]
-        if old_lines == new_lines:
-            raise ValueError(f"hunk {hunk_number} for {action.path} contains no changes")
 
         if old_lines:
             matches = [
@@ -226,8 +254,17 @@ def _apply_update(action: _PatchAction, text: str) -> str:
 
         if must_end_at_eof and start + len(old_lines) != len(lines):
             raise ValueError(f"hunk {hunk_number} does not match the end of {action.path}")
+
+        if old_lines == new_lines:
+            cursor = start + len(old_lines)
+            continue
+
         lines[start : start + len(old_lines)] = new_lines
         cursor = start + len(new_lines)
+        changed = True
+
+    if not changed:
+        raise ValueError(f"update action for {action.path} contains no changes")
 
     return newline.join(lines) + (newline if trailing_newline and lines else "")
 

--- a/src/local_shell_mcp/patch_ops.py
+++ b/src/local_shell_mcp/patch_ops.py
@@ -50,11 +50,12 @@ def git_apply_command(
     quoted_git: str,
     quoted_patch: str,
     quoted_prefix: str | None = None,
+    *,
+    check: bool = False,
 ) -> str:
+    check_flag = " --check" if check else ""
     directory = f" --directory={quoted_prefix}" if quoted_prefix else ""
-    check = f"{quoted_git} apply --check{directory} {quoted_patch}"
-    apply = f"{quoted_git} apply{directory} {quoted_patch}"
-    return f"{check} && {apply}"
+    return f"{quoted_git} apply{check_flag}{directory} {quoted_patch}"
 
 
 def normalize_patch_text(patch: str, cwd: str = ".") -> str:

--- a/src/local_shell_mcp/patch_ops.py
+++ b/src/local_shell_mcp/patch_ops.py
@@ -54,7 +54,7 @@ def git_apply_command(
     check: bool = False,
 ) -> str:
     check_flag = " --check" if check else ""
-    directory = f" --directory={quoted_prefix}" if quoted_prefix else ""
+    directory = f" --directory {quoted_prefix}" if quoted_prefix else ""
     return f"{quoted_git} apply{check_flag}{directory} {quoted_patch}"
 
 

--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -54,6 +54,7 @@ from .shell_ops import (
     public_run_shell,
     public_run_shell_timeout,
     quote_shell_argument,
+    quote_shell_executable,
     read_shell,
     resize_shell,
     run_shell,
@@ -910,7 +911,7 @@ async def _apply_patch_text(patch: str, cwd: str = ".") -> dict[str, Any]:
     patch_path.parent.mkdir(parents=True, exist_ok=True)
     await asyncio.to_thread(patch_path.write_bytes, normalized_patch.encode("utf-8"))
     git_bin = get_settings().git_bin
-    git = quote_shell_argument(git_bin)
+    git = quote_shell_executable(git_bin)
     quoted_patch = quote_shell_argument(str(patch_path))
     prefix = await asyncio.to_thread(git_apply_prefix, git_bin, cwd)
     quoted_prefix = quote_shell_argument(prefix) if prefix else None

--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -42,7 +42,7 @@ from .fs_ops import (
 )
 from .jobs import list_jobs, retry_job, start_job, stop_job, tail_job
 from .models import ok_result as _ok
-from .patch_ops import normalize_patch_text
+from .patch_ops import git_apply_command, git_apply_prefix, normalize_patch_text
 from .playwright_ops import browser_capture, browser_get_text, playwright_run_script
 from .search_ops import grep, tree
 from .settings import get_settings, safe_settings_dump
@@ -909,11 +909,13 @@ async def _apply_patch_text(patch: str, cwd: str = ".") -> dict[str, Any]:
     patch_path = temp_dir() / f"remote-patch-{uuid.uuid4().hex}.diff"
     patch_path.parent.mkdir(parents=True, exist_ok=True)
     await asyncio.to_thread(patch_path.write_bytes, normalized_patch.encode("utf-8"))
+    git_bin = get_settings().git_bin
+    git = quote_shell_argument(git_bin)
+    quoted_patch = quote_shell_argument(str(patch_path))
+    prefix = await asyncio.to_thread(git_apply_prefix, git_bin, cwd)
+    quoted_prefix = quote_shell_argument(prefix) if prefix else None
     result = await run_shell(
-        f"{quote_shell_argument(get_settings().git_bin)} apply --check "
-        f"{quote_shell_argument(str(patch_path))} && "
-        f"{quote_shell_argument(get_settings().git_bin)} apply "
-        f"{quote_shell_argument(str(patch_path))}",
+        git_apply_command(git, quoted_patch, quoted_prefix),
         cwd=cwd,
         timeout_s=60,
         max_output_bytes=500_000,

--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -914,6 +914,15 @@ async def _apply_patch_text(patch: str, cwd: str = ".") -> dict[str, Any]:
     quoted_patch = quote_shell_argument(str(patch_path))
     prefix = await asyncio.to_thread(git_apply_prefix, git_bin, cwd)
     quoted_prefix = quote_shell_argument(prefix) if prefix else None
+    check_result = await run_shell(
+        git_apply_command(git, quoted_patch, quoted_prefix, check=True),
+        cwd=cwd,
+        timeout_s=60,
+        max_output_bytes=500_000,
+    )
+    if check_result.exit_code != 0 or check_result.timed_out:
+        return {**check_result.model_dump(), "patch_path": relative_display(patch_path)}
+
     result = await run_shell(
         git_apply_command(git, quoted_patch, quoted_prefix),
         cwd=cwd,

--- a/src/local_shell_mcp/shell_ops.py
+++ b/src/local_shell_mcp/shell_ops.py
@@ -179,6 +179,15 @@ def quote_shell_argument(value: str) -> str:
     return shlex.quote(value)
 
 
+def quote_shell_executable(value: str) -> str:
+    quoted = quote_shell_argument(value)
+    name = _shell_program_name(get_settings().shell_executable)
+    powershell = "power" + "shell"
+    if name in {powershell + ".exe", powershell, "pwsh.exe", "pwsh"}:
+        return f"& {quoted}"
+    return quoted
+
+
 def _shell_command_args(command: str) -> list[str]:
     return shell_command_args(get_settings().shell_executable, command)
 

--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -163,6 +163,15 @@ async def _apply_patch_text(patch: str, cwd: str = ".") -> dict:
     git = quote_shell_argument(git_bin)
     prefix = await asyncio.to_thread(git_apply_prefix, git_bin, cwd)
     quoted_prefix = quote_shell_argument(prefix) if prefix else None
+    check_result = await run_shell(
+        git_apply_command(git, quoted, quoted_prefix, check=True),
+        cwd=cwd,
+        timeout_s=60,
+        max_output_bytes=500_000,
+    )
+    if check_result.exit_code != 0 or check_result.timed_out:
+        return {**check_result.model_dump(), "patch_path": relative_display(patch_path)}
+
     result = await run_shell(
         git_apply_command(git, quoted, quoted_prefix),
         cwd=cwd,

--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -59,6 +59,7 @@ from .shell_ops import (
     public_run_shell,
     public_run_shell_timeout,
     quote_shell_argument,
+    quote_shell_executable,
     read_shell,
     run_shell,
     send_shell,
@@ -160,7 +161,7 @@ async def _apply_patch_text(patch: str, cwd: str = ".") -> dict:
     await asyncio.to_thread(patch_path.write_bytes, normalized_patch.encode("utf-8"))
     quoted = quote_shell_argument(str(patch_path))
     git_bin = get_settings().git_bin
-    git = quote_shell_argument(git_bin)
+    git = quote_shell_executable(git_bin)
     prefix = await asyncio.to_thread(git_apply_prefix, git_bin, cwd)
     quoted_prefix = quote_shell_argument(prefix) if prefix else None
     check_result = await run_shell(

--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -40,7 +40,7 @@ from .jobs import list_jobs, retry_job, start_job, stop_job, tail_job
 from .models import ToolResult
 from .models import ok_result as _ok
 from .oauth import ALL_OAUTH_SCOPES
-from .patch_ops import normalize_patch_text
+from .patch_ops import git_apply_command, git_apply_prefix, normalize_patch_text
 from .playwright_ops import browser_capture, browser_get_text, playwright_run_script
 from .remote import remote_manager
 from .remote_transfer import (
@@ -159,9 +159,12 @@ async def _apply_patch_text(patch: str, cwd: str = ".") -> dict:
     patch_path.parent.mkdir(parents=True, exist_ok=True)
     await asyncio.to_thread(patch_path.write_bytes, normalized_patch.encode("utf-8"))
     quoted = quote_shell_argument(str(patch_path))
-    git = quote_shell_argument(get_settings().git_bin)
+    git_bin = get_settings().git_bin
+    git = quote_shell_argument(git_bin)
+    prefix = await asyncio.to_thread(git_apply_prefix, git_bin, cwd)
+    quoted_prefix = quote_shell_argument(prefix) if prefix else None
     result = await run_shell(
-        f"{git} apply --check {quoted} && {git} apply {quoted}",
+        git_apply_command(git, quoted, quoted_prefix),
         cwd=cwd,
         timeout_s=60,
         max_output_bytes=500_000,

--- a/tests/test_patch_ops.py
+++ b/tests/test_patch_ops.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from local_shell_mcp.patch_ops import normalize_patch_text
+from local_shell_mcp.patch_ops import git_apply_command, normalize_patch_text
 
 
 def _git_apply(root: Path, patch: str) -> None:
@@ -14,6 +14,13 @@ def _git_apply(root: Path, patch: str) -> None:
     subprocess.run(["git", "init", "-q"], cwd=root, check=True)
     subprocess.run(["git", "apply", "--check", str(patch_path)], cwd=root, check=True)
     subprocess.run(["git", "apply", str(patch_path)], cwd=root, check=True)
+
+
+def test_git_apply_command_keeps_directory_as_separate_argument() -> None:
+    command = git_apply_command("git", "'patch file.diff'", "'nested dir'", check=True)
+
+    assert command == "git apply --check --directory 'nested dir' 'patch file.diff'"
+    assert "--directory=" not in command
 
 
 def test_standard_unified_diff_passes_through() -> None:

--- a/tests/test_patch_ops.py
+++ b/tests/test_patch_ops.py
@@ -68,6 +68,83 @@ def test_envelope_supports_multiple_hunks_and_eof_append(tmp_path: Path) -> None
     assert target.read_text(encoding="utf-8") == "ALPHA\nbeta\ngamma\ndelta\n"
 
 
+def test_envelope_supports_context_only_section_anchors(tmp_path: Path) -> None:
+    target = tmp_path / "sample.py"
+    target.write_text(
+        "from package import (\n"
+        "    Existing,\n"
+        ")\n"
+        "\n"
+        "def helper():\n"
+        "    return 1\n"
+        "\n"
+        "\n"
+        "def test_target():\n"
+        "    result = helper()\n"
+        "    assert result == 1\n",
+        encoding="utf-8",
+    )
+    patch = """*** Begin Patch
+*** Update File: sample.py
+@@
+ from package import (
++    Added,
+     Existing,
+@@
+ def test_target():
+@@
+     assert result == 1
++
++
++def test_added():
++    assert Added is not None
+*** End Patch
+"""
+
+    _git_apply(tmp_path, normalize_patch_text(patch, str(tmp_path)))
+
+    assert target.read_text(encoding="utf-8") == (
+        "from package import (\n"
+        "    Added,\n"
+        "    Existing,\n"
+        ")\n"
+        "\n"
+        "def helper():\n"
+        "    return 1\n"
+        "\n"
+        "\n"
+        "def test_target():\n"
+        "    result = helper()\n"
+        "    assert result == 1\n"
+        "\n"
+        "\n"
+        "def test_added():\n"
+        "    assert Added is not None\n"
+    )
+
+
+def test_envelope_rejects_ambiguous_context_anchor_without_touching_files(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "sample.py"
+    original = "def target():\n    return 1\n\ndef target():\n    return 2\n"
+    target.write_text(original, encoding="utf-8")
+    patch = """*** Begin Patch
+*** Update File: sample.py
+@@
+ def target():
+@@
+-    return 2
++    return 3
+*** End Patch
+"""
+
+    with pytest.raises(ValueError, match="multiple locations"):
+        normalize_patch_text(patch, str(tmp_path))
+
+    assert target.read_text(encoding="utf-8") == original
+
+
 def test_envelope_rejects_ambiguous_hunk_without_touching_files(tmp_path: Path) -> None:
     target = tmp_path / "sample.txt"
     original = "same\nvalue\nsame\nvalue\n"

--- a/tests/test_remote_complete.py
+++ b/tests/test_remote_complete.py
@@ -637,7 +637,7 @@ async def test_worker_apply_patch_honors_nested_cwd_in_git_worktree(
 
     result = await remote._apply_patch_text(patch, str(nested))
 
-    assert result["exit_code"] == 0
+    assert result["exit_code"] == 0, result
     assert target.read_text(encoding="utf-8").endswith("def target():\n    return 2\n")
 
 

--- a/tests/test_remote_complete.py
+++ b/tests/test_remote_complete.py
@@ -612,6 +612,35 @@ def test_worker_upload_protocol_and_generated_execution_edges(tmp_path, monkeypa
     assert remote._handled_remote_exception(ValueError("bad"))["error"] == "ValueError"
 
 
+@pytest.mark.asyncio
+async def test_worker_apply_patch_honors_nested_cwd_in_git_worktree(
+    tmp_path, monkeypatch
+):
+    _configure(tmp_path, monkeypatch)
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    target = nested / "sample.py"
+    target.write_text(
+        "def helper():\n    return 0\n\n\ndef target():\n    return 1\n",
+        encoding="utf-8",
+    )
+    patch = """*** Begin Patch
+*** Update File: sample.py
+@@
+ def target():
+@@
+-    return 1
++    return 2
+*** End Patch
+"""
+
+    result = await remote._apply_patch_text(patch, str(nested))
+
+    assert result["exit_code"] == 0
+    assert target.read_text(encoding="utf-8").endswith("def target():\n    return 2\n")
+
+
 def test_worker_resume_identity_and_curl_post_failures(tmp_path, monkeypatch, capsys):
     _configure(
         tmp_path,

--- a/tests/test_runtime_edge_complete.py
+++ b/tests/test_runtime_edge_complete.py
@@ -303,6 +303,9 @@ def test_shell_buffers_arguments_timeouts_and_reader_helpers(tmp_path, monkeypat
     monkeypatch.setenv("LOCAL_SHELL_MCP_SHELL_EXECUTABLE", "powershell.exe")
     get_settings.cache_clear()
     assert shell.quote_shell_argument("a'b") == "'a''b'"
+    assert shell.quote_shell_executable("C:\\Program Files\\Git\\git.exe") == (
+        "& 'C:\\Program Files\\Git\\git.exe'"
+    )
     monkeypatch.setenv("LOCAL_SHELL_MCP_SHELL_EXECUTABLE", "cmd.exe")
     get_settings.cache_clear()
     assert "a b" in shell.quote_shell_argument("a b")

--- a/tests/test_tools_complete.py
+++ b/tests/test_tools_complete.py
@@ -430,7 +430,7 @@ async def test_apply_patch_honors_nested_cwd_in_git_worktree(tmp_path, monkeypat
 
     result = await tools._apply_patch_text(patch, str(nested))
 
-    assert result["exit_code"] == 0
+    assert result["exit_code"] == 0, result
     assert target.read_text(encoding="utf-8").endswith("def target():\n    return 2\n")
 
 

--- a/tests/test_tools_complete.py
+++ b/tests/test_tools_complete.py
@@ -368,6 +368,46 @@ def test_tool_helpers_audit_serialization_timeout_and_tail(tmp_path, monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_apply_patch_stops_after_failed_preflight(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    target = tmp_path / "sample.py"
+    original = "value = 1\n"
+    target.write_text(original, encoding="utf-8")
+    commands: list[str] = []
+
+    async def fail_check(command, **kwargs):
+        commands.append(command)
+        return CommandResult(
+            ok=False,
+            exit_code=1,
+            timed_out=False,
+            duration_ms=1,
+            cwd=str(tmp_path),
+            command=command,
+            stdout="",
+            stderr="patch does not apply",
+            truncated=False,
+        )
+
+    monkeypatch.setattr(tools, "run_shell", fail_check)
+    patch = """*** Begin Patch
+*** Update File: sample.py
+@@
+-value = 1
++value = 2
+*** End Patch
+"""
+
+    result = await tools._apply_patch_text(patch, str(tmp_path))
+
+    assert result["exit_code"] == 1
+    assert len(commands) == 1
+    assert " apply --check" in commands[0]
+    assert "&&" not in commands[0]
+    assert target.read_text(encoding="utf-8") == original
+
+
+@pytest.mark.asyncio
 async def test_apply_patch_honors_nested_cwd_in_git_worktree(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
     subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)

--- a/tests/test_tools_complete.py
+++ b/tests/test_tools_complete.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import subprocess
 
 import pytest
 
@@ -364,6 +365,33 @@ def test_tool_helpers_audit_serialization_timeout_and_tail(tmp_path, monkeypatch
     assert tail["bytes_read"] > 0
     audit_path.unlink()
     assert tools._read_audit_tail_entries(10) == {"entries": []}
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_honors_nested_cwd_in_git_worktree(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    nested = tmp_path / "nested dir"
+    nested.mkdir()
+    target = nested / "sample.py"
+    target.write_text(
+        "def helper():\n    return 0\n\n\ndef target():\n    return 1\n",
+        encoding="utf-8",
+    )
+    patch = """*** Begin Patch
+*** Update File: sample.py
+@@
+ def target():
+@@
+-    return 1
++    return 2
+*** End Patch
+"""
+
+    result = await tools._apply_patch_text(patch, str(nested))
+
+    assert result["exit_code"] == 0
+    assert target.read_text(encoding="utf-8").endswith("def target():\n    return 2\n")
 
 
 def test_transport_security_secret_helpers_and_remote_unwrap(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- accept context-only `@@` hunks as section anchors while still rejecting ambiguous anchors and true no-op updates
- make local and remote-worker `apply_patch` honor paths relative to a nested `cwd` inside a Git worktree
- execute `git apply --check` and `git apply` separately so Windows PowerShell 5.1 is supported
- invoke quoted executables with PowerShell's call operator
- stop immediately after a failed preflight, without touching target files
- add parser and end-to-end regressions, including nested paths containing spaces

## Real failure replays
- replayed the latest UTF-8 boundary patch envelope that previously failed with `hunk 2 ... contains no changes`
- replayed the earlier dashboard multi-file envelope with the same context-anchor pattern
- both normalize to valid unified diffs and pass `git apply --check`

## Validation
- `ruff check .`
- focused parser and local/remote end-to-end tests: 30 passed
- full suite on latest main: 530 passed
- branch coverage: 94.0% (required: 93%)
- GitHub Actions: all 41 checks passed, including Windows Python 3.11/3.12, Windows endpoints, packaging, standalone, Docker, macOS, Linux, and aarch64
- changed-file secret scan: clean
