### PR TITLE
feat: auto-upgrade remote workers during polling

### DIFF
--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -82,6 +82,7 @@ from .version import version_info as get_version_info
 REMOTE_JOIN_PATH = "/join"
 REMOTE_API_PREFIX = "/remote"
 REMOTE_WORKER_BUNDLE_PATH = "/remote/worker-bundle.tgz"
+REMOTE_WORKER_POLL_PROTOCOL_VERSION = 1
 # The remote worker is designed to start on machines that only have Python, curl,
 # and tar. Keep this empty unless a dependency is pure Python and imported on the
 # worker startup path. Tool-specific dependencies such as Playwright should be
@@ -495,21 +496,38 @@ class RemoteManager:
             self._cancel_job_locked(job_id)
             return True
 
-    async def poll(self, token: str) -> dict[str, Any]:
+    async def poll(
+        self, token: str, payload: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
         worker = self._worker_by_token(token)
+        payload = payload or {}
+        worker_version = str(payload.get("worker_version") or "")
+        protocol_version = int(payload.get("protocol_version") or 0)
+        upgrade = None
+        if protocol_version >= REMOTE_WORKER_POLL_PROTOCOL_VERSION:
+            upgrade = {
+                "required": worker_version != __version__,
+                "version": __version__,
+            }
         with self._state_lock:
             worker.status = "online"
             worker.last_seen = _utc()
+            if worker_version:
+                worker.info["lsm_version"] = worker_version
+            if protocol_version:
+                worker.info["poll_protocol_version"] = protocol_version
+        if upgrade and upgrade["required"]:
+            return {"job": None, "upgrade": upgrade}
         loop = asyncio.get_running_loop()
         deadline = loop.time() + get_settings().remote_poll_timeout_s
         while True:
             remaining = deadline - loop.time()
             if remaining <= 0:
-                return {"job": None, "heartbeat": True}
+                return {"job": None, "heartbeat": True, "upgrade": upgrade}
             try:
                 job = await asyncio.wait_for(worker.queue.get(), timeout=remaining)
             except TimeoutError:
-                return {"job": None, "heartbeat": True}
+                return {"job": None, "heartbeat": True, "upgrade": upgrade}
             job_id = str(job.get("id") or "")
             with self._state_lock:
                 self._prune_cancelled_jobs_locked()
@@ -517,7 +535,7 @@ class RemoteManager:
                     self.cancelled_jobs.pop(job_id, None)
                     continue
                 self.claimed_jobs.add(job_id)
-            return {"job": job}
+            return {"job": job, "upgrade": upgrade}
 
     async def heartbeat(self, token: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
         worker = self._worker_by_token(token)
@@ -851,7 +869,9 @@ async def poll_endpoint(request: Any):  # noqa: ANN201
     from starlette.responses import JSONResponse
 
     try:
-        return JSONResponse(_ok(await remote_manager().poll(_bearer_token(request))))
+        return JSONResponse(
+            _ok(await remote_manager().poll(_bearer_token(request), await request.json()))
+        )
     except Exception as exc:
         return _error(str(exc), type(exc).__name__, 401)
 
@@ -1513,6 +1533,45 @@ def worker_info(workdir: str) -> dict[str, Any]:
     }
 
 
+def _worker_poll_payload() -> dict[str, Any]:
+    return {
+        "protocol_version": REMOTE_WORKER_POLL_PROTOCOL_VERSION,
+        "worker_version": __version__,
+    }
+
+
+def _reexec_updated_worker_runtime() -> None:
+    from .remote_worker_cli import _worker_run_exec_argv
+    from .remote_worker_state import worker_runtime_dir
+
+    runtime = worker_runtime_dir()
+    preferred = [str(runtime), str(runtime / "vendor")]
+    current = [entry for entry in os.environ.get("PYTHONPATH", "").split(os.pathsep) if entry]
+    os.environ["PYTHONPATH"] = os.pathsep.join(
+        preferred + [entry for entry in current if entry not in preferred]
+    )
+    argv = _worker_run_exec_argv()
+    os.execv(argv[0], argv)
+
+
+async def _upgrade_worker_runtime(server: str, target_version: str) -> None:
+    from .remote_worker_installer import install_or_update_runtime
+
+    result = await asyncio.to_thread(install_or_update_runtime, server)
+    installed_version = str(result.get("version") or "")
+    if target_version and installed_version != target_version:
+        raise RuntimeError(
+            f"controller requested worker {target_version}, but manifest provides "
+            f"{installed_version or 'no version'}"
+        )
+    print(
+        f"Status: worker runtime updated to {installed_version or 'unknown'}; restarting...",
+        file=sys.stderr,
+        flush=True,
+    )
+    _reexec_updated_worker_runtime()
+
+
 def _parse_worker_http_json(url: str, status_code: int, response_body: str) -> dict[str, Any]:
     if not 200 <= status_code < 300:
         detail = response_body.strip() or "<empty response body>"
@@ -1880,11 +1939,28 @@ async def run_worker(
         flush=True,
     )
     headers = {"Author" + "ization": "B" + "earer " + access}
+    upgrade_attempt = 0
     while True:
         poll_body = await _worker_post_json_forever(
-            f"{server}{REMOTE_API_PREFIX}/poll", {}, headers, None, "poll"
+            f"{server}{REMOTE_API_PREFIX}/poll",
+            _worker_poll_payload(),
+            headers,
+            None,
+            "poll",
         )
         payload = poll_body.get("data", {})
+        upgrade = payload.get("upgrade") if isinstance(payload, dict) else None
+        if isinstance(upgrade, dict) and upgrade.get("required"):
+            target_version = str(upgrade.get("version") or "")
+            try:
+                await _upgrade_worker_runtime(server, target_version)
+            except Exception as exc:  # noqa: BLE001
+                delay_s = _worker_retry_delay(upgrade_attempt)
+                upgrade_attempt += 1
+                _worker_log_retry("worker upgrade", exc, delay_s)
+                await asyncio.sleep(delay_s)
+            continue
+        upgrade_attempt = 0
         job = payload.get("job")
         if not job:
             continue

--- a/src/local_shell_mcp/remote_worker_installer.py
+++ b/src/local_shell_mcp/remote_worker_installer.py
@@ -22,7 +22,11 @@ _WORKER_MANIFEST_PATH = "/remote/worker-bundle.tgz?manifest=1"
 
 
 def _fetch_bytes(url: str, timeout: float = 60) -> bytes:
-    with urllib.request.urlopen(url, timeout=timeout) as response:  # noqa: S310
+    request = urllib.request.Request(
+        url,
+        headers={"Cache-Control": "no-cache", "Pragma": "no-cache"},
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
         return response.read()
 
 

--- a/src/local_shell_mcp/remote_worker_routes.py
+++ b/src/local_shell_mcp/remote_worker_routes.py
@@ -59,12 +59,13 @@ def _worker_manifest_data() -> dict[str, Any]:
     settings = get_settings()
     server = (settings.public_base_url or f"http://{settings.host}:{settings.port}").rstrip("/")
     payload = worker_bundle_bytes()
+    digest = hashlib.sha256(payload).hexdigest()
     return {
         "schema_version": 1,
         "bundle_version": __version__,
-        "sha256": hashlib.sha256(payload).hexdigest(),
+        "sha256": digest,
         "size": len(payload),
-        "url": server + remote.REMOTE_WORKER_BUNDLE_PATH,
+        "url": server + remote.REMOTE_WORKER_BUNDLE_PATH + f"?sha256={digest}",
     }
 
 
@@ -73,14 +74,18 @@ async def worker_bundle(request: Any):  # noqa: ANN201
 
     query = getattr(request, "query_params", {}) if request is not None else {}
     if query.get("manifest") == "1":
-        return JSONResponse(_worker_manifest_data())
-    return Response(worker_bundle_bytes(), media_type="application/gzip")
+        return JSONResponse(_worker_manifest_data(), headers={"Cache-Control": "no-store"})
+    return Response(
+        worker_bundle_bytes(),
+        media_type="application/gzip",
+        headers={"Cache-Control": "no-store"},
+    )
 
 
 async def worker_manifest(request: Any):  # noqa: ARG001, ANN201
     from starlette.responses import JSONResponse
 
-    return JSONResponse(_worker_manifest_data())
+    return JSONResponse(_worker_manifest_data(), headers={"Cache-Control": "no-store"})
 
 
 async def join_script(request: Any):  # noqa: ARG001, ANN201

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -70,6 +70,43 @@ async def test_timed_out_remote_job_is_skipped_on_next_poll(tmp_path, monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_poll_requires_upgrade_before_dequeuing_jobs(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(tmp_path / ".state"))
+    get_settings.cache_clear()
+    manager = remote.RemoteManager()
+    worker = remote.RemoteWorker(name="worker-a", token="token-a")
+    manager.workers[worker.name] = worker
+    manager.tokens[worker.token] = worker.name
+    worker.queue.put_nowait({"id": "job-valid", "tool": "list_files", "args": {}})
+
+    mismatch = await manager.poll(
+        worker.token,
+        {
+            "protocol_version": remote.REMOTE_WORKER_POLL_PROTOCOL_VERSION,
+            "worker_version": "0.0.0",
+        },
+    )
+
+    assert mismatch == {
+        "job": None,
+        "upgrade": {"required": True, "version": remote.__version__},
+    }
+    assert worker.queue.qsize() == 1
+    assert worker.info["lsm_version"] == "0.0.0"
+
+    matched = await manager.poll(
+        worker.token,
+        {
+            "protocol_version": remote.REMOTE_WORKER_POLL_PROTOCOL_VERSION,
+            "worker_version": remote.__version__,
+        },
+    )
+    assert matched["job"]["id"] == "job-valid"
+    assert matched["upgrade"] == {"required": False, "version": remote.__version__}
+
+
+@pytest.mark.asyncio
 async def test_remote_queue_is_bounded_per_worker(tmp_path, monkeypatch):
     monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
     monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(tmp_path / ".state"))
@@ -216,6 +253,62 @@ def test_worker_post_json_urllib_reports_non_2xx_body(monkeypatch):
 
 def test_worker_retry_delay_is_capped():
     assert [remote._worker_retry_delay(i) for i in range(7)] == [1.0, 2.0, 4.0, 8.0, 16.0, 30.0, 30.0]  # noqa: SLF001
+
+
+def test_reexec_updated_worker_runtime_prefers_installed_bundle(tmp_path, monkeypatch):
+    from local_shell_mcp import remote_worker_cli
+
+    state_dir = tmp_path / "state"
+    runtime = state_dir / "runtime"
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKER_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("PYTHONPATH", "/old/runtime:/other")
+    monkeypatch.setattr(
+        remote_worker_cli,
+        "_worker_run_exec_argv",
+        lambda: [sys.executable, "-m", "local_shell_mcp.main", "worker", "run"],
+    )
+    calls = []
+    monkeypatch.setattr(remote.os, "execv", lambda executable, argv: calls.append((executable, argv)))
+
+    remote._reexec_updated_worker_runtime()  # noqa: SLF001
+
+    pythonpath = remote.os.environ["PYTHONPATH"].split(remote.os.pathsep)
+    assert pythonpath[:2] == [str(runtime), str(runtime / "vendor")]
+    assert pythonpath[2:] == ["/old/runtime", "/other"]
+    assert calls == [
+        (
+            sys.executable,
+            [sys.executable, "-m", "local_shell_mcp.main", "worker", "run"],
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_upgrade_worker_runtime_validates_manifest_version(monkeypatch):
+    from local_shell_mcp import remote_worker_installer
+
+    monkeypatch.setattr(
+        remote_worker_installer,
+        "install_or_update_runtime",
+        lambda server: {"version": "3.1.0"},
+    )
+    monkeypatch.setattr(
+        remote,
+        "_reexec_updated_worker_runtime",
+        lambda: pytest.fail("re-executed mismatched runtime"),
+    )
+    with pytest.raises(RuntimeError, match="manifest provides 3.1.0"):
+        await remote._upgrade_worker_runtime("https://example.test", "3.2.0")  # noqa: SLF001
+
+    calls = []
+    monkeypatch.setattr(
+        remote_worker_installer,
+        "install_or_update_runtime",
+        lambda server: {"version": "3.2.0"},
+    )
+    monkeypatch.setattr(remote, "_reexec_updated_worker_runtime", lambda: calls.append("reexec"))
+    await remote._upgrade_worker_runtime("https://example.test", "3.2.0")  # noqa: SLF001
+    assert calls == ["reexec"]
 
 
 def test_worker_cli_keyboard_interrupt_exits_cleanly():

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -261,7 +261,7 @@ def test_reexec_updated_worker_runtime_prefers_installed_bundle(tmp_path, monkey
     state_dir = tmp_path / "state"
     runtime = state_dir / "runtime"
     monkeypatch.setenv("LOCAL_SHELL_MCP_WORKER_STATE_DIR", str(state_dir))
-    monkeypatch.setenv("PYTHONPATH", "/old/runtime:/other")
+    monkeypatch.setenv("PYTHONPATH", remote.os.pathsep.join(("/old/runtime", "/other")))
     monkeypatch.setattr(
         remote_worker_cli,
         "_worker_run_exec_argv",

--- a/tests/test_remote_worker_cli.py
+++ b/tests/test_remote_worker_cli.py
@@ -76,6 +76,48 @@ async def test_run_worker_overrides_stale_scope(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_run_worker_reports_version_and_applies_poll_upgrade(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_ALLOW_FULL_CONTAINER", "false")
+    monkeypatch.setattr(cli.remote, "worker_capabilities", lambda: [])
+    monkeypatch.setattr(cli.remote, "worker_info", lambda workdir: {})
+    monkeypatch.setattr(cli.remote, "_read_worker_identity", lambda server, name=None: None)
+    monkeypatch.setattr(cli.remote, "_write_worker_identity", lambda data: None)
+    calls = []
+
+    async def fake_post(url, payload, headers=None, timeout=None, operation="request"):
+        calls.append((url, payload, headers, timeout, operation))
+        if url.endswith("/remote/register"):
+            return {"ok": True, "data": {"token": "access", "name": "worker"}}
+        return {
+            "ok": True,
+            "data": {
+                "job": None,
+                "upgrade": {"required": True, "version": "9.9.9"},
+            },
+        }
+
+    async def fake_upgrade(server, target_version):
+        assert server == "https://example.test"
+        assert target_version == "9.9.9"
+        raise SystemExit(0)
+
+    monkeypatch.setattr(cli.remote, "_worker_post_json_forever", fake_post)
+    monkeypatch.setattr(cli.remote, "_upgrade_worker_runtime", fake_upgrade)
+
+    with pytest.raises(SystemExit):
+        await cli.remote.run_worker(
+            "https://example.test", "invite", workdir=str(tmp_path)
+        )
+
+    poll_payload = calls[1][1]
+    assert poll_payload == {
+        "protocol_version": cli.remote.REMOTE_WORKER_POLL_PROTOCOL_VERSION,
+        "worker_version": cli.remote.__version__,
+    }
+
+
+@pytest.mark.asyncio
 async def test_enroll_worker_registers_and_persists(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
     monkeypatch.setattr(cli.remote, "worker_capabilities", lambda: ["shell"])

--- a/tests/test_remote_worker_installer.py
+++ b/tests/test_remote_worker_installer.py
@@ -128,10 +128,14 @@ def test_fetch_bytes_uses_urlopen(monkeypatch):
     monkeypatch.setattr(
         installer.urllib.request,
         "urlopen",
-        lambda url, timeout=60: captured.append((url, timeout)) or Response(),
+        lambda request, timeout=60: captured.append((request, timeout)) or Response(),
     )
     assert installer._fetch_bytes("https://example.test/file", timeout=7) == b"payload"  # noqa: SLF001
-    assert captured == [("https://example.test/file", 7)]
+    request, timeout = captured[0]
+    assert request.full_url == "https://example.test/file"
+    assert request.headers["Cache-control"] == "no-cache"
+    assert request.headers["Pragma"] == "no-cache"
+    assert timeout == 7
 
 
 def test_install_without_existing_config_rejects_incomplete_bundle(tmp_path, monkeypatch):

--- a/tests/test_remote_worker_routes.py
+++ b/tests/test_remote_worker_routes.py
@@ -24,12 +24,17 @@ async def test_worker_bundle_and_manifest_are_stable(tmp_path, monkeypatch):
     response = await routes.worker_manifest(None)  # type: ignore[arg-type]
     data = json.loads(response.body)
     assert data["sha256"] == hashlib.sha256(first).hexdigest()
-    assert data["url"] == "https://example.test/remote/worker-bundle.tgz"
+    assert data["url"] == (
+        "https://example.test/remote/worker-bundle.tgz?sha256=" + data["sha256"]
+    )
+    assert response.headers["cache-control"] == "no-store"
 
     public_manifest = await routes.worker_bundle(SimpleNamespace(query_params={"manifest": "1"}))
     assert json.loads(public_manifest.body) == data
+    assert public_manifest.headers["cache-control"] == "no-store"
     bundle = await routes.worker_bundle(None)  # type: ignore[arg-type]
     assert bundle.body == first
+    assert bundle.headers["cache-control"] == "no-store"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- include the worker protocol/version in every poll request and compare it with the controller version
- withhold queued user jobs while versions differ, then atomically install and re-exec the worker runtime
- prevent stale proxy caches with no-store responses, cache-bypass requests, and digest-qualified bundle URLs
- keep legacy workers compatible by only enabling automatic gating after they advertise the new poll protocol

## Migration
Workers already running a pre-feature release need one final manual update/restart to gain the poll protocol. After that, future controller releases are detected and applied automatically on the next poll.

## Validation
- Ruff: passed
- Full Python suite: 547 passed
- Python branch coverage before rebase: 93.9% (threshold: 93%)
- Secret scan: no findings