### PR TITLE
fix: run remote transfers as resumable jobs

### DIFF
--- a/docs/guides/remote-workers.md
+++ b/docs/guides/remote-workers.md
@@ -12,7 +12,7 @@ MCP client -> control server -> outbound polling worker -> remote machine
 2. Run the generated command on the remote machine.
 3. Confirm registration with `remote_list_machines`.
 4. Call normal tools with `machine="<worker-name>"`, for example `environment_info`, `run_shell_tool`, `read_file`, or `browser_capture_tool`.
-5. Use `transfer_path` for controller-to-worker, worker-to-controller, or worker-to-worker file and directory transfers.
+5. Use `transfer_path` to start a tracked controller-to-worker, worker-to-controller, or worker-to-worker file or directory transfer. Follow it with `job_list` or `job_tail`; stop or retry it with `job_stop` or `job_retry`.
 6. Rename or revoke workers with `remote_rename_machine` and `remote_revoke_machine`.
 
 Only worker administration uses `remote_*` names. Execution, shell, job, filesystem, patch, and browser operations share the same schema locally and remotely. Supplying a machine additionally requires the `remote:use` OAuth scope.

--- a/docs/guides/usage-patterns.md
+++ b/docs/guides/usage-patterns.md
@@ -94,7 +94,7 @@ Good practice:
 
 - Name machines clearly with `remote_invite` or `remote_rename_machine`.
 - Call `environment_info(machine=...)` before acting.
-- Use `transfer_path` for all controller/worker and worker/worker file or directory transfers.
+- Use `transfer_path` to start tracked controller/worker and worker/worker file or directory transfers, then manage them with the normal `job_*` tools.
 - Revoke workers after the task with `remote_revoke_machine`.
 
 ## Anti-patterns

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -459,7 +459,7 @@ When `machine` is supplied, the call additionally requires `remote:use` and runs
 
 ### `transfer_path`
 
-Copy a file or directory between the controller and remote machines using one-time raw binary HTTP streams. A missing machine denotes the controller; at least one endpoint must be remote.
+Start a tracked job that copies a file or directory between the controller and remote machines. A missing machine denotes the controller; at least one endpoint must be remote. The call returns immediately with a job record; use `job_list`, `job_tail`, `job_stop`, and `job_retry` to follow or control it.
 
 | Parameter | Type | Required/default | Description |
 |---|---|---|---|
@@ -468,13 +468,13 @@ Copy a file or directory between the controller and remote machines using one-ti
 | `source_machine` | `string \| null` | `null` |  |
 | `destination_machine` | `string \| null` | `null` |  |
 | `overwrite` | `boolean` | `false` |  |
-| `chunk_size` | `integer \| null` | `null` | Compatibility parameter; validated and reported but does not change the raw HTTP streaming transport. |
+| `chunk_size` | `integer \| null` | `null` | Raw-binary chunk size for worker-to-controller upload legs. Defaults to 1 MiB and is capped at 4 MiB. |
 | `purpose` | `string \| null` | `null` |  |
 | `explanation` | `string \| null` | `null` |  |
 
 OAuth scopes: `remote:use, shell:read, shell:write`.
 
-At least one of `source_machine` and `destination_machine` must be supplied. Omitted endpoints refer to the controller workspace; the source may be either a file or a directory.
+At least one of `source_machine` and `destination_machine` must be supplied. Omitted endpoints refer to the controller workspace; the source may be either a file or a directory. Worker-to-controller upload legs use transactional, resumable raw-binary chunks with per-chunk and final SHA-256 validation.
 
 ### `create_file_link`
 

--- a/docs/reference/tools.zh-Hant.md
+++ b/docs/reference/tools.zh-Hant.md
@@ -32,7 +32,7 @@ Git 不再擁有專用 MCP 工具。請透過 `run_shell_tool` 執行標準 Git 
 
 - `read_file.path` 可以是單一路徑，也可以是路徑陣列。
 - `edit_file.edits` 接受一個或多個精確替換項，不再區分單次與批次編輯工具。
-- `transfer_path` 自動判斷來源是檔案還是目錄，並支援控制端到 worker、worker 到控制端以及 worker 到 worker。`source_machine` 或 `destination_machine` 至少指定一個。
+- `transfer_path` 自動判斷來源是檔案還是目錄，並立即建立一個可追蹤的傳輸 job，支援控制端到 worker、worker 到控制端以及 worker 到 worker。使用 `job_list`、`job_tail`、`job_stop` 和 `job_retry` 查看、停止或重試；worker 到控制端的上傳使用可續傳的原始二進位分塊。`source_machine` 或 `destination_machine` 至少指定一個。
 
 ### 瀏覽器自動化
 

--- a/docs/reference/tools.zh.md
+++ b/docs/reference/tools.zh.md
@@ -32,7 +32,7 @@ Git 不再拥有专用 MCP 工具。请通过 `run_shell_tool` 执行标准 Git 
 
 - `read_file.path` 可以是单个路径，也可以是路径数组。
 - `edit_file.edits` 接受一个或多个精确替换项，不再区分单次与批量编辑工具。
-- `transfer_path` 自动判断源是文件还是目录，并支持控制端到 worker、worker 到控制端以及 worker 到 worker。`source_machine` 或 `destination_machine` 至少指定一个。
+- `transfer_path` 自动判断源是文件还是目录，并立即创建一个可跟踪的传输 job，支持控制端到 worker、worker 到控制端以及 worker 到 worker。使用 `job_list`、`job_tail`、`job_stop` 和 `job_retry` 查看、停止或重试；worker 到控制端的上传使用可续传的原始二进制分块。`source_machine` 或 `destination_machine` 至少指定一个。
 
 ### 浏览器自动化
 

--- a/src/local_shell_mcp/audit.py
+++ b/src/local_shell_mcp/audit.py
@@ -465,6 +465,9 @@ _TOOL_OPERATION_GROUPS: dict[str, frozenset[str]] = {
             "delete_file_or_dir",
             "apply_patch",
             "secret_scan",
+            "create_file_link",
+            "list_file_links",
+            "revoke_file_link",
         }
     ),
     "shell": frozenset(
@@ -479,9 +482,6 @@ _TOOL_OPERATION_GROUPS: dict[str, frozenset[str]] = {
         }
     ),
     "jobs": frozenset({"job_start", "job_list", "job_tail", "job_stop", "job_retry"}),
-    "transfer": frozenset(
-        {"create_file_link", "list_file_links", "revoke_file_link", "transfer_path"}
-    ),
     "browser": frozenset(
         {"browser_capture_tool", "browser_get_text_tool", "playwright_run_script_tool"}
     ),
@@ -491,6 +491,7 @@ _TOOL_OPERATION_GROUPS: dict[str, frozenset[str]] = {
             "remote_list_machines",
             "remote_revoke_machine",
             "remote_rename_machine",
+            "transfer_path",
         }
     ),
     "agent": frozenset(
@@ -524,8 +525,10 @@ def _operation_type(record: dict[str, Any]) -> str:
         return "browser"
     if event.startswith("remote_"):
         return "remote"
-    if event.startswith(("download_", "file_link_", "transfer_")):
-        return "transfer"
+    if event.startswith(("download_", "file_link_")):
+        return "files"
+    if event.startswith("transfer_"):
+        return "remote"
     return "other"
 
 

--- a/src/local_shell_mcp/human_ui.py
+++ b/src/local_shell_mcp/human_ui.py
@@ -343,6 +343,9 @@ _AUDIT_EXECUTE_TOOLS = frozenset(
         "job_retry",
     }
 )
+_AUDIT_FILE_SHARE_TOOLS = frozenset(
+    {"create_file_link", "list_file_links", "revoke_file_link"}
+)
 
 
 def _audit_detail_scopes(entry: dict[str, Any]) -> tuple[str, ...]:
@@ -355,7 +358,7 @@ def _audit_detail_scopes(entry: dict[str, Any]) -> tuple[str, ...]:
         required.add("shell:execute")
     if operation == "browser":
         required.add("browser:use")
-    if operation == "transfer":
+    if tool in _AUDIT_FILE_SHARE_TOOLS:
         required.add("file:share")
     if operation == "remote" or str(entry.get("node") or "local") != "local":
         required.add("remote:use")

--- a/src/local_shell_mcp/jobs.py
+++ b/src/local_shell_mcp/jobs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import base64
 import contextlib
 import json
@@ -12,6 +13,7 @@ import sys
 import threading
 import time
 import uuid
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any, BinaryIO
 
@@ -34,6 +36,11 @@ JOB_STORE_LEGACY_VERSIONS = {1}
 TERMINAL_STATUSES = {"succeeded", "failed", "exited", "stopped", "lost"}
 _JOB_STORE_THREAD_LOCK = threading.RLock()
 _ACTIVE_JOB_OPERATIONS: set[str] = set()
+ManagedJobHandler = Callable[
+    ["ManagedJobContext", dict[str, Any]], Awaitable[dict[str, Any] | None]
+]
+_MANAGED_JOB_HANDLERS: dict[str, ManagedJobHandler] = {}
+_MANAGED_JOB_TASKS: dict[str, asyncio.Task[None]] = {}
 
 
 def _utc() -> float:
@@ -398,6 +405,25 @@ def _refresh_job_status(
         return job
 
     updated = now or _utc()
+    if job.get("kind") == "managed":
+        task = _MANAGED_JOB_TASKS.get(str(job.get("job_id") or ""))
+        if task is not None and not task.done():
+            return job
+        job.update(
+            {
+                "status": "stopped" if status == "stopping" else "lost",
+                "updated_at": updated,
+                "completed_at": updated,
+                "exit_code": None,
+                "error": (
+                    None
+                    if status == "stopping"
+                    else "managed job is no longer running; retry it to resume the operation"
+                ),
+            }
+        )
+        return job
+
     if status == "starting" and _job_operation_is_active(job, "start"):
         return job
     if status == "retrying" and _job_operation_is_active(job, "retry"):
@@ -508,6 +534,7 @@ def _refresh_job_status(
 def _public_job(job: dict[str, Any]) -> dict[str, Any]:
     return {
         "job_id": job.get("job_id"),
+        "kind": job.get("kind", "shell"),
         "name": job.get("name"),
         "status": job.get("status"),
         "command": job.get("command"),
@@ -523,6 +550,8 @@ def _public_job(job: dict[str, Any]) -> dict[str, Any]:
         "log_truncated": bool(job.get("log_truncated", False)),
         "output_bytes": int(job.get("output_bytes") or 0),
         "attempts": job.get("attempts", 1),
+        "progress": job.get("progress"),
+        "result": job.get("result"),
     }
 
 
@@ -552,6 +581,190 @@ def _read_log_tail(path: str | None, lines: int) -> str:
         if data.endswith((b"\n", b"\r")) and text:
             text += "\n"
     return text
+
+
+def register_managed_job_handler(kind: str, handler: ManagedJobHandler) -> None:
+    normalized = kind.strip()
+    if not normalized:
+        raise ValueError("managed job kind must not be empty")
+    existing = _MANAGED_JOB_HANDLERS.get(normalized)
+    if existing is not None and existing is not handler:
+        raise ValueError(f"managed job handler already registered: {normalized}")
+    _MANAGED_JOB_HANDLERS[normalized] = handler
+
+
+def _append_managed_log(path: str, message: str) -> None:
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    payload = message if message.endswith("\n") else message + "\n"
+    max_bytes = max(1, int(get_settings().max_job_log_bytes))
+    encoded = payload.encode("utf-8", errors="replace")
+    with target.open("a+b") as handle:
+        with contextlib.suppress(OSError):
+            target.chmod(0o600)
+        handle.write(encoded)
+        handle.flush()
+        truncated = _compact_log(handle, max_bytes)
+    with _store_transaction() as store:
+        job_id = target.name.split("-attempt-", 1)[0]
+        with contextlib.suppress(KeyError):
+            job = _find_job(store, job_id)
+            job["output_bytes"] = int(job.get("output_bytes") or 0) + len(encoded)
+            job["log_truncated"] = bool(job.get("log_truncated")) or truncated
+
+
+def _update_managed_progress(job_id: str, progress: dict[str, Any]) -> None:
+    with _store_transaction() as store:
+        job = _find_job(store, job_id)
+        if job.get("status") in {"starting", "running", "stopping", "retrying"}:
+            job["progress"] = dict(progress)
+            job["updated_at"] = _utc()
+
+
+class ManagedJobContext:
+    def __init__(self, job_id: str, log_path: str):
+        self.job_id = job_id
+        self.log_path = log_path
+
+    async def log(self, message: str) -> None:
+        await asyncio.to_thread(_append_managed_log, self.log_path, message)
+
+    async def update_progress(self, **progress: Any) -> None:
+        await asyncio.to_thread(_update_managed_progress, self.job_id, progress)
+
+
+def _finish_managed_job(
+    job_id: str,
+    *,
+    status: str,
+    exit_code: int | None,
+    error: str | None,
+    result: dict[str, Any] | None = None,
+) -> None:
+    with _store_transaction() as store:
+        job = _find_job(store, job_id)
+        if job.get("status") not in {"starting", "running", "stopping", "retrying"}:
+            return
+        completed_at = _utc()
+        job.update(
+            {
+                "status": status,
+                "updated_at": completed_at,
+                "completed_at": completed_at,
+                "exit_code": exit_code,
+                "error": error,
+            }
+        )
+        if result is not None:
+            job["result"] = result
+
+
+async def _run_managed_job(
+    job_id: str,
+    kind: str,
+    payload: dict[str, Any],
+    log_path: str,
+) -> None:
+    context = ManagedJobContext(job_id, log_path)
+    handler = _MANAGED_JOB_HANDLERS[kind]
+    try:
+        result = await handler(context, dict(payload))
+    except asyncio.CancelledError:
+        await asyncio.to_thread(_append_managed_log, log_path, "job cancelled")
+        await asyncio.to_thread(
+            _finish_managed_job,
+            job_id,
+            status="stopped",
+            exit_code=None,
+            error=None,
+        )
+        raise
+    except Exception as exc:
+        error = f"{type(exc).__name__}: {exc}"
+        await asyncio.to_thread(_append_managed_log, log_path, error)
+        await asyncio.to_thread(
+            _finish_managed_job,
+            job_id,
+            status="failed",
+            exit_code=1,
+            error=error,
+        )
+    else:
+        await asyncio.to_thread(
+            _finish_managed_job,
+            job_id,
+            status="succeeded",
+            exit_code=0,
+            error=None,
+            result=result,
+        )
+    finally:
+        _MANAGED_JOB_TASKS.pop(job_id, None)
+
+
+def _launch_managed_job(
+    job_id: str,
+    kind: str,
+    payload: dict[str, Any],
+    log_path: str,
+) -> None:
+    task = asyncio.create_task(
+        _run_managed_job(job_id, kind, payload, log_path),
+        name=f"managed-job-{job_id}",
+    )
+    _MANAGED_JOB_TASKS[job_id] = task
+
+
+async def start_managed_job(
+    kind: str,
+    payload: dict[str, Any],
+    *,
+    name: str | None = None,
+    command: str | None = None,
+) -> dict[str, Any]:
+    normalized = kind.strip()
+    if normalized not in _MANAGED_JOB_HANDLERS:
+        raise ValueError(f"unknown managed job kind: {normalized}")
+    job_id = _new_job_id()
+    display_name = name or f"{normalized}-{job_id}"
+    paths = _attempt_paths(job_id, 1)
+    _private_write_text(paths["log"], "")
+    now = _utc()
+    job = {
+        "job_id": job_id,
+        "kind": "managed",
+        "managed_kind": normalized,
+        "managed_payload": dict(payload),
+        "name": display_name,
+        "status": "running",
+        "command": command or normalized,
+        "cwd": ".",
+        "session_id": None,
+        "backend": "managed",
+        "command_path": None,
+        "log_path": str(paths["log"]),
+        "status_path": None,
+        "created_at": now,
+        "updated_at": now,
+        "last_started_at": now,
+        "completed_at": None,
+        "exit_code": None,
+        "error": None,
+        "log_truncated": False,
+        "output_bytes": 0,
+        "attempts": 1,
+    }
+    try:
+        with _store_transaction() as store:
+            store["jobs"].append(job)
+        _launch_managed_job(job_id, normalized, payload, str(paths["log"]))
+    except BaseException:
+        _remove_attempt_files(job_id)
+        with contextlib.suppress(Exception), _store_transaction() as store:
+            store["jobs"] = [row for row in store.get("jobs", []) if row.get("job_id") != job_id]
+        raise
+    audit("job_start", job_id=job_id, backend="managed", kind=normalized)
+    return _public_job(job)
 
 
 async def start_job(command: str, cwd: str = ".", name: str | None = None) -> dict[str, Any]:
@@ -674,7 +887,7 @@ async def tail_job(job_id: str, lines: int = 200) -> dict[str, Any]:
         session_id = str(job.get("session_id") or "")
         status = str(job.get("status") or "")
     output = _read_log_tail(log_path, lines)
-    if not output and status == "running":
+    if not output and status == "running" and public_job.get("backend") != "managed":
         try:
             tail = await read_shell(session_id, lines)
             output = str(tail.get("output", ""))
@@ -700,7 +913,99 @@ async def tail_job(job_id: str, lines: int = 200) -> dict[str, Any]:
     return result
 
 
+async def _stop_managed_job(job_id: str) -> dict[str, Any]:
+    with _store_transaction() as store:
+        job = _refresh_job_status(_find_job(store, job_id), set())
+        if job.get("status") != "running":
+            return {"job": _public_job(job), "killed": False, "stderr": ""}
+        job["status"] = "stopping"
+        job["updated_at"] = _utc()
+
+    task = _MANAGED_JOB_TASKS.get(job_id)
+    killed = task is not None and not task.done()
+    if killed:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+    else:
+        await asyncio.to_thread(
+            _finish_managed_job,
+            job_id,
+            status="stopped",
+            exit_code=None,
+            error=None,
+        )
+
+    with _store_transaction() as store:
+        job = _find_job(store, job_id)
+        if job.get("status") == "stopping":
+            completed_at = _utc()
+            job.update(
+                {
+                    "status": "stopped",
+                    "updated_at": completed_at,
+                    "completed_at": completed_at,
+                    "exit_code": None,
+                    "error": None,
+                }
+            )
+        public_job = _public_job(job)
+    audit("job_stop", job_id=job_id, backend="managed", killed=killed)
+    return {"job": public_job, "killed": killed, "stderr": ""}
+
+
+async def _retry_managed_job(job_id: str) -> dict[str, Any]:
+    with _store_transaction() as store:
+        job = _refresh_job_status(_find_job(store, job_id), set())
+        if job.get("status") in {"starting", "running", "stopping", "retrying"}:
+            raise RuntimeError(f"job is still active: {job_id}")
+        kind = str(job.get("managed_kind") or "")
+        if kind not in _MANAGED_JOB_HANDLERS:
+            raise RuntimeError(f"managed job handler is unavailable: {kind}")
+        payload = dict(job.get("managed_payload") or {})
+        attempts = int(job.get("attempts") or 1) + 1
+        paths = _attempt_paths(job_id, attempts)
+        _private_write_text(paths["log"], "")
+        started_at = _utc()
+        job.update(
+            {
+                "status": "running",
+                "updated_at": started_at,
+                "last_started_at": started_at,
+                "completed_at": None,
+                "exit_code": None,
+                "error": None,
+                "log_path": str(paths["log"]),
+                "log_truncated": False,
+                "output_bytes": 0,
+                "attempts": attempts,
+                "progress": None,
+                "result": None,
+            }
+        )
+        public_job = _public_job(job)
+    _remove_attempt_files(job_id, keep_attempt=attempts)
+    try:
+        _launch_managed_job(job_id, kind, payload, str(paths["log"]))
+    except BaseException as exc:
+        error = f"retry failed: {type(exc).__name__}: {exc}"
+        await asyncio.to_thread(
+            _finish_managed_job,
+            job_id,
+            status="failed",
+            exit_code=1,
+            error=error,
+        )
+        raise
+    audit("job_retry", job_id=job_id, backend="managed", attempts=attempts)
+    return public_job
+
+
 async def stop_job(job_id: str) -> dict[str, Any]:
+    with _store_transaction() as store:
+        managed = _find_job(store, job_id).get("kind") == "managed"
+    if managed:
+        return await _stop_managed_job(job_id)
     active = _active_session_ids(await list_shells())
     session_id = ""
     operation_id = ""
@@ -766,6 +1071,10 @@ async def stop_job(job_id: str) -> dict[str, Any]:
 
 
 async def retry_job(job_id: str) -> dict[str, Any]:
+    with _store_transaction() as store:
+        managed = _find_job(store, job_id).get("kind") == "managed"
+    if managed:
+        return await _retry_managed_job(job_id)
     active = _active_session_ids(await list_shells())
     operation_id = ""
     try:

--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import contextlib
+import hashlib
 import importlib.metadata as importlib_metadata
 import json
 import os
@@ -63,6 +64,8 @@ from .shell_ops import (
 )
 from .tmux_helper import persistent_shell_backend_info
 from .transfer_ops import (
+    DEFAULT_TRANSFER_CHUNK_BYTES,
+    normalize_chunk_size,
     transfer_abort_write,
     transfer_alloc_temp_path,
     transfer_begin_write,
@@ -1052,49 +1055,99 @@ def _worker_upload_url(
     expected_bytes: int,
     expected_sha256: str,
     timeout_s: int | None = None,
+    offset: int = 0,
+    chunk_size: int | None = None,
 ) -> dict[str, Any]:
     _worker_validate_transfer_url(url)
     source = resolve_path(path, must_exist=True)
-    stat = transfer_stat(str(source), True)
+    stat = transfer_stat(str(source), False)
     if stat.get("type") != "file":
         raise ValueError(f"source is not a file: {path}")
-    if stat["size"] != int(expected_bytes):
-        raise ValueError(f"size mismatch: expected {expected_bytes}, got {stat['size']}")
-    if str(stat.get("sha256") or "").lower() != str(expected_sha256).lower():
-        raise ValueError("file sha256 mismatch before upload")
+    total = int(expected_bytes)
+    if stat["size"] != total:
+        raise ValueError(f"size mismatch: expected {total}, got {stat['size']}")
+    start = int(offset)
+    if start < 0 or start > total:
+        raise ValueError("offset is outside the source file")
+    if start == 0:
+        digest = transfer_stat(str(source), True).get("sha256")
+        if str(digest or "").lower() != str(expected_sha256).lower():
+            raise ValueError("file sha256 mismatch before upload")
+
+    effective_chunk_size = normalize_chunk_size(
+        DEFAULT_TRANSFER_CHUNK_BYTES if chunk_size is None else chunk_size
+    )
+    with source.open("rb") as handle:
+        handle.seek(start)
+        data = handle.read(min(effective_chunk_size, total - start))
+    end = start + len(data)
+
     curl = shutil.which("curl")
     if not curl:
         raise FileNotFoundError("curl is required for remote file streaming")
-    completed = subprocess.run(  # noqa: S603
+    marker = "\n__LSM_HTTP_STATUS__:"
+    command = [
+        curl,
+        "-sS",
+        "--http1.1",
+        "--connect-timeout",
+        "15",
+        "--max-time",
+        str(_worker_curl_timeout(timeout_s)),
+        "-X",
+        "PUT",
+        "-H",
+        "Expect:",
+        "-H",
+        "Content-Type: application/octet-stream",
+        "-H",
+        f"X-Chunk-SHA256: {hashlib.sha256(data).hexdigest()}",
+    ]
+    if total:
+        command.extend(["-H", f"Content-Range: bytes {start}-{end - 1}/{total}"])
+    command.extend(
         [
-            curl,
-            "-fsS",
-            "--connect-timeout",
-            "15",
-            "--max-time",
-            str(_worker_curl_timeout(timeout_s)),
-            "-H",
-            "Expect:",
-            "-H",
-            "Content-Type: application/octet-stream",
-            "--upload-file",
-            str(source),
+            "--data-binary",
+            "@-",
+            "--write-out",
+            marker + "%{http_code}",
             url,
-        ],
+        ]
+    )
+    completed = subprocess.run(  # noqa: S603
+        command,
+        input=data,
         capture_output=True,
-        text=True,
         check=False,
     )
+    raw_stdout = completed.stdout or b""
+    raw_stderr = completed.stderr or b""
+    stdout = raw_stdout.encode() if isinstance(raw_stdout, str) else raw_stdout
+    stderr = (
+        raw_stderr
+        if isinstance(raw_stderr, str)
+        else raw_stderr.decode(errors="replace")
+    )
+    raw_marker = marker.encode("ascii")
+    body, separator, raw_status = stdout.rpartition(raw_marker)
     if completed.returncode != 0:
-        detail = completed.stderr.strip() or completed.stdout.strip()
-        raise RuntimeError(f"stream upload failed with curl exit {completed.returncode}: {detail}")
+        raise RuntimeError(
+            f"chunk upload failed with curl exit {completed.returncode}: {stderr.strip()}"
+        )
+    if not separator:
+        raise RuntimeError("chunk upload returned an invalid response")
     try:
-        payload = json.loads(completed.stdout)
-    except json.JSONDecodeError as exc:
-        raise RuntimeError("stream upload returned invalid JSON") from exc
-    if not isinstance(payload, dict) or not payload.get("ok"):
-        raise RuntimeError(f"stream upload failed: {payload}")
-    return dict(payload.get("data") or {})
+        status_code = int(raw_status.strip())
+        payload = json.loads(body)
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise RuntimeError("chunk upload returned an invalid response") from exc
+    if status_code >= 400 or not isinstance(payload, dict) or not payload.get("ok"):
+        raise RuntimeError(f"chunk upload failed with HTTP {status_code}: {payload}")
+    result = dict(payload.get("data") or {})
+    result["offset"] = start
+    result["chunk_bytes"] = len(data)
+    result["chunk_size"] = effective_chunk_size
+    return result
 
 
 def _worker_download_url(
@@ -1371,6 +1424,8 @@ async def _execute_transfer_worker_tool(tool: str, args: dict[str, Any]) -> Any:
             args["expected_bytes"],
             args["expected_sha256"],
             args.get("timeout_s"),
+            args.get("offset", 0),
+            args.get("chunk_size"),
         )
 
     if tool == "transfer_download_url":
@@ -1841,9 +1896,7 @@ async def run_worker(
                 "error": "TimeoutError",
                 "message": "remote job expired before execution",
             }
-            await _submit_worker_result_with_heartbeat(
-                out, server, headers, heartbeat_interval_s
-            )
+            await _submit_worker_result_with_heartbeat(out, server, headers, heartbeat_interval_s)
             continue
         try:
             result = await _execute_worker_job_with_heartbeat(

--- a/src/local_shell_mcp/remote_transfer.py
+++ b/src/local_shell_mcp/remote_transfer.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import hashlib
 import os
+import re
 import secrets
 import threading
 import time
@@ -21,6 +22,7 @@ from .audit import audit
 from .fs_ops import relative_display, resolve_path
 from .settings import get_settings
 from .transfer_ops import (
+    MAX_TRANSFER_CHUNK_BYTES,
     transfer_abort_write,
     transfer_begin_write,
     transfer_finish_write,
@@ -31,6 +33,7 @@ REMOTE_TRANSFER_PREFIX = "/remote/transfer"
 REMOTE_TRANSFER_UPLOAD_PREFIX = f"{REMOTE_TRANSFER_PREFIX}/upload/"
 REMOTE_TRANSFER_DOWNLOAD_PREFIX = f"{REMOTE_TRANSFER_PREFIX}/download/"
 _TRANSFER_CHUNK_BYTES = 1024 * 1024
+_CONTENT_RANGE_RE = re.compile(r"^bytes (\d+)-(\d+)/(\d+)$")
 _TICKET_LOCK = threading.RLock()
 
 
@@ -47,6 +50,9 @@ class _TransferTicket:
     display_path: str | None = None
     cleanup_path: str | None = None
     claimed: bool = False
+    transfer_id: str | None = None
+    received_bytes: int = 0
+    completed_data: dict[str, Any] | None = None
 
 
 _TICKETS: dict[str, _TransferTicket] = {}
@@ -87,6 +93,10 @@ def _validate_expected(expected_bytes: int, expected_sha256: str) -> tuple[int, 
 
 
 def _cleanup_ticket_file(ticket: _TransferTicket) -> None:
+    if ticket.direction == "upload" and ticket.transfer_id:
+        with contextlib.suppress(Exception):
+            transfer_abort_write(ticket.path, ticket.transfer_id)
+        ticket.transfer_id = None
     if not ticket.cleanup_path:
         return
     with contextlib.suppress(OSError):
@@ -96,7 +106,7 @@ def _cleanup_ticket_file(ticket: _TransferTicket) -> None:
 def _prune_locked(now: float | None = None) -> None:
     current = _now() if now is None else now
     for token, ticket in list(_TICKETS.items()):
-        if ticket.expires_at <= current:
+        if ticket.expires_at <= current and not ticket.claimed:
             removed = _TICKETS.pop(token, None)
             if removed is not None:
                 _cleanup_ticket_file(removed)
@@ -112,6 +122,7 @@ def _create_ticket(
     token: str | None = None,
     display_path: Path | None = None,
     cleanup_path: Path | None = None,
+    transfer_id: str | None = None,
 ) -> dict[str, Any]:
     size, digest = _validate_expected(expected_bytes, expected_sha256)
     token = token or secrets.token_urlsafe(32)
@@ -127,6 +138,7 @@ def _create_ticket(
         expires_at=now + _ticket_ttl_s(),
         display_path=str(display_path or path),
         cleanup_path=str(cleanup_path) if cleanup_path is not None else None,
+        transfer_id=transfer_id,
     )
     with _TICKET_LOCK:
         _prune_locked(now)
@@ -155,7 +167,19 @@ def create_upload_ticket(
     overwrite: bool = True,
 ) -> dict[str, Any]:
     destination = resolve_path(destination_path, follow_final_symlink=False)
-    return _create_ticket("upload", destination, expected_bytes, expected_sha256, overwrite)
+    begin = transfer_begin_write(str(destination), overwrite, expected_bytes)
+    try:
+        return _create_ticket(
+            "upload",
+            destination,
+            expected_bytes,
+            expected_sha256,
+            overwrite,
+            transfer_id=begin["transfer_id"],
+        )
+    except Exception:
+        transfer_abort_write(str(destination), begin["transfer_id"])
+        raise
 
 
 def _download_snapshot_path(token: str) -> Path:
@@ -270,6 +294,85 @@ def _release_ticket(token: str) -> None:
         ticket = _TICKETS.get(token)
         if ticket is not None:
             ticket.claimed = False
+            ticket.expires_at = _now() + _ticket_ttl_s()
+
+
+def _upload_ticket_data(ticket: _TransferTicket) -> dict[str, Any]:
+    if ticket.completed_data is not None:
+        return dict(ticket.completed_data)
+    return {
+        "path": relative_display(Path(ticket.display_path or ticket.path)),
+        "bytes": ticket.expected_bytes,
+        "sha256": ticket.expected_sha256,
+        "received_bytes": ticket.received_bytes,
+        "completed": False,
+        "transport": "http-chunks",
+    }
+
+
+def get_upload_ticket_status(token: str) -> dict[str, Any]:
+    with _TICKET_LOCK:
+        _prune_locked()
+        ticket = _TICKETS.get(token)
+        if ticket is None:
+            raise FileNotFoundError("transfer ticket does not exist or has expired")
+        if ticket.direction != "upload":
+            raise PermissionError("transfer ticket direction mismatch")
+        ticket.expires_at = _now() + _ticket_ttl_s()
+        return _upload_ticket_data(ticket)
+
+
+def _complete_upload_ticket(
+    token: str, ticket: _TransferTicket, finish: dict[str, Any]
+) -> dict[str, Any]:
+    data = {
+        "path": finish["path"],
+        "bytes": finish["bytes"],
+        "sha256": finish["sha256"],
+        "received_bytes": finish["bytes"],
+        "completed": True,
+        "transport": "http-chunks",
+    }
+    with _TICKET_LOCK:
+        ticket.transfer_id = None
+        ticket.received_bytes = finish["bytes"]
+        ticket.completed_data = data
+        ticket.claimed = False
+        ticket.expires_at = _now() + _ticket_ttl_s()
+    audit(
+        "remote_transfer_completed",
+        direction="upload",
+        path=finish["path"],
+        bytes=finish["bytes"],
+        token_id=_token_id(token),
+    )
+    return data
+
+
+def _write_upload_chunk(
+    ticket: _TransferTicket,
+    start: int,
+    end: int,
+    payload: bytes,
+) -> None:
+    if ticket.transfer_id is None:
+        raise RuntimeError("upload transaction is unavailable")
+    transfer_write_bytes(ticket.path, ticket.transfer_id, start, payload)
+    with _TICKET_LOCK:
+        ticket.received_bytes = end
+        ticket.expires_at = _now() + _ticket_ttl_s()
+
+
+def _finish_upload_transaction(token: str, ticket: _TransferTicket) -> dict[str, Any]:
+    if ticket.transfer_id is None:
+        raise RuntimeError("upload transaction is unavailable")
+    finish = transfer_finish_write(
+        ticket.path,
+        ticket.transfer_id,
+        ticket.expected_bytes,
+        ticket.expected_sha256,
+    )
+    return _complete_upload_ticket(token, ticket, finish)
 
 
 def _complete_ticket(token: str) -> None:
@@ -302,6 +405,32 @@ def _content_disposition(filename: str) -> str:
     return f"attachment; filename=\"{fallback}\"; filename*=UTF-8''{encoded}"
 
 
+def _upload_range(request: Request, ticket: _TransferTicket) -> tuple[int, int, bool]:
+    raw_range = request.headers.get("content-range")
+    if not raw_range:
+        return 0, ticket.expected_bytes, True
+    match = _CONTENT_RANGE_RE.fullmatch(raw_range.strip())
+    if match is None:
+        raise ValueError("Content-Range must use 'bytes start-end/total'")
+    start, inclusive_end, total = (int(value) for value in match.groups())
+    if total != ticket.expected_bytes:
+        raise ValueError(f"Content-Range total must be {ticket.expected_bytes}")
+    if inclusive_end < start or inclusive_end >= total:
+        raise ValueError("Content-Range bounds are invalid")
+    return start, inclusive_end + 1, False
+
+
+async def upload_status_endpoint(request: Request) -> JSONResponse:
+    token = request.path_params["token"]
+    try:
+        data = get_upload_ticket_status(token)
+    except FileNotFoundError as exc:
+        return _error_response(404, "transfer_not_found", str(exc))
+    except PermissionError as exc:
+        return _error_response(409, "transfer_unavailable", str(exc))
+    return JSONResponse({"ok": True, "data": data})
+
+
 async def upload_endpoint(request: Request) -> JSONResponse:
     token = request.path_params["token"]
     try:
@@ -311,88 +440,88 @@ async def upload_endpoint(request: Request) -> JSONResponse:
     except (PermissionError, RuntimeError) as exc:
         return _error_response(409, "transfer_unavailable", str(exc))
 
-    raw_length = request.headers.get("content-length")
-    if raw_length:
-        try:
-            content_length = int(raw_length)
-        except ValueError:
+    if ticket.completed_data is not None:
+        data = _upload_ticket_data(ticket)
+        _release_ticket(token)
+        return JSONResponse({"ok": True, "data": data})
+
+    try:
+        start, end, legacy_full_upload = _upload_range(request, ticket)
+        expected_chunk_bytes = end - start
+        if expected_chunk_bytes > MAX_TRANSFER_CHUNK_BYTES:
+            detail = (
+                "legacy full-file upload exceeds the supported request size; update the remote worker"
+                if legacy_full_upload
+                else "upload chunk exceeds the supported request size"
+            )
+            raise ValueError(f"{detail}: maximum is {MAX_TRANSFER_CHUNK_BYTES} bytes")
+        raw_length = request.headers.get("content-length")
+        if raw_length:
+            try:
+                content_length = int(raw_length)
+            except ValueError as exc:
+                raise ValueError("Content-Length is invalid") from exc
+            if content_length != expected_chunk_bytes:
+                raise ValueError(
+                    f"Expected {expected_chunk_bytes} bytes, got Content-Length {content_length}"
+                )
+        if start != ticket.received_bytes:
+            data = _upload_ticket_data(ticket)
             _release_ticket(token)
-            return _error_response(400, "invalid_content_length", "Content-Length is invalid")
-        if content_length != ticket.expected_bytes:
-            _release_ticket(token)
-            return _error_response(
-                400,
-                "size_mismatch",
-                f"Expected {ticket.expected_bytes} bytes, got Content-Length {content_length}",
+            return JSONResponse(
+                {
+                    "ok": False,
+                    "error": "offset_mismatch",
+                    "message": f"Expected upload offset {ticket.received_bytes}, got {start}",
+                    "data": data,
+                },
+                status_code=409,
             )
 
-    begin: dict[str, Any] | None = None
-    offset = 0
-    digest = hashlib.sha256()
-    try:
-        begin = await asyncio.to_thread(
-            transfer_begin_write,
-            ticket.path,
-            ticket.overwrite,
-            ticket.expected_bytes,
-        )
+        payload = bytearray()
         async for chunk in request.stream():
             if not chunk:
                 continue
-            if offset + len(chunk) > ticket.expected_bytes:
-                raise ValueError("upload exceeds expected transfer size")
-            digest.update(chunk)
-            await asyncio.to_thread(
-                transfer_write_bytes,
-                ticket.path,
-                begin["transfer_id"],
-                offset,
-                chunk,
+            if len(payload) + len(chunk) > expected_chunk_bytes:
+                raise ValueError("upload exceeds declared chunk size")
+            payload.extend(chunk)
+        if len(payload) != expected_chunk_bytes:
+            raise ValueError(f"size mismatch: expected {expected_chunk_bytes}, got {len(payload)}")
+
+        expected_chunk_sha256 = request.headers.get("x-chunk-sha256")
+        actual_chunk_sha256 = hashlib.sha256(payload).hexdigest()
+        if expected_chunk_sha256 and actual_chunk_sha256 != expected_chunk_sha256.lower():
+            raise ValueError("chunk sha256 mismatch")
+        await asyncio.to_thread(
+            _write_upload_chunk,
+            ticket,
+            start,
+            end,
+            bytes(payload),
+        )
+
+        if end == ticket.expected_bytes:
+            data = await asyncio.to_thread(
+                _finish_upload_transaction,
+                token,
+                ticket,
             )
-            offset += len(chunk)
-        if offset != ticket.expected_bytes:
-            raise ValueError(f"size mismatch: expected {ticket.expected_bytes}, got {offset}")
-        actual_sha256 = digest.hexdigest()
-        if actual_sha256 != ticket.expected_sha256:
-            raise ValueError("file sha256 mismatch")
-        finish = await asyncio.to_thread(
-            transfer_finish_write,
-            ticket.path,
-            begin["transfer_id"],
-            ticket.expected_bytes,
-            ticket.expected_sha256,
-        )
-        _complete_ticket(token)
-        return JSONResponse(
-            {
-                "ok": True,
-                "data": {
-                    "path": finish["path"],
-                    "bytes": finish["bytes"],
-                    "sha256": finish["sha256"],
-                    "transport": "http-stream",
-                },
-            }
-        )
+            return JSONResponse({"ok": True, "data": data})
+
+        data = _upload_ticket_data(ticket)
+        _release_ticket(token)
+        return JSONResponse({"ok": True, "data": data})
     except asyncio.CancelledError:
-        if begin is not None:
-            with contextlib.suppress(Exception):
-                await asyncio.to_thread(
-                    transfer_abort_write,
-                    ticket.path,
-                    begin["transfer_id"],
-                )
         _release_ticket(token)
         raise
     except Exception as exc:
-        if begin is not None:
-            with contextlib.suppress(Exception):
-                await asyncio.to_thread(
-                    transfer_abort_write,
-                    ticket.path,
-                    begin["transfer_id"],
-                )
-        _release_ticket(token)
+        if ticket.received_bytes == ticket.expected_bytes:
+            with _TICKET_LOCK:
+                removed = _TICKETS.pop(token, None)
+            if removed is not None:
+                _cleanup_ticket_file(removed)
+        else:
+            _release_ticket(token)
         audit(
             "remote_transfer_upload_failed",
             token_id=_token_id(token),
@@ -464,6 +593,11 @@ def remote_transfer_routes() -> list[Any]:
             f"{REMOTE_TRANSFER_PREFIX}/upload/{{token}}",
             upload_endpoint,
             methods=["PUT"],
+        ),
+        Route(
+            f"{REMOTE_TRANSFER_PREFIX}/upload/{{token}}",
+            upload_status_endpoint,
+            methods=["GET"],
         ),
         Route(
             f"{REMOTE_TRANSFER_PREFIX}/download/{{token}}",

--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -7,6 +7,7 @@ import json
 import subprocess
 import time
 import uuid
+from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from pathlib import Path
 from typing import Any, cast
@@ -36,7 +37,16 @@ from .fs_ops import (
     write_text,
 )
 from .image_ops import ImageFile, assert_view_image_size, read_image
-from .jobs import list_jobs, retry_job, start_job, stop_job, tail_job
+from .jobs import (
+    ManagedJobContext,
+    list_jobs,
+    register_managed_job_handler,
+    retry_job,
+    start_job,
+    start_managed_job,
+    stop_job,
+    tail_job,
+)
 from .models import ToolResult
 from .models import ok_result as _ok
 from .oauth import ALL_OAUTH_SCOPES
@@ -46,6 +56,7 @@ from .remote import remote_manager
 from .remote_transfer import (
     create_download_ticket,
     create_upload_ticket,
+    get_upload_ticket_status,
     revoke_transfer_ticket,
 )
 from .search_ops import grep, tree
@@ -73,6 +84,7 @@ from .skill_ops import (
 from .tmux_helper import persistent_shell_backend_info
 from .todo_ops import todo_read, todo_write
 from .transfer_ops import (
+    DEFAULT_TRANSFER_CHUNK_BYTES,
     normalize_chunk_size,
     transfer_alloc_temp_path,
     transfer_pack_dir,
@@ -204,6 +216,7 @@ SECRET_PATTERNS = {
     "private_key": r"-----BEGIN (?:RSA |OPENSSH |EC |DSA )?PRIVATE KEY-----",
     "generic_assignment": r"(?i)(token|secret|password|passwd|api_key|apikey)\s*[:=]\s*['\"][^'\"]{8,}['\"]",
 }
+
 
 def _oauth_security_scheme(scopes: list[str] | tuple[str, ...]) -> dict[str, Any]:
     return {"type": "oauth2", "scopes": list(ALL_OAUTH_SCOPES)}
@@ -657,6 +670,14 @@ class RemoteTransferError(RuntimeError):
     pass
 
 
+TransferProgress = Callable[[dict[str, Any]], Awaitable[None]]
+
+
+async def _report_transfer_progress(progress: TransferProgress | None, **fields: Any) -> None:
+    if progress is not None:
+        await progress(fields)
+
+
 def _unwrap_remote_transfer_result(result: dict, *, machine: str, tool: str) -> Any:
     if not result.get("ok", False):
         raise RemoteTransferError(f"{tool} on {machine} failed: {result.get('message') or result}")
@@ -681,13 +702,12 @@ async def _copy_local_file_to_remote(
     dst_path: str,
     overwrite: bool = True,
     chunk_size: int | None = None,
+    progress: TransferProgress | None = None,
 ) -> dict:
     stat = await asyncio.to_thread(transfer_stat, source_path, True)
     if stat.get("type") != "file":
         raise ValueError(f"source is not a file: {source_path}")
-    effective_chunk_size = (
-        stat["size"] if chunk_size is None else normalize_chunk_size(chunk_size)
-    )
+    effective_chunk_size = stat["size"] if chunk_size is None else normalize_chunk_size(chunk_size)
     ticket = create_download_ticket(
         source_path,
         stat["size"],
@@ -709,6 +729,14 @@ async def _copy_local_file_to_remote(
         )
     finally:
         revoke_transfer_ticket(ticket["token"])
+    await _report_transfer_progress(
+        progress,
+        phase="transferring",
+        bytes_transferred=stat["size"],
+        total_bytes=stat["size"],
+        chunks=1,
+        chunk_size=effective_chunk_size,
+    )
     return {
         "source": {"machine": "controller", "path": stat["path"]},
         "destination": {"machine": dst_machine, "path": finish["path"]},
@@ -726,44 +754,110 @@ async def _copy_remote_file_to_local(
     destination_path: str,
     overwrite: bool = True,
     chunk_size: int | None = None,
+    progress: TransferProgress | None = None,
 ) -> dict:
     stat = await _remote_transfer_data(
         src_machine, "transfer_stat", {"path": src_path, "sha256": True}
     )
     if stat.get("type") != "file":
         raise ValueError(f"source is not a file: {src_path}")
-    effective_chunk_size = (
-        stat["size"] if chunk_size is None else normalize_chunk_size(chunk_size)
+    total_bytes = int(stat["size"])
+    effective_chunk_size = normalize_chunk_size(
+        DEFAULT_TRANSFER_CHUNK_BYTES if chunk_size is None else chunk_size
     )
+    chunk_timeout_s = min(int(get_settings().remote_job_timeout_s), 300)
     ticket = create_upload_ticket(
         destination_path,
-        stat["size"],
+        total_bytes,
         stat["sha256"],
         overwrite,
     )
+    chunks = 0
+    finish: dict[str, Any] | None = None
     try:
-        finish = await _remote_transfer_data(
-            src_machine,
-            "transfer_upload_url",
-            {
-                "path": src_path,
-                "url": ticket["url"],
-                "expected_bytes": stat["size"],
-                "expected_sha256": stat["sha256"],
-                "timeout_s": get_settings().remote_job_timeout_s,
-            },
-            get_settings().remote_job_timeout_s,
+        status = get_upload_ticket_status(ticket["token"])
+        offset = int(status["received_bytes"])
+        await _report_transfer_progress(
+            progress,
+            phase="transferring",
+            bytes_transferred=offset,
+            total_bytes=total_bytes,
+            chunks=chunks,
+            chunk_size=effective_chunk_size,
         )
+        while offset < total_bytes or (total_bytes == 0 and chunks == 0):
+            expected_end = min(total_bytes, offset + effective_chunk_size)
+            last_error: Exception | None = None
+            for attempt in range(3):
+                try:
+                    response = await _remote_transfer_data(
+                        src_machine,
+                        "transfer_upload_url",
+                        {
+                            "path": src_path,
+                            "url": ticket["url"],
+                            "expected_bytes": total_bytes,
+                            "expected_sha256": stat["sha256"],
+                            "timeout_s": chunk_timeout_s,
+                            "offset": offset,
+                            "chunk_size": effective_chunk_size,
+                        },
+                        chunk_timeout_s,
+                    )
+                except Exception as exc:
+                    last_error = exc
+                    status = get_upload_ticket_status(ticket["token"])
+                    acknowledged = int(status["received_bytes"])
+                    if acknowledged == expected_end or (
+                        total_bytes == 0 and status.get("completed")
+                    ):
+                        response = status
+                    elif acknowledged != offset or attempt == 2:
+                        raise
+                    else:
+                        await asyncio.sleep(1)
+                        continue
+
+                acknowledged = int(response.get("received_bytes", -1))
+                if total_bytes == 0:
+                    if not response.get("completed"):
+                        raise RemoteTransferError("empty upload was not completed")
+                elif acknowledged != expected_end:
+                    raise RemoteTransferError(
+                        f"upload acknowledged offset {acknowledged}, expected {expected_end}"
+                    )
+                offset = acknowledged
+                chunks += 1
+                finish = response
+                await _report_transfer_progress(
+                    progress,
+                    phase="transferring",
+                    bytes_transferred=offset,
+                    total_bytes=total_bytes,
+                    chunks=chunks,
+                    chunk_size=effective_chunk_size,
+                )
+                break
+            else:
+                assert last_error is not None
+                raise last_error
+            if finish.get("completed"):
+                break
+
+        if finish is None or not finish.get("completed"):
+            finish = get_upload_ticket_status(ticket["token"])
+        if not finish.get("completed"):
+            raise RemoteTransferError(f"upload did not complete: {finish}")
     finally:
         revoke_transfer_ticket(ticket["token"])
     return {
         "source": {"machine": src_machine, "path": stat["path"]},
         "destination": {"machine": "controller", "path": finish["path"]},
-        "bytes": stat["size"],
+        "bytes": total_bytes,
         "sha256": stat.get("sha256"),
-        "chunks": 1,
+        "chunks": chunks,
         "chunk_size": effective_chunk_size,
-        "transport": "http-stream",
+        "transport": "http-chunks",
     }
 
 
@@ -774,6 +868,7 @@ async def _copy_remote_file_to_remote(
     dst_path: str,
     overwrite: bool = True,
     chunk_size: int | None = None,
+    progress: TransferProgress | None = None,
 ) -> dict:
     temporary = await asyncio.to_thread(transfer_alloc_temp_path, ".bin")
     try:
@@ -783,6 +878,7 @@ async def _copy_remote_file_to_remote(
             temporary["path"],
             True,
             chunk_size,
+            progress,
         )
         push = await _copy_local_file_to_remote(
             temporary["path"],
@@ -790,6 +886,7 @@ async def _copy_remote_file_to_remote(
             dst_path,
             overwrite,
             chunk_size,
+            progress,
         )
     finally:
         with suppress(Exception):
@@ -801,7 +898,7 @@ async def _copy_remote_file_to_remote(
         "sha256": pull["sha256"],
         "chunks": pull["chunks"] + push["chunks"],
         "chunk_size": pull["chunk_size"],
-        "transport": "http-stream-via-controller",
+        "transport": "http-chunks-via-controller",
     }
 
 
@@ -819,6 +916,7 @@ async def _copy_packed_dir_to_remote(
     dst_path: str,
     overwrite: bool,
     chunk_size: int | None,
+    progress: TransferProgress | None = None,
 ) -> dict:
     dst_archive = await _remote_transfer_data(
         dst_machine, "transfer_alloc_temp_path", {"suffix": ".tar.gz"}
@@ -832,6 +930,7 @@ async def _copy_packed_dir_to_remote(
                 dst_archive["path"],
                 True,
                 chunk_size,
+                progress,
             )
         else:
             copy_result = await _copy_local_file_to_remote(
@@ -840,6 +939,7 @@ async def _copy_packed_dir_to_remote(
                 dst_archive["path"],
                 True,
                 chunk_size,
+                progress,
             )
         unpack = await _remote_transfer_data(
             dst_machine,
@@ -877,7 +977,9 @@ async def _copy_remote_dir_to_remote(
     dst_path: str,
     overwrite: bool = True,
     chunk_size: int | None = None,
+    progress: TransferProgress | None = None,
 ) -> dict:
+    await _report_transfer_progress(progress, phase="packing", bytes_transferred=0)
     pack = await _remote_transfer_data(
         src_machine, "transfer_pack_dir", {"path": src_path, "compression": "gz"}
     )
@@ -888,6 +990,7 @@ async def _copy_remote_dir_to_remote(
         dst_path,
         overwrite,
         chunk_size,
+        progress,
     )
 
 
@@ -897,14 +1000,28 @@ async def _copy_remote_dir_to_local(
     destination_path: str,
     overwrite: bool = True,
     chunk_size: int | None = None,
+    progress: TransferProgress | None = None,
 ) -> dict:
+    await _report_transfer_progress(progress, phase="packing", bytes_transferred=0)
     pack = await _remote_transfer_data(
         src_machine, "transfer_pack_dir", {"path": src_path, "compression": "gz"}
     )
     archive = await asyncio.to_thread(transfer_alloc_temp_path, ".tar.gz")
     try:
         copy_result = await _copy_remote_file_to_local(
-            src_machine, pack["archive_path"], archive["path"], True, chunk_size
+            src_machine,
+            pack["archive_path"],
+            archive["path"],
+            True,
+            chunk_size,
+            progress,
+        )
+        await _report_transfer_progress(
+            progress,
+            phase="unpacking",
+            bytes_transferred=pack["bytes"],
+            total_bytes=pack["bytes"],
+            chunks=copy_result["chunks"],
         )
         unpack = await asyncio.to_thread(
             transfer_unpack_archive, archive["path"], destination_path, overwrite, True
@@ -929,7 +1046,9 @@ async def _copy_local_dir_to_remote(
     dst_path: str,
     overwrite: bool = True,
     chunk_size: int | None = None,
+    progress: TransferProgress | None = None,
 ) -> dict:
+    await _report_transfer_progress(progress, phase="packing", bytes_transferred=0)
     pack = await asyncio.to_thread(transfer_pack_dir, source_path, "gz")
     return await _copy_packed_dir_to_remote(
         pack,
@@ -938,16 +1057,18 @@ async def _copy_local_dir_to_remote(
         dst_path,
         overwrite,
         chunk_size,
+        progress,
     )
 
 
-async def _transfer_path(
+async def _execute_transfer_path(
     source_path: str,
     destination_path: str,
     source_machine: str | None = None,
     destination_machine: str | None = None,
     overwrite: bool = False,
     chunk_size: int | None = None,
+    progress: TransferProgress | None = None,
 ) -> dict:
     if not source_machine and not destination_machine:
         raise ValueError("At least one transfer endpoint must be a remote machine")
@@ -968,38 +1089,116 @@ async def _transfer_path(
         operation = (
             _copy_remote_dir_to_remote if source_type == "dir" else _copy_remote_file_to_remote
         )
-        result = await operation(
+        arguments = (
             source_machine,
             source_path,
             destination_machine,
             destination_path,
-            overwrite,
-            chunk_size,
         )
     elif source_machine:
         operation = (
             _copy_remote_dir_to_local if source_type == "dir" else _copy_remote_file_to_local
         )
-        result = await operation(
-            source_machine,
-            source_path,
-            destination_path,
-            overwrite,
-            chunk_size,
-        )
+        arguments = (source_machine, source_path, destination_path)
     else:
         assert destination_machine is not None
         operation = (
             _copy_local_dir_to_remote if source_type == "dir" else _copy_local_file_to_remote
         )
-        result = await operation(
-            source_path,
-            destination_machine,
-            destination_path,
-            overwrite,
-            chunk_size,
-        )
+        arguments = (source_path, destination_machine, destination_path)
+
+    result = await operation(
+        *arguments,
+        overwrite,
+        chunk_size,
+        progress,
+    )
     return {"type": source_type, **result}
+
+
+_transfer_path = _execute_transfer_path
+
+
+def _transfer_endpoint(machine: str | None, path: str) -> str:
+    return f"{machine or 'controller'}:{path}"
+
+
+async def _run_transfer_job(context: ManagedJobContext, payload: dict[str, Any]) -> dict[str, Any]:
+    source_path = str(payload["source_path"])
+    destination_path = str(payload["destination_path"])
+    source_machine = payload.get("source_machine")
+    destination_machine = payload.get("destination_machine")
+    source = _transfer_endpoint(source_machine, source_path)
+    destination = _transfer_endpoint(destination_machine, destination_path)
+    await context.log(f"transfer started: {source} -> {destination}")
+    await context.update_progress(phase="preparing", bytes_transferred=0)
+
+    async def report(fields: dict[str, Any]) -> None:
+        await context.update_progress(**fields)
+        phase = str(fields.get("phase") or "transferring")
+        done = fields.get("bytes_transferred")
+        total = fields.get("total_bytes")
+        chunks = fields.get("chunks")
+        if isinstance(done, int) and isinstance(total, int):
+            await context.log(
+                f"{phase}: {done}/{total} bytes"
+                + (f" in {chunks} chunks" if isinstance(chunks, int) else "")
+            )
+        else:
+            await context.log(phase)
+
+    result = await _execute_transfer_path(
+        source_path,
+        destination_path,
+        source_machine,
+        destination_machine,
+        bool(payload.get("overwrite", False)),
+        payload.get("chunk_size"),
+        report,
+    )
+    completed_bytes = result.get("bytes", result.get("archive_bytes"))
+    await context.update_progress(
+        phase="completed",
+        bytes_transferred=completed_bytes,
+        total_bytes=completed_bytes,
+        chunks=result.get("chunks"),
+    )
+    await context.log(f"transfer completed: {source} -> {destination}")
+    return result
+
+
+async def _start_transfer_job(
+    source_path: str,
+    destination_path: str,
+    source_machine: str | None = None,
+    destination_machine: str | None = None,
+    overwrite: bool = False,
+    chunk_size: int | None = None,
+) -> dict[str, Any]:
+    if not source_machine and not destination_machine:
+        raise ValueError("At least one transfer endpoint must be a remote machine")
+    if chunk_size is not None:
+        normalize_chunk_size(chunk_size)
+    payload = {
+        "source_path": source_path,
+        "destination_path": destination_path,
+        "source_machine": source_machine,
+        "destination_machine": destination_machine,
+        "overwrite": overwrite,
+        "chunk_size": chunk_size,
+    }
+    source = _transfer_endpoint(source_machine, source_path)
+    destination = _transfer_endpoint(destination_machine, destination_path)
+    name = f"transfer-{Path(destination_path).name or 'path'}"
+    return await start_managed_job(
+        "transfer",
+        payload,
+        name=name,
+        command=f"transfer {source} -> {destination}",
+    )
+
+
+register_managed_job_handler("transfer", _run_transfer_job)
 
 
 def _view_image_success_result(
@@ -1744,10 +1943,10 @@ def _register_workspace_write_tools(mcp: FastMCP, settings: Any) -> None:
         purpose: str | None = None,
         explanation: str | None = None,
     ) -> ToolResult:
-        """Copy a file or directory between the controller and remote machines using raw HTTP streaming. A missing machine denotes the controller; at least one endpoint must be remote. chunk_size is retained for API compatibility and does not change the transport."""
+        """Start a tracked job that copies a file or directory between the controller and remote machines. Remote uploads use resumable raw-binary chunks; use job_list, job_tail, job_stop, and job_retry to manage the transfer."""
         _audit_tool_purpose("transfer_path", purpose, explanation)
         return await _tool_call(
-            _transfer_path,
+            _start_transfer_job,
             source_path,
             destination_path,
             source_machine,

--- a/tests/test_audit_ui_complete.py
+++ b/tests/test_audit_ui_complete.py
@@ -46,7 +46,9 @@ def test_audit_call_helpers_cover_legacy_unpaired_and_optional_fields():
     assert audit_module._operation_type({"event": "run_shell_start"}) == "shell"
     assert audit_module._operation_type({"event": "job_started"}) == "jobs"
     assert audit_module._operation_type({"event": "browser_capture"}) == "browser"
-    assert audit_module._operation_type({"event": "download_created"}) == "transfer"
+    assert audit_module._operation_type({"event": "download_created"}) == "files"
+    assert audit_module._operation_type({"event": "transfer_completed"}) == "remote"
+    assert audit_module._operation_type({"tool": "transfer_path"}) == "remote"
     assert audit_module._call_input({"arguments": "invalid"}) is None
     assert audit_module._call_input({"arguments": {"positional_count": 2}}) == {
         "positional_count": 2
@@ -221,7 +223,7 @@ def test_query_audit_covers_tail_reading_and_filter_rejections(tmp_path, monkeyp
     assert audit_module.query_audit(end_ts=1.5)["entries"][0]["ts"] == 1
     assert audit_module.query_audit(node="missing")["total_matched"] == 0
     assert audit_module.query_audit(event="missing")["total_matched"] == 0
-    assert audit_module.query_audit(operation="transfer")["total_matched"] == 0
+    assert audit_module.query_audit(operation="remote")["total_matched"] == 0
     assert audit_module.query_audit(session="missing")["total_matched"] == 0
     assert audit_module.query_audit(search="missing")["total_matched"] == 0
 

--- a/tests/test_edge_modules_complete.py
+++ b/tests/test_edge_modules_complete.py
@@ -133,7 +133,8 @@ def test_audit_serialization_trimming_and_all_filters(tmp_path, monkeypatch):
     assert audit_module._operation_type({}) == "other"
     assert audit_module._operation_type({"event": "remote_worker_registered"}) == "remote"
     assert audit_module._operation_type({"tool": "job_tail"}) == "jobs"
-    assert audit_module._operation_type({"tool": "create_file_link"}) == "transfer"
+    assert audit_module._operation_type({"tool": "create_file_link"}) == "files"
+    assert audit_module._operation_type({"tool": "transfer_path"}) == "remote"
 
 
 def test_auth_scopes_hosts_tokens_and_metadata(tmp_path, monkeypatch):

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -9,7 +9,15 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 
 import local_shell_mcp.jobs as jobs_module
-from local_shell_mcp.jobs import list_jobs, retry_job, start_job, stop_job, tail_job
+from local_shell_mcp.jobs import (
+    list_jobs,
+    register_managed_job_handler,
+    retry_job,
+    start_job,
+    start_managed_job,
+    stop_job,
+    tail_job,
+)
 from local_shell_mcp.settings import get_settings
 
 
@@ -35,12 +43,8 @@ def test_runner_command_invokes_powershell_executable_and_quotes_arguments():
 def test_runner_environment_policy_is_shell_neutral_and_round_trips(tmp_path, monkeypatch):
     monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
     monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(tmp_path / ".local-shell-mcp"))
-    monkeypatch.setenv(
-        "LOCAL_SHELL_MCP_SHELL_ENV_BLOCKLIST", "TOKEN_ONE,TOKEN_TWO"
-    )
-    monkeypatch.setenv(
-        "LOCAL_SHELL_MCP_SHELL_ENV_BLOCKED_PREFIXES", "PRIVATE_,SERVICE_"
-    )
+    monkeypatch.setenv("LOCAL_SHELL_MCP_SHELL_ENV_BLOCKLIST", "TOKEN_ONE,TOKEN_TWO")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_SHELL_ENV_BLOCKED_PREFIXES", "PRIVATE_,SERVICE_")
     get_settings.cache_clear()
 
     paths = jobs_module._attempt_paths("job_test", 1)
@@ -54,12 +58,14 @@ def test_runner_environment_policy_is_shell_neutral_and_round_trips(tmp_path, mo
     assert "'" not in blocklist_payload
     assert '"' not in prefixes_payload
     assert "'" not in prefixes_payload
-    assert jobs_module._parse_runner_env_policy(
-        blocklist_payload, "env blocklist"
-    ) == ["TOKEN_ONE", "TOKEN_TWO"]
-    assert jobs_module._parse_runner_env_policy(
-        prefixes_payload, "env blocked prefixes"
-    ) == ["PRIVATE_", "SERVICE_"]
+    assert jobs_module._parse_runner_env_policy(blocklist_payload, "env blocklist") == [
+        "TOKEN_ONE",
+        "TOKEN_TWO",
+    ]
+    assert jobs_module._parse_runner_env_policy(prefixes_payload, "env blocked prefixes") == [
+        "PRIVATE_",
+        "SERVICE_",
+    ]
 
     powershell_command = jobs_module._runner_command(argv, "powershell.exe")
     assert blocklist_payload in powershell_command
@@ -117,6 +123,54 @@ async def test_jobs_track_tail_stop_and_retry(tmp_path, monkeypatch):
     assert retried["status"] == "running"
     assert retried["attempts"] == 2
     assert retried["session_id"] != job["session_id"]
+
+
+@pytest.mark.asyncio
+async def test_managed_jobs_track_tail_stop_and_retry(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(tmp_path / ".local-shell-mcp"))
+    get_settings.cache_clear()
+    release = asyncio.Event()
+
+    async def handler(context, payload):
+        await context.log(f"started {payload['value']}")
+        await context.update_progress(phase="waiting", value=payload["value"])
+        await release.wait()
+        await context.log("finished")
+        return {"value": payload["value"]}
+
+    register_managed_job_handler("test-managed", handler)
+    job = await start_managed_job(
+        "test-managed",
+        {"value": 7},
+        name="managed",
+        command="managed test",
+    )
+    assert job["kind"] == "managed"
+    assert job["status"] == "running"
+
+    for _ in range(50):
+        await asyncio.sleep(0.01)
+        tail = await tail_job(job["job_id"])
+        if "started 7" in tail["output"]:
+            break
+    assert tail["job"]["progress"] == {"phase": "waiting", "value": 7}
+
+    stopped = await stop_job(job["job_id"])
+    assert stopped["killed"] is True
+    assert stopped["job"]["status"] == "stopped"
+
+    retried = await retry_job(job["job_id"])
+    assert retried["status"] == "running"
+    assert retried["attempts"] == 2
+    release.set()
+    for _ in range(50):
+        await asyncio.sleep(0.01)
+        current = (await list_jobs())["jobs"][0]
+        if current["status"] != "running":
+            break
+    assert current["status"] == "succeeded"
+    assert current["result"] == {"value": 7}
 
 
 @pytest.mark.asyncio
@@ -429,9 +483,7 @@ async def test_job_store_migrates_v1_without_losing_history(tmp_path, monkeypatc
         },
     ]
     store_path = state_dir / jobs_module.JOB_STORE_FILE_NAME
-    store_path.write_text(
-        json.dumps({"version": 1, "jobs": legacy_jobs}), encoding="utf-8"
-    )
+    store_path.write_text(json.dumps({"version": 1, "jobs": legacy_jobs}), encoding="utf-8")
 
     async def legacy_shells():
         return {"sessions": [{"session_id": "legacy-live-session"}]}
@@ -454,9 +506,7 @@ async def test_job_store_migrates_v1_without_losing_history(tmp_path, monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_job_start_does_not_launch_shell_when_store_is_invalid(
-    tmp_path, monkeypatch
-):
+async def test_job_start_does_not_launch_shell_when_store_is_invalid(tmp_path, monkeypatch):
     state_dir = tmp_path / ".state"
     state_dir.mkdir()
     monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
@@ -497,9 +547,7 @@ async def test_job_start_records_shell_launch_failure(tmp_path, monkeypatch):
     with pytest.raises(RuntimeError, match="shell launch failed"):
         await start_job("echo never-ran")
 
-    stored = json.loads(
-        (state_dir / jobs_module.JOB_STORE_FILE_NAME).read_text(encoding="utf-8")
-    )
+    stored = json.loads((state_dir / jobs_module.JOB_STORE_FILE_NAME).read_text(encoding="utf-8"))
     assert len(stored["jobs"]) == 1
     job = stored["jobs"][0]
     assert job["status"] == "failed"
@@ -511,9 +559,7 @@ async def test_job_start_records_shell_launch_failure(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_job_start_kills_shell_when_running_state_cannot_be_committed(
-    tmp_path, monkeypatch
-):
+async def test_job_start_kills_shell_when_running_state_cannot_be_committed(tmp_path, monkeypatch):
     state_dir = tmp_path / ".state"
     monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
     monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(state_dir))
@@ -624,9 +670,7 @@ async def test_job_list_recovers_interrupted_start(tmp_path, monkeypatch):
     assert "recovered job start" in recovered["job_start_live"]["error"]
     assert recovered["job_start_missing"]["status"] == "failed"
     assert "start was interrupted" in recovered["job_start_missing"]["error"]
-    stored = json.loads(
-        (state_dir / jobs_module.JOB_STORE_FILE_NAME).read_text(encoding="utf-8")
-    )
+    stored = json.loads((state_dir / jobs_module.JOB_STORE_FILE_NAME).read_text(encoding="utf-8"))
     assert all("operation_id" not in job for job in stored["jobs"])
 
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -152,7 +152,10 @@ async def test_managed_jobs_track_tail_stop_and_retry(tmp_path, monkeypatch):
     for _ in range(50):
         await asyncio.sleep(0.01)
         tail = await tail_job(job["job_id"])
-        if "started 7" in tail["output"]:
+        if (
+            "started 7" in tail["output"]
+            and tail["job"]["progress"] == {"phase": "waiting", "value": 7}
+        ):
             break
     assert tail["job"]["progress"] == {"phase": "waiting", "value": 7}
 
@@ -171,6 +174,82 @@ async def test_managed_jobs_track_tail_stop_and_retry(tmp_path, monkeypatch):
             break
     assert current["status"] == "succeeded"
     assert current["result"] == {"value": 7}
+
+
+def test_managed_job_validation_and_lost_recovery():
+    async def first_handler(context, payload):  # noqa: ARG001
+        return payload
+
+    async def second_handler(context, payload):  # noqa: ARG001
+        return payload
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        register_managed_job_handler("   ", first_handler)
+
+    register_managed_job_handler("validation-managed", first_handler)
+    register_managed_job_handler("validation-managed", first_handler)
+    with pytest.raises(ValueError, match="already registered"):
+        register_managed_job_handler("validation-managed", second_handler)
+
+    with pytest.raises(ValueError, match="unknown managed job kind"):
+        asyncio.run(start_managed_job("missing-managed", {}))
+
+    running = jobs_module._refresh_job_status(
+        {"job_id": "managed-running", "kind": "managed", "status": "running"},
+        set(),
+        now=10.0,
+    )
+    assert running["status"] == "lost"
+    assert running["completed_at"] == 10.0
+    assert "retry it" in running["error"]
+
+    stopping = jobs_module._refresh_job_status(
+        {"job_id": "managed-stopping", "kind": "managed", "status": "stopping"},
+        set(),
+        now=11.0,
+    )
+    assert stopping["status"] == "stopped"
+    assert stopping["error"] is None
+
+
+@pytest.mark.asyncio
+async def test_managed_job_failure_and_launch_cleanup(tmp_path, monkeypatch):
+    state_dir = tmp_path / ".state"
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(state_dir))
+    get_settings.cache_clear()
+
+    async def failing_handler(context, payload):  # noqa: ARG001
+        raise RuntimeError("managed failure")
+
+    register_managed_job_handler("failing-managed", failing_handler)
+    failed = await start_managed_job("failing-managed", {})
+    for _ in range(50):
+        await asyncio.sleep(0.01)
+        current = (await list_jobs())["jobs"][0]
+        if current["status"] == "failed":
+            break
+    assert current["status"] == "failed"
+    assert current["exit_code"] == 1
+    assert current["error"] == "RuntimeError: managed failure"
+    assert "managed failure" in (await tail_job(failed["job_id"]))["output"]
+
+    async def idle_handler(context, payload):  # noqa: ARG001
+        return payload
+
+    register_managed_job_handler("launch-failure-managed", idle_handler)
+    def fail_launch(*args, **kwargs):  # noqa: ARG001
+        raise RuntimeError("launch failed")
+
+    monkeypatch.setattr(jobs_module, "_launch_managed_job", fail_launch)
+    with pytest.raises(RuntimeError, match="launch failed"):
+        await start_managed_job("launch-failure-managed", {})
+
+    stored = json.loads((state_dir / jobs_module.JOB_STORE_FILE_NAME).read_text(encoding="utf-8"))
+    assert [job["job_id"] for job in stored["jobs"]] == [failed["job_id"]]
+    assert [path.name for path in (state_dir / "jobs").glob("*-attempt-1.log")] == [
+        f"{failed['job_id']}-attempt-1.log"
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_remote_complete.py
+++ b/tests/test_remote_complete.py
@@ -589,16 +589,19 @@ def test_worker_upload_protocol_and_generated_execution_edges(tmp_path, monkeypa
             args[0], 0, stdout="not-json", stderr=""
         ),
     )
-    with pytest.raises(RuntimeError, match="invalid JSON"):
+    with pytest.raises(RuntimeError, match="invalid response"):
         remote._worker_upload_url("source.bin", url, 7, digest)
     monkeypatch.setattr(
         remote.subprocess,
         "run",
         lambda *args, **kwargs: subprocess.CompletedProcess(
-            args[0], 0, stdout='{"ok":false,"message":"bad"}', stderr=""
+            args[0],
+            0,
+            stdout='{"ok":false,"message":"bad"}\n__LSM_HTTP_STATUS__:400',
+            stderr="",
         ),
     )
-    with pytest.raises(RuntimeError, match="stream upload failed"):
+    with pytest.raises(RuntimeError, match="HTTP 400"):
         remote._worker_upload_url("source.bin", url, 7, digest)
 
     async def fake_run_shell(command, **kwargs):

--- a/tests/test_remote_process_e2e.py
+++ b/tests/test_remote_process_e2e.py
@@ -196,7 +196,7 @@ def test_real_controller_worker_tools_transfers_and_reconnect(tmp_path, monkeypa
                 "process-node", "pushed.bin", "roundtrip.bin", True, None
             )
         )
-        assert pulled["transport"] == "http-stream"
+        assert pulled["transport"] == "http-chunks"
         assert (controller_root / "roundtrip.bin").read_bytes() == local_file.read_bytes()
 
         local_dir = controller_root / "tree"

--- a/tests/test_remote_streaming.py
+++ b/tests/test_remote_streaming.py
@@ -27,7 +27,7 @@ def _client(tmp_path, monkeypatch, *, request_limit: int = 1024) -> TestClient:
     return TestClient(app)
 
 
-def test_stream_upload_bypasses_json_body_limit_and_is_one_time(tmp_path, monkeypatch):
+def test_stream_upload_bypasses_json_body_limit_and_retains_status(tmp_path, monkeypatch):
     client = _client(tmp_path, monkeypatch, request_limit=1024)
     data = (b"streamed-binary-data" * 131072)[:2_000_000]
     digest = hashlib.sha256(data).hexdigest()
@@ -36,9 +36,59 @@ def test_stream_upload_bypasses_json_body_limit_and_is_one_time(tmp_path, monkey
     response = client.put(ticket["url"], content=data)
 
     assert response.status_code == 200
-    assert response.json()["data"]["transport"] == "http-stream"
+    assert response.json()["data"]["transport"] == "http-chunks"
     assert (tmp_path / "artifact.bin").read_bytes() == data
-    assert client.put(ticket["url"], content=data).status_code == 404
+    repeated = client.put(ticket["url"], content=data)
+    assert repeated.status_code == 200
+    assert repeated.json()["data"]["completed"] is True
+    assert revoke_transfer_ticket(ticket["token"])["revoked"] is True
+    assert client.get(ticket["url"]).status_code == 404
+
+
+def test_chunk_upload_tracks_offset_and_rejects_overlap(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch)
+    first = b"first-half"
+    second = b"second-half"
+    data = first + second
+    ticket = create_upload_ticket("artifact.bin", len(data), hashlib.sha256(data).hexdigest())
+    path = ticket["url"]
+
+    response = client.put(
+        path,
+        content=first,
+        headers={
+            "Content-Range": f"bytes 0-{len(first) - 1}/{len(data)}",
+            "X-Chunk-SHA256": hashlib.sha256(first).hexdigest(),
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["data"]["received_bytes"] == len(first)
+    assert response.json()["data"]["completed"] is False
+    assert client.get(path).json()["data"]["received_bytes"] == len(first)
+
+    overlap = client.put(
+        path,
+        content=first,
+        headers={
+            "Content-Range": f"bytes 0-{len(first) - 1}/{len(data)}",
+            "X-Chunk-SHA256": hashlib.sha256(first).hexdigest(),
+        },
+    )
+    assert overlap.status_code == 409
+    assert overlap.json()["data"]["received_bytes"] == len(first)
+
+    response = client.put(
+        path,
+        content=second,
+        headers={
+            "Content-Range": f"bytes {len(first)}-{len(data) - 1}/{len(data)}",
+            "X-Chunk-SHA256": hashlib.sha256(second).hexdigest(),
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["data"]["completed"] is True
+    assert (tmp_path / "artifact.bin").read_bytes() == data
+    revoke_transfer_ticket(ticket["token"])
 
 
 def test_stream_upload_hash_failure_is_transactional(tmp_path, monkeypatch):
@@ -82,9 +132,8 @@ def _worker_identity(tmp_path):
     return path
 
 
-def test_worker_upload_uses_raw_stream_endpoint(tmp_path, monkeypatch):
+def test_worker_upload_uses_raw_chunk_endpoint(tmp_path, monkeypatch):
     import subprocess
-    from pathlib import Path
     from urllib.parse import urlsplit
 
     import local_shell_mcp.remote as remote
@@ -99,21 +148,36 @@ def test_worker_upload_uses_raw_stream_endpoint(tmp_path, monkeypatch):
     monkeypatch.setattr(remote.shutil, "which", lambda name: "/usr/bin/curl")
 
     def fake_run(command, **kwargs):
-        del kwargs
-        upload_path = Path(command[command.index("--upload-file") + 1])
-        response = client.put(urlsplit(command[-1]).path, content=upload_path.read_bytes())
+        headers = {}
+        for index, value in enumerate(command):
+            if value == "-H":
+                name, header_value = command[index + 1].split(":", 1)
+                headers[name] = header_value.strip()
+        response = client.put(
+            urlsplit(command[-1]).path,
+            content=kwargs["input"],
+            headers=headers,
+        )
+        stdout = response.text + f"\n__LSM_HTTP_STATUS__:{response.status_code}"
         return subprocess.CompletedProcess(
             command,
-            0 if response.status_code < 400 else 22,
-            stdout=response.text,
-            stderr="",
+            0,
+            stdout=stdout.encode(),
+            stderr=b"",
         )
 
     monkeypatch.setattr(remote.subprocess, "run", fake_run)
 
-    result = remote._worker_upload_url("source.bin", ticket["url"], len(data), digest, 60)
+    result = remote._worker_upload_url(
+        "source.bin",
+        ticket["url"],
+        len(data),
+        digest,
+        60,
+        chunk_size=len(data),
+    )
 
-    assert result["transport"] == "http-stream"
+    assert result["transport"] == "http-chunks"
     assert (tmp_path / "destination.bin").read_bytes() == data
 
 

--- a/tests/test_remote_streaming.py
+++ b/tests/test_remote_streaming.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import hashlib
 
+import pytest
 from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
+import local_shell_mcp.remote_transfer as remote_transfer
 from local_shell_mcp.auth import RequestBodyLimitMiddleware
 from local_shell_mcp.remote_transfer import (
     _content_disposition,
@@ -89,6 +91,94 @@ def test_chunk_upload_tracks_offset_and_rejects_overlap(tmp_path, monkeypatch):
     assert response.json()["data"]["completed"] is True
     assert (tmp_path / "artifact.bin").read_bytes() == data
     revoke_transfer_ticket(ticket["token"])
+
+
+@pytest.mark.parametrize(
+    "content_range",
+    [
+        "invalid",
+        "bytes 0-0/2",
+        "bytes 1-0/1",
+        "bytes 0-1/1",
+    ],
+)
+def test_chunk_upload_rejects_invalid_ranges(tmp_path, monkeypatch, content_range):
+    client = _client(tmp_path, monkeypatch)
+    data = b"x"
+    ticket = create_upload_ticket("artifact.bin", len(data), hashlib.sha256(data).hexdigest())
+
+    response = client.put(
+        ticket["url"],
+        content=data,
+        headers={"Content-Range": content_range},
+    )
+
+    assert response.status_code == 400
+    assert revoke_transfer_ticket(ticket["token"])["revoked"] is True
+
+
+def test_chunk_upload_rejects_bad_hash_and_oversized_legacy_request(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch)
+    data = b"payload"
+    ticket = create_upload_ticket("artifact.bin", len(data), hashlib.sha256(data).hexdigest())
+
+    response = client.put(
+        ticket["url"],
+        content=data,
+        headers={
+            "Content-Range": f"bytes 0-{len(data) - 1}/{len(data)}",
+            "X-Chunk-SHA256": "0" * 64,
+        },
+    )
+    assert response.status_code == 400
+    revoke_transfer_ticket(ticket["token"])
+
+    oversized = remote_transfer.MAX_TRANSFER_CHUNK_BYTES + 1
+    ticket = create_upload_ticket("oversized.bin", oversized, "0" * 64)
+    response = client.put(ticket["url"], content=b"")
+    assert response.status_code == 400
+    assert "update the remote worker" in response.json()["message"]
+    revoke_transfer_ticket(ticket["token"])
+
+
+def test_upload_status_and_claim_conflicts(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch)
+    data = b"payload"
+    upload = create_upload_ticket("artifact.bin", len(data), hashlib.sha256(data).hexdigest())
+    remote_transfer._claim_ticket(upload["token"], "upload")
+    try:
+        response = client.put(upload["url"], content=data)
+        assert response.status_code == 409
+    finally:
+        remote_transfer._release_ticket(upload["token"])
+        revoke_transfer_ticket(upload["token"])
+
+    source = tmp_path / "source.bin"
+    source.write_bytes(data)
+    download = create_download_ticket("source.bin", len(data), hashlib.sha256(data).hexdigest())
+    status_url = download["url"].replace("/download/", "/upload/")
+    assert client.get(status_url).status_code == 409
+    revoke_transfer_ticket(download["token"])
+
+
+def test_ticket_creation_failures_cleanup_transactions(tmp_path, monkeypatch):
+    _client(tmp_path, monkeypatch)
+    digest = hashlib.sha256(b"payload").hexdigest()
+
+    def fail_create(*args, **kwargs):  # noqa: ARG001
+        raise RuntimeError("ticket creation failed")
+
+    monkeypatch.setattr(remote_transfer, "_create_ticket", fail_create)
+    with pytest.raises(RuntimeError, match="ticket creation failed"):
+        create_upload_ticket("upload.bin", 7, digest)
+    assert not list(tmp_path.glob(".upload.bin.local-shell-mcp-transfer-*.tmp"))
+
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"payload")
+    with pytest.raises(RuntimeError, match="ticket creation failed"):
+        create_download_ticket("source.bin", 7, digest)
+    transfer_dir = tmp_path / ".state" / "remote-transfers"
+    assert not transfer_dir.exists() or not list(transfer_dir.iterdir())
 
 
 def test_stream_upload_hash_failure_is_transactional(tmp_path, monkeypatch):

--- a/tests/test_remote_transfer_tools.py
+++ b/tests/test_remote_transfer_tools.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 from typing import Any
 from urllib.parse import urlsplit
 
@@ -8,6 +9,7 @@ import pytest
 from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
+import local_shell_mcp.jobs as jobs_module
 import local_shell_mcp.tools as tools
 from local_shell_mcp.fs_ops import delete_path, resolve_path
 from local_shell_mcp.remote_transfer import remote_transfer_routes
@@ -70,10 +72,20 @@ class FakeRemoteManager:
                 data = transfer_abort_write(args["path"], args["transfer_id"])
             elif tool == "transfer_upload_url":
                 source = resolve_path(args["path"], must_exist=True)
+                offset = int(args.get("offset", 0))
+                chunk_size = int(args.get("chunk_size") or source.stat().st_size or 1)
+                with source.open("rb") as handle:
+                    handle.seek(offset)
+                    content = handle.read(chunk_size)
+                end = offset + len(content)
+                headers = {"X-Chunk-SHA256": hashlib.sha256(content).hexdigest()}
+                if source.stat().st_size:
+                    headers["Content-Range"] = f"bytes {offset}-{end - 1}/{source.stat().st_size}"
                 response = await asyncio.to_thread(
                     self.client.put,
                     urlsplit(args["url"]).path,
-                    content=source.read_bytes(),
+                    content=content,
+                    headers=headers,
                 )
                 payload = response.json()
                 if response.status_code >= 400 or not payload.get("ok"):
@@ -139,7 +151,7 @@ async def test_remote_copy_file_streams_between_workers(tmp_path, monkeypatch):
     root = _workspace(tmp_path, monkeypatch)
     (root / "src-machine").mkdir()
     (root / "dst-machine").mkdir()
-    data = bytes(range(256)) * 24_000
+    data = bytes(range(256)) * 24
     (root / "src-machine" / "payload.bin").write_bytes(data)
     calls: list[str] = []
     transfer = tools._remote_transfer_data
@@ -151,19 +163,60 @@ async def test_remote_copy_file_streams_between_workers(tmp_path, monkeypatch):
     monkeypatch.setattr(tools, "_remote_transfer_data", record_transfer)
 
     result = await tools._copy_remote_file_to_remote(
-        "src", "src-machine/payload.bin", "dst", "dst-machine/payload.bin", True, 128
+        "src", "src-machine/payload.bin", "dst", "dst-machine/payload.bin", True, 1024
     )
 
-    assert result["chunks"] == 2
-    assert result["chunk_size"] == 128
-    assert result["transport"] == "http-stream-via-controller"
+    assert result["chunks"] == 7
+    assert result["chunk_size"] == 1024
+    assert result["transport"] == "http-chunks-via-controller"
     assert result["bytes"] == len(data)
-    assert calls == [
-        "transfer_stat",
-        "transfer_upload_url",
-        "transfer_download_url",
-    ]
+    assert calls[0] == "transfer_stat"
+    assert calls[1:7] == ["transfer_upload_url"] * 6
+    assert calls[7] == "transfer_download_url"
     assert (root / "dst-machine" / "payload.bin").read_bytes() == data
+
+
+@pytest.mark.asyncio
+async def test_remote_upload_recovers_lost_chunk_acknowledgement(tmp_path, monkeypatch):
+    root = _workspace(tmp_path, monkeypatch)
+    (root / "src-machine").mkdir()
+    payload = bytes(range(256)) * 12
+    (root / "src-machine" / "payload.bin").write_bytes(payload)
+
+    class LostAckManager(FakeRemoteManager):
+        def __init__(self):
+            super().__init__()
+            self.drop_next_ack = True
+            self.upload_calls = 0
+
+        async def call(self, machine, tool, args, timeout_s=None):
+            result = await super().call(machine, tool, args, timeout_s)
+            if tool == "transfer_upload_url":
+                self.upload_calls += 1
+                if self.drop_next_ack:
+                    self.drop_next_ack = False
+                    return {
+                        "ok": False,
+                        "error": "ConnectionError",
+                        "message": "response lost after commit",
+                    }
+            return result
+
+    manager = LostAckManager()
+    monkeypatch.setattr(tools, "remote_manager", lambda: manager)
+
+    result = await tools._copy_remote_file_to_local(
+        "src",
+        "src-machine/payload.bin",
+        "copied.bin",
+        True,
+        1024,
+    )
+
+    assert result["transport"] == "http-chunks"
+    assert result["chunks"] == 3
+    assert manager.upload_calls == 3
+    assert (root / "copied.bin").read_bytes() == payload
 
 
 @pytest.mark.asyncio
@@ -172,9 +225,42 @@ async def test_streaming_transfer_preserves_chunk_size_validation(tmp_path, monk
     (root / "payload.bin").write_bytes(b"content")
 
     with pytest.raises(ValueError, match="chunk_size must be greater than zero"):
-        await tools._copy_local_file_to_remote(
-            "payload.bin", "dst", "copied.bin", True, 0
-        )
+        await tools._copy_local_file_to_remote("payload.bin", "dst", "copied.bin", True, 0)
+
+
+@pytest.mark.asyncio
+async def test_transfer_path_starts_tracked_managed_job(tmp_path, monkeypatch):
+    root = _workspace(tmp_path, monkeypatch)
+    (root / "src-machine").mkdir()
+    payload = bytes(range(256)) * 12
+    (root / "src-machine" / "payload.bin").write_bytes(payload)
+
+    job = await tools._start_transfer_job(
+        "src-machine/payload.bin",
+        "copied.bin",
+        source_machine="src",
+        overwrite=True,
+        chunk_size=1024,
+    )
+
+    assert job["kind"] == "managed"
+    assert job["backend"] == "managed"
+    assert job["status"] == "running"
+
+    current = job
+    for _ in range(100):
+        await asyncio.sleep(0.01)
+        current = (await jobs_module.list_jobs())["jobs"][0]
+        if current["status"] != "running":
+            break
+
+    assert current["status"] == "succeeded"
+    assert current["progress"]["phase"] == "completed"
+    assert current["result"]["transport"] == "http-chunks"
+    assert (root / "copied.bin").read_bytes() == payload
+    tail = await jobs_module.tail_job(job["job_id"])
+    assert "transfer started" in tail["output"]
+    assert "transfer completed" in tail["output"]
 
 
 @pytest.mark.asyncio
@@ -182,15 +268,13 @@ async def test_remote_copy_dir_packs_transfers_and_unpacks(tmp_path, monkeypatch
     root = _workspace(tmp_path, monkeypatch)
     (root / "src-machine" / "run" / "nested").mkdir(parents=True)
     (root / "dst-machine").mkdir()
-    (root / "src-machine" / "run" / "nested" / "result.txt").write_text(
-        "ok", encoding="utf-8"
-    )
+    (root / "src-machine" / "run" / "nested" / "result.txt").write_text("ok", encoding="utf-8")
 
     result = await tools._copy_remote_dir_to_remote(
         "src", "src-machine/run", "dst", "dst-machine/run-copy", True, 256
     )
 
     assert result["entries"] >= 1
-    assert (
-        root / "dst-machine" / "run-copy" / "nested" / "result.txt"
-    ).read_text(encoding="utf-8") == "ok"
+    assert (root / "dst-machine" / "run-copy" / "nested" / "result.txt").read_text(
+        encoding="utf-8"
+    ) == "ok"

--- a/tests/test_tools_complete.py
+++ b/tests/test_tools_complete.py
@@ -107,7 +107,7 @@ async def test_all_public_tool_wrappers_local_and_remote(tmp_path, monkeypatch):
         "retry_job",
         "tree",
         "_apply_patch_text",
-        "_transfer_path",
+        "_start_transfer_job",
         "_secret_scan",
         "browser_capture",
         "browser_get_text",
@@ -258,7 +258,7 @@ async def test_tool_wrapper_error_paths_and_remote_disabled(tmp_path, monkeypatc
     monkeypatch.setattr(tools, "edit_text", fail_sync)
     monkeypatch.setattr(tools, "delete_path", fail_sync)
     monkeypatch.setattr(tools, "_apply_patch_text", fail_async)
-    monkeypatch.setattr(tools, "_transfer_path", fail_async)
+    monkeypatch.setattr(tools, "_start_transfer_job", fail_async)
     monkeypatch.setattr(tools, "_secret_scan", fail_async)
     monkeypatch.setattr(tools, "todo_read", fail_sync)
     monkeypatch.setattr(tools, "todo_write", fail_sync)


### PR DESCRIPTION
## Summary

- make `transfer_path` return immediately with a tracked managed job
- support transfer progress, logs, stop, and retry through the existing `job_*` tools
- replace worker-to-controller whole-file PUTs with transactional raw-binary chunks
- recover safely when a chunk is committed but its response is lost
- keep per-chunk and final SHA-256 validation and bounded request sizes
- group transfer tools and lifecycle events under `remote` in Audit; keep file-link tools under `files`
- update English, Simplified Chinese, and Traditional Chinese documentation

## Validation

- `ruff check src tests`
- `python -m pytest -q` — 534 passed
