### PR TITLE
feat: diagnose stale calls to deprecated tools

### DIFF
--- a/src/local_shell_mcp/deprecated_tools.py
+++ b/src/local_shell_mcp/deprecated_tools.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from mcp.server import fastmcp as fastmcp_module
+from mcp.server.fastmcp import FastMCP as _FastMCP
+
+DEPRECATED_TOOL_HELP_URL = "https://github.com/fwerkor/local-shell-mcp/issues/70"
+
+
+@dataclass(frozen=True, slots=True)
+class DeprecatedTool:
+    replacement: str
+    removed_in: str = "3.0.0"
+
+
+DEPRECATED_TOOLS: dict[str, DeprecatedTool] = {
+    "version_info": DeprecatedTool("environment_info"),
+    "read_many_files": DeprecatedTool("read_file"),
+    "multi_edit_file": DeprecatedTool("edit_file"),
+    "git_clone_tool": DeprecatedTool("run_shell_tool"),
+    "git_status_tool": DeprecatedTool("run_shell_tool"),
+    "git_diff_tool": DeprecatedTool("run_shell_tool"),
+    "git_log_tool": DeprecatedTool("run_shell_tool"),
+    "git_checkout_tool": DeprecatedTool("run_shell_tool"),
+    "git_fetch_tool": DeprecatedTool("run_shell_tool"),
+    "git_pull_tool": DeprecatedTool("run_shell_tool"),
+    "git_add_tool": DeprecatedTool("run_shell_tool"),
+    "git_commit_tool": DeprecatedTool("run_shell_tool"),
+    "git_push_tool": DeprecatedTool("run_shell_tool"),
+    "git_show_tool": DeprecatedTool("run_shell_tool"),
+    "git_reset_tool": DeprecatedTool("run_shell_tool"),
+    "playwright_install_tool": DeprecatedTool("run_shell_tool"),
+    "browser_screenshot_tool": DeprecatedTool("browser_capture_tool"),
+    "browser_eval_tool": DeprecatedTool("playwright_run_script_tool"),
+    "browser_pdf_tool": DeprecatedTool("browser_capture_tool"),
+    "remote_environment_info": DeprecatedTool("environment_info"),
+    "remote_run_shell_tool": DeprecatedTool("run_shell_tool"),
+    "remote_run_python_tool": DeprecatedTool("run_python_tool"),
+    "remote_shell_start": DeprecatedTool("shell_start"),
+    "remote_shell_send": DeprecatedTool("shell_send"),
+    "remote_shell_read": DeprecatedTool("shell_read"),
+    "remote_shell_kill": DeprecatedTool("shell_kill"),
+    "remote_shell_list": DeprecatedTool("shell_list"),
+    "remote_job_start": DeprecatedTool("job_start"),
+    "remote_job_list": DeprecatedTool("job_list"),
+    "remote_job_tail": DeprecatedTool("job_tail"),
+    "remote_job_stop": DeprecatedTool("job_stop"),
+    "remote_job_retry": DeprecatedTool("job_retry"),
+    "remote_list_files": DeprecatedTool("list_files"),
+    "remote_tree_view": DeprecatedTool("tree_view"),
+    "remote_glob_search": DeprecatedTool("glob_search"),
+    "remote_grep_search": DeprecatedTool("grep_search"),
+    "remote_read_file": DeprecatedTool("read_file"),
+    "remote_read_many_files": DeprecatedTool("read_file"),
+    "remote_write_file": DeprecatedTool("write_file"),
+    "remote_edit_file": DeprecatedTool("edit_file"),
+    "remote_multi_edit_file": DeprecatedTool("edit_file"),
+    "remote_delete_file_or_dir": DeprecatedTool("delete_file_or_dir"),
+    "remote_apply_patch": DeprecatedTool("apply_patch"),
+    "remote_copy_file": DeprecatedTool("transfer_path"),
+    "remote_copy_dir": DeprecatedTool("transfer_path"),
+    "remote_pull_file": DeprecatedTool("transfer_path"),
+    "remote_push_file": DeprecatedTool("transfer_path"),
+    "remote_pull_dir": DeprecatedTool("transfer_path"),
+    "remote_push_dir": DeprecatedTool("transfer_path"),
+    "remote_git_clone_tool": DeprecatedTool("run_shell_tool"),
+    "remote_git_status_tool": DeprecatedTool("run_shell_tool"),
+    "remote_git_diff_tool": DeprecatedTool("run_shell_tool"),
+    "remote_git_log_tool": DeprecatedTool("run_shell_tool"),
+    "remote_git_checkout_tool": DeprecatedTool("run_shell_tool"),
+    "remote_git_fetch_tool": DeprecatedTool("run_shell_tool"),
+    "remote_git_pull_tool": DeprecatedTool("run_shell_tool"),
+    "remote_git_add_tool": DeprecatedTool("run_shell_tool"),
+    "remote_git_commit_tool": DeprecatedTool("run_shell_tool"),
+    "remote_git_push_tool": DeprecatedTool("run_shell_tool"),
+    "remote_git_show_tool": DeprecatedTool("run_shell_tool"),
+    "remote_git_reset_tool": DeprecatedTool("run_shell_tool"),
+    "remote_playwright_install_tool": DeprecatedTool("run_shell_tool"),
+    "remote_browser_screenshot_tool": DeprecatedTool("browser_capture_tool"),
+    "remote_browser_get_text_tool": DeprecatedTool("browser_get_text_tool"),
+    "remote_browser_eval_tool": DeprecatedTool("playwright_run_script_tool"),
+    "remote_browser_pdf_tool": DeprecatedTool("browser_capture_tool"),
+    "remote_playwright_run_script_tool": DeprecatedTool("playwright_run_script_tool"),
+}
+
+
+def _deprecated_tool_result(name: str, tool: DeprecatedTool) -> dict[str, Any]:
+    return {
+        "ok": False,
+        "message": (
+            f"Tool '{name}' was removed in local-shell-mcp {tool.removed_in}. "
+            "The client is using an outdated MCP tool snapshot."
+        ),
+        "data": {
+            "status": "stale_tool_snapshot",
+            "deprecated_tool": name,
+            "replacement": tool.replacement,
+            "removed_in": tool.removed_in,
+            "help_url": DEPRECATED_TOOL_HELP_URL,
+            "assistant_instruction": (
+                "Do not retry this deprecated tool. Explain to the user that ChatGPT is using "
+                "a stale local-shell-mcp tool snapshot and ask them to refresh the LSM App's "
+                "tools, or remove and re-add the App if refresh is unavailable. Refer them to "
+                f"{DEPRECATED_TOOL_HELP_URL}. After the cache is updated, use the replacement "
+                f"tool '{tool.replacement}'."
+            ),
+        },
+    }
+
+
+class DeprecatedToolFastMCP(_FastMCP):
+    """FastMCP variant that keeps removed tool names as non-enumerated tombstones."""
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> Any:
+        deprecated = DEPRECATED_TOOLS.get(name)
+        if deprecated is not None:
+            return _deprecated_tool_result(name, deprecated)
+        return await super().call_tool(name, arguments)
+
+
+def install_deprecated_tool_tombstones() -> None:
+    """Make subsequent FastMCP imports use the tombstone-aware implementation."""
+
+    if fastmcp_module.FastMCP is DeprecatedToolFastMCP:
+        return
+    fastmcp_module.FastMCP = DeprecatedToolFastMCP

--- a/src/local_shell_mcp/main.py
+++ b/src/local_shell_mcp/main.py
@@ -78,6 +78,10 @@ def _build_mcp_http_app(mcp):  # noqa: ANN001
 def run_mcp() -> None:
     import uvicorn
 
+    from .deprecated_tools import install_deprecated_tool_tombstones
+
+    install_deprecated_tool_tombstones()
+
     from .settings import get_settings, validate_public_oauth_configuration
     from .tools import build_mcp
 

--- a/tests/test_deprecated_tools.py
+++ b/tests/test_deprecated_tools.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from mcp.server import fastmcp as fastmcp_module
+
+from local_shell_mcp.deprecated_tools import (
+    DEPRECATED_TOOL_HELP_URL,
+    DeprecatedToolFastMCP,
+    install_deprecated_tool_tombstones,
+)
+
+
+async def test_deprecated_tools_are_tombstones_not_listed_tools() -> None:
+    original = fastmcp_module.FastMCP
+    try:
+        install_deprecated_tool_tombstones()
+        assert fastmcp_module.FastMCP is DeprecatedToolFastMCP
+
+        install_deprecated_tool_tombstones()
+        assert fastmcp_module.FastMCP is DeprecatedToolFastMCP
+
+        mcp = fastmcp_module.FastMCP("test")
+
+        @mcp.tool()
+        def current_tool() -> str:
+            return "current"
+
+        listed = {tool.name for tool in await mcp.list_tools()}
+        assert listed == {"current_tool"}
+        assert "version_info" not in listed
+
+        result = await mcp.call_tool("version_info", {})
+        assert result["ok"] is False
+        assert result["data"] == {
+            "status": "stale_tool_snapshot",
+            "deprecated_tool": "version_info",
+            "replacement": "environment_info",
+            "removed_in": "3.0.0",
+            "help_url": DEPRECATED_TOOL_HELP_URL,
+            "assistant_instruction": (
+                "Do not retry this deprecated tool. Explain to the user that ChatGPT is using "
+                "a stale local-shell-mcp tool snapshot and ask them to refresh the LSM App's "
+                "tools, or remove and re-add the App if refresh is unavailable. Refer them to "
+                f"{DEPRECATED_TOOL_HELP_URL}. After the cache is updated, use the replacement "
+                "tool 'environment_info'."
+            ),
+        }
+
+        current = await mcp.call_tool("current_tool", {})
+        assert current
+    finally:
+        fastmcp_module.FastMCP = original
+
+
+async def test_remote_tombstone_points_to_unified_machine_tool() -> None:
+    mcp = DeprecatedToolFastMCP("test")
+    result = await mcp.call_tool("remote_run_shell_tool", {"machine": "worker"})
+
+    assert result["data"]["status"] == "stale_tool_snapshot"
+    assert result["data"]["replacement"] == "run_shell_tool"
+    assert "refresh the LSM App's tools" in result["data"]["assistant_instruction"]


### PR DESCRIPTION
## Summary

- maintain non-enumerated tombstones for tool names removed during the v3 tool-surface cleanup
- intercept stale `tools/call` requests before FastMCP returns a generic `Unknown tool`
- return a structured `stale_tool_snapshot` result with the replacement tool, refresh instructions, and a link to #70
- keep deprecated names out of `tools/list`, so refreshed clients only cache the current tool surface
- cover local and former `remote_*` tool migrations with regression tests

## Validation

- Python syntax compilation passed for the new module, startup change, and tests
- local behavior was exercised with a FastMCP-compatible stub; GitHub Actions will run the repository test suite

Fixes the discoverability gap described in #70.