### PR TITLE
fix: contain Audit image previews

### DIFF
--- a/ui/src/audit-screen.tsx
+++ b/ui/src/audit-screen.tsx
@@ -1,3 +1,4 @@
+import type { Renderable } from "@opentui/core"
 import { useKeyboard } from "@opentui/react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { api, formatError } from "./api"
@@ -14,7 +15,7 @@ import {
 import { EmptyState, KeyHint, Loading, Modal, Panel, useVisibleRows } from "./components"
 import { ImagePreviewView } from "./image-preview-view"
 import { handleSelectionScroll } from "./mouse"
-import { clampIndex } from "./state-utils"
+import { clampIndex, nextPreviewMeasurement } from "./state-utils"
 import { HighlightedText } from "./syntax-highlight"
 import { parseTerminalCellAspect } from "./terminal-geometry"
 import { screenTheme, theme } from "./theme"
@@ -82,12 +83,14 @@ export function AuditScreen({
   const [loading, setLoading] = useState(true)
   const [loaded, setLoaded] = useState(false)
   const [detail, setDetail] = useState<AuditEntry | null>(null)
+  const [previewBounds, setPreviewBounds] = useState({ columns: 8, rows: 4 })
   const refreshRequest = useRef(0)
   const refreshController = useRef<AbortController | null>(null)
   const detailRequest = useRef(0)
   const detailController = useRef<AbortController | null>(null)
   const entriesRef = useRef<AuditEntry[]>([])
   const selectedRef = useRef(0)
+  const measuredPreviewViewport = useRef("")
 
   const nodes = useMemo(() => ["", ...machines.map((machine) => machine.name)], [machines])
   const selectedNode = nodes[nodeIndex] || ""
@@ -104,14 +107,7 @@ export function AuditScreen({
     ? Math.max(6, height - 15)
     : auditStackedVisibleRows(height, stackedDetailHeight, hasFilterSummary)
   const { rows, start } = useVisibleRows(entries, selected, tableHeight)
-  const previewColumns = Math.max(
-    8,
-    Math.min(200, horizontal ? width - listLayout.paneWidth - 8 : width - 8),
-  )
-  const previewRows = Math.max(
-    4,
-    Math.min(100, Math.floor((horizontal ? height - 12 : stackedDetailHeight - 8) / 2)),
-  )
+  const previewViewport = `${width}x${height}:${horizontal ? `split-${listLayout.paneWidth}` : "stacked"}:${hasFilterSummary ? "filtered" : "plain"}`
 
   const selectIndex = useCallback((next: number | ((value: number) => number)) => {
     const resolved = typeof next === "function" ? next(selectedRef.current) : next
@@ -190,7 +186,13 @@ export function AuditScreen({
     setDetail(null)
     if (!current?.id) return () => controller.abort()
     void api
-      .auditDetail(current.id, previewColumns, previewRows, terminalCellAspect, controller.signal)
+      .auditDetail(
+        current.id,
+        previewBounds.columns,
+        previewBounds.rows,
+        terminalCellAspect,
+        controller.signal,
+      )
       .then((entry) => {
         if (requestId === detailRequest.current && !controller.signal.aborted) setDetail(entry)
       })
@@ -204,7 +206,14 @@ export function AuditScreen({
       controller.abort()
       if (detailController.current === controller) detailController.current = null
     }
-  }, [current?.id, current?.paired, current?.status, previewColumns, previewRows, setStatus])
+  }, [
+    current?.id,
+    current?.paired,
+    current?.status,
+    previewBounds.columns,
+    previewBounds.rows,
+    setStatus,
+  ])
 
   useEffect(() => {
     onInteractionLockChange(dialog.type !== "none")
@@ -363,20 +372,60 @@ export function AuditScreen({
                 fg={theme.faint}
                 content={`${new Date(displayed.ts * 1000).toLocaleString()} · ${displayed.node}${duration ? ` · ${duration}` : ""}`}
               />
-              <Panel title="Call result" style={{ flexGrow: 1, padding: 1 }}>
-                {displayed.image_preview?.kind === "image" ? (
-                  <ImagePreviewView
-                    preview={displayed.image_preview}
-                    title={String(displayed.image_preview.path || "Image result")}
-                  />
-                ) : (
-                  <scrollbox focused={false} style={{ flexGrow: 1 }} scrollY verticalScrollbarOptions={{ visible: true }}>
-                    <HighlightedText content={outputText} baseColor={theme.muted} />
-                  </scrollbox>
-                )}
+              <Panel
+                title="Call result"
+                style={{ flexGrow: 1, minHeight: 0, overflow: "hidden", padding: 1 }}
+              >
+                <box
+                  style={{
+                    flexGrow: 1,
+                    minWidth: 0,
+                    minHeight: 0,
+                    overflow: "hidden",
+                    flexDirection: "column",
+                  }}
+                  onSizeChange={function (this: Renderable) {
+                    const measurement = nextPreviewMeasurement(
+                      measuredPreviewViewport.current,
+                      previewViewport,
+                      this.width,
+                      this.height,
+                    )
+                    if (!measurement) return
+                    measuredPreviewViewport.current = measurement.viewport
+                    setPreviewBounds({
+                      columns: Math.min(200, measurement.columns),
+                      rows: Math.min(100, measurement.rows),
+                    })
+                  }}
+                >
+                  {displayed.image_preview?.kind === "image" ? (
+                    <ImagePreviewView
+                      preview={displayed.image_preview}
+                      title={String(displayed.image_preview.path || "Image result")}
+                    />
+                  ) : (
+                    <scrollbox
+                      focused={false}
+                      style={{ flexGrow: 1, minWidth: 0, minHeight: 0 }}
+                      scrollY
+                      verticalScrollbarOptions={{ visible: true }}
+                    >
+                      <HighlightedText content={outputText} baseColor={theme.muted} />
+                    </scrollbox>
+                  )}
+                </box>
               </Panel>
-              <Panel title="Call input" style={{ flexGrow: 1, padding: 1 }}>
-                <scrollbox focused={false} style={{ flexGrow: 1 }} scrollY verticalScrollbarOptions={{ visible: true }}>
+              <Panel
+                title="Call input"
+                style={{ flexGrow: 1, minHeight: 0, overflow: "hidden", padding: 1 }}
+              >
+                <scrollbox
+                  focused={false}
+                  style={{ flexGrow: 1, minWidth: 0, minHeight: 0 }}
+                  scrollY
+                  verticalScrollbarOptions={{ visible: true }}
+                >
                   <HighlightedText content={inputText} baseColor={theme.faint} />
                 </scrollbox>
               </Panel>

--- a/ui/src/image-preview-view.tsx
+++ b/ui/src/image-preview-view.tsx
@@ -34,7 +34,17 @@ export function ImagePreviewView({
   }
 
   return (
-    <box style={{ flexGrow: 1, flexDirection: "column", alignItems: "center", justifyContent: "center" }}>
+    <box
+      style={{
+        flexGrow: 1,
+        minWidth: 0,
+        minHeight: 0,
+        overflow: "hidden",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
       <box
         style={{ width: cellWidth, height: cellHeight, flexShrink: 0 }}
         renderAfter={drawPixels}


### PR DESCRIPTION
## Summary
- size Audit image thumbnails from the actual Call result viewport
- clip result/input content to their panels so previews cannot bleed across borders
- reuse one measurement per viewport to avoid resize/refetch oscillation

## Validation
- `bun test` (98 passed)
- `bun run typecheck`
- `bun run build:tui`
- `python3 -m pytest -q tests/test_human_ui_complete.py tests/test_view_image.py` (24 passed)
- visually checked 1400×900, 1200×760, 1000×700, and 800×600 WebUI TUI viewports