### PR TITLE
chore: prepare v3.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "local-shell-mcp"
-version = "3.0.9"
+version = "3.1.0"
 description = "A ChatGPT-compatible OAuth MCP server that gives AI coding agents controlled shell, filesystem, remote-worker, and Playwright access inside a local container."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/local_shell_mcp/__init__.py
+++ b/src/local_shell_mcp/__init__.py
@@ -1,3 +1,3 @@
 """local-shell-mcp."""
 
-__version__ = "3.0.9"
+__version__ = "3.1.0"


### PR DESCRIPTION
## Summary

- bump the Python package version to 3.1.0
- keep the package and runtime version declarations synchronized

## Validation

- `python -m pytest -q` — 530 passed
- `ruff check .`
- `bun run test` — 96 passed
- `bun run typecheck`
- `bun run build`

This PR only prepares the version on `main`; it does not create a tag or publish a release.