### PR TITLE
chore: prepare v3.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "local-shell-mcp"
-version = "3.1.0"
+version = "3.1.1"
 description = "A ChatGPT-compatible OAuth MCP server that gives AI coding agents controlled shell, filesystem, remote-worker, and Playwright access inside a local container."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/local_shell_mcp/__init__.py
+++ b/src/local_shell_mcp/__init__.py
@@ -1,3 +1,3 @@
 """local-shell-mcp."""
 
-__version__ = "3.1.0"
+__version__ = "3.1.1"


### PR DESCRIPTION
## Summary

- bump the project version to 3.1.1
- keep the package runtime version in sync

## Validation

- built wheel and source distribution locally
- verified both artifacts use version 3.1.1