### PR TITLE
fix: enforce single worker process and bounded polling

### DIFF
--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -6,6 +6,7 @@ import contextlib
 import hashlib
 import importlib.metadata as importlib_metadata
 import json
+import math
 import os
 import re
 import secrets
@@ -83,6 +84,9 @@ REMOTE_JOIN_PATH = "/join"
 REMOTE_API_PREFIX = "/remote"
 REMOTE_WORKER_BUNDLE_PATH = "/remote/worker-bundle.tgz"
 REMOTE_WORKER_POLL_PROTOCOL_VERSION = 1
+_WORKER_CONNECT_TIMEOUT_S = 10.0
+_WORKER_DEFAULT_POLL_TIMEOUT_S = 25.0
+_WORKER_POLL_TIMEOUT_GRACE_S = 10.0
 # The remote worker is designed to start on machines that only have Python, curl,
 # and tar. Keep this empty unless a dependency is pure Python and imported on the
 # worker startup path. Tool-specific dependencies such as Playwright should be
@@ -420,6 +424,7 @@ class RemoteManager:
             "token": token,
             "name": name,
             "poll_interval_s": 0,
+            "poll_timeout_s": get_settings().remote_poll_timeout_s,
             "heartbeat_interval_s": _remote_heartbeat_interval_s(),
         }
 
@@ -447,6 +452,7 @@ class RemoteManager:
             "token": access,
             "name": name,
             "poll_interval_s": 0,
+            "poll_timeout_s": get_settings().remote_poll_timeout_s,
             "heartbeat_interval_s": _remote_heartbeat_interval_s(),
         }
 
@@ -1589,29 +1595,37 @@ def _parse_worker_http_json(url: str, status_code: int, response_body: str) -> d
 
 
 def _worker_post_json_with_curl(
-    url: str, body: bytes, headers: dict[str, str], timeout: float | None = None
+    url: str,
+    body: bytes,
+    headers: dict[str, str],
+    timeout: float | None = None,
+    connect_timeout: float | None = _WORKER_CONNECT_TIMEOUT_S,
 ) -> dict[str, Any]:
     curl = shutil.which("curl")
     if not curl:
         raise FileNotFoundError("curl is not available")
     status_marker = "\nLOCAL_SHELL_MCP_HTTP_STATUS:"
-    command = [
-        curl,
-        "-sS",
-        "-L",
-        "-X",
-        "POST",
-        "-H",
-        "Content-Type: application/json",
-        "--data-binary",
-        "@-",
-        "-w",
-        f"{status_marker}%{{http_code}}",
-    ]
+    command = [curl]
+    if connect_timeout is not None:
+        command.extend(["--connect-timeout", f"{connect_timeout:g}"])
+    if timeout is not None:
+        command.extend(["--max-time", f"{timeout:g}"])
+    command.extend(
+        [
+            "-sS",
+            "-L",
+            "-X",
+            "POST",
+            "-H",
+            "Content-Type: application/json",
+            "--data-binary",
+            "@-",
+            "-w",
+            f"{status_marker}%{{http_code}}",
+        ]
+    )
     for name, value in headers.items():
         command.extend(["-H", f"{name}: {value}"])
-    if timeout is not None:
-        command[1:1] = ["--max-time", str(timeout)]
     command.append(url)
 
     completed = subprocess.run(  # noqa: S603
@@ -1657,6 +1671,7 @@ def _worker_post_json(
     payload: dict[str, Any],
     headers: dict[str, str] | None = None,
     timeout: float | None = None,
+    connect_timeout: float | None = _WORKER_CONNECT_TIMEOUT_S,
 ) -> dict[str, Any]:
     parsed = urllib.parse.urlsplit(url)
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
@@ -1664,12 +1679,24 @@ def _worker_post_json(
     body = json.dumps(payload).encode("utf-8")
     request_headers = headers or {}
     if shutil.which("curl"):
-        return _worker_post_json_with_curl(url, body, request_headers, timeout)
+        return _worker_post_json_with_curl(
+            url, body, request_headers, timeout, connect_timeout
+        )
     return _worker_post_json_with_urllib(url, body, request_headers, timeout)
 
 
 _WORKER_RETRY_INITIAL_DELAY_S = 1.0
 _WORKER_RETRY_MAX_DELAY_S = 30.0
+
+
+def _worker_poll_request_timeout_s(data: dict[str, Any]) -> float:
+    try:
+        poll_timeout_s = float(data.get("poll_timeout_s", _WORKER_DEFAULT_POLL_TIMEOUT_S))
+    except (TypeError, ValueError):
+        poll_timeout_s = _WORKER_DEFAULT_POLL_TIMEOUT_S
+    if not math.isfinite(poll_timeout_s) or poll_timeout_s <= 0:
+        poll_timeout_s = _WORKER_DEFAULT_POLL_TIMEOUT_S
+    return poll_timeout_s + _WORKER_POLL_TIMEOUT_GRACE_S
 
 
 def _worker_retry_delay(attempt: int) -> float:
@@ -1939,6 +1966,7 @@ async def _run_worker_locked(
         data = body["data"]
         machine_name = data["name"]
     heartbeat_interval_s = float(data.get("heartbeat_interval_s") or _remote_heartbeat_interval_s())
+    poll_request_timeout_s = _worker_poll_request_timeout_s(data)
     _write_worker_identity(
         {"server": server, "name": machine_name, "access": access, "workdir": workdir}
     )
@@ -1958,7 +1986,7 @@ async def _run_worker_locked(
             f"{server}{REMOTE_API_PREFIX}/poll",
             _worker_poll_payload(),
             headers,
-            None,
+            poll_request_timeout_s,
             "poll",
         )
         payload = poll_body.get("data", {})

--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -508,6 +508,14 @@ class RemoteManager:
         payload = payload or {}
         worker_version = str(payload.get("worker_version") or "")
         protocol_version = int(payload.get("protocol_version") or 0)
+        configured_poll_timeout_s = float(get_settings().remote_poll_timeout_s)
+        effective_poll_timeout_s = configured_poll_timeout_s
+        try:
+            worker_poll_timeout_s = float(payload.get("poll_timeout_s") or 0)
+        except (TypeError, ValueError):
+            worker_poll_timeout_s = 0
+        if math.isfinite(worker_poll_timeout_s) and worker_poll_timeout_s > 0:
+            effective_poll_timeout_s = min(configured_poll_timeout_s, worker_poll_timeout_s)
         upgrade = None
         if protocol_version >= REMOTE_WORKER_POLL_PROTOCOL_VERSION:
             upgrade = {
@@ -522,17 +530,31 @@ class RemoteManager:
             if protocol_version:
                 worker.info["poll_protocol_version"] = protocol_version
         if upgrade and upgrade["required"]:
-            return {"job": None, "upgrade": upgrade}
+            return {
+                "job": None,
+                "upgrade": upgrade,
+                "poll_timeout_s": configured_poll_timeout_s,
+            }
         loop = asyncio.get_running_loop()
-        deadline = loop.time() + get_settings().remote_poll_timeout_s
+        deadline = loop.time() + effective_poll_timeout_s
         while True:
             remaining = deadline - loop.time()
             if remaining <= 0:
-                return {"job": None, "heartbeat": True, "upgrade": upgrade}
+                return {
+                    "job": None,
+                    "heartbeat": True,
+                    "upgrade": upgrade,
+                    "poll_timeout_s": configured_poll_timeout_s,
+                }
             try:
                 job = await asyncio.wait_for(worker.queue.get(), timeout=remaining)
             except TimeoutError:
-                return {"job": None, "heartbeat": True, "upgrade": upgrade}
+                return {
+                    "job": None,
+                    "heartbeat": True,
+                    "upgrade": upgrade,
+                    "poll_timeout_s": configured_poll_timeout_s,
+                }
             job_id = str(job.get("id") or "")
             with self._state_lock:
                 self._prune_cancelled_jobs_locked()
@@ -540,7 +562,11 @@ class RemoteManager:
                     self.cancelled_jobs.pop(job_id, None)
                     continue
                 self.claimed_jobs.add(job_id)
-            return {"job": job, "upgrade": upgrade}
+            return {
+                "job": job,
+                "upgrade": upgrade,
+                "poll_timeout_s": configured_poll_timeout_s,
+            }
 
     async def heartbeat(self, token: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
         worker = self._worker_by_token(token)
@@ -1538,11 +1564,16 @@ def worker_info(workdir: str) -> dict[str, Any]:
     }
 
 
-def _worker_poll_payload() -> dict[str, Any]:
-    return {
+def _worker_poll_payload(poll_request_timeout_s: float | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {
         "protocol_version": REMOTE_WORKER_POLL_PROTOCOL_VERSION,
         "worker_version": __version__,
     }
+    if poll_request_timeout_s is not None:
+        payload["poll_timeout_s"] = max(
+            0.001, poll_request_timeout_s - _WORKER_POLL_TIMEOUT_GRACE_S
+        )
+    return payload
 
 
 def _reexec_updated_worker_runtime() -> None:
@@ -1992,12 +2023,15 @@ async def _run_worker_locked(
     while True:
         poll_body = await _worker_post_json_forever(
             f"{server}{REMOTE_API_PREFIX}/poll",
-            _worker_poll_payload(),
+            _worker_poll_payload(poll_request_timeout_s),
             headers,
             poll_request_timeout_s,
             "poll",
         )
         payload = poll_body.get("data", {})
+        updated_poll_request_timeout_s = _worker_poll_request_timeout_s(payload)
+        if updated_poll_request_timeout_s is not None:
+            poll_request_timeout_s = updated_poll_request_timeout_s
         upgrade = payload.get("upgrade") if isinstance(payload, dict) else None
         if isinstance(upgrade, dict) and upgrade.get("required"):
             target_version = str(upgrade.get("version") or "")

--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -1886,6 +1886,19 @@ async def run_worker(
     name: str | None = None,
     workdir: str | None = None,
     persist: bool = False,
+) -> None:
+    from .remote_worker_service import worker_run_lock
+
+    with worker_run_lock():
+        await _run_worker_locked(server, invite, name, workdir, persist)
+
+
+async def _run_worker_locked(
+    server: str,
+    invite: str,
+    name: str | None = None,
+    workdir: str | None = None,
+    persist: bool = False,
 ) -> None:  # noqa: ARG001
     workdir = str(Path(workdir or os.getcwd()).expanduser().resolve())
     os.environ["LOCAL_SHELL_MCP_WORKSPACE_ROOT"] = workdir

--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -85,7 +85,6 @@ REMOTE_API_PREFIX = "/remote"
 REMOTE_WORKER_BUNDLE_PATH = "/remote/worker-bundle.tgz"
 REMOTE_WORKER_POLL_PROTOCOL_VERSION = 1
 _WORKER_CONNECT_TIMEOUT_S = 10.0
-_WORKER_DEFAULT_POLL_TIMEOUT_S = 25.0
 _WORKER_POLL_TIMEOUT_GRACE_S = 10.0
 # The remote worker is designed to start on machines that only have Python, curl,
 # and tar. Keep this empty unless a dependency is pure Python and imported on the
@@ -1687,6 +1686,8 @@ def _worker_post_json(
         return _worker_post_json_with_curl(
             url, body, request_headers, timeout, connect_timeout
         )
+    if timeout is not None and parsed.path.endswith(f"{REMOTE_API_PREFIX}/poll"):
+        raise RuntimeError("curl is required for bounded worker poll requests")
     return _worker_post_json_with_urllib(url, body, request_headers, timeout)
 
 
@@ -1694,13 +1695,15 @@ _WORKER_RETRY_INITIAL_DELAY_S = 1.0
 _WORKER_RETRY_MAX_DELAY_S = 30.0
 
 
-def _worker_poll_request_timeout_s(data: dict[str, Any]) -> float:
+def _worker_poll_request_timeout_s(data: dict[str, Any]) -> float | None:
+    if "poll_timeout_s" not in data:
+        return None
     try:
-        poll_timeout_s = float(data.get("poll_timeout_s", _WORKER_DEFAULT_POLL_TIMEOUT_S))
+        poll_timeout_s = float(data["poll_timeout_s"])
     except (TypeError, ValueError):
-        poll_timeout_s = _WORKER_DEFAULT_POLL_TIMEOUT_S
+        return None
     if not math.isfinite(poll_timeout_s) or poll_timeout_s <= 0:
-        poll_timeout_s = _WORKER_DEFAULT_POLL_TIMEOUT_S
+        return None
     return poll_timeout_s + _WORKER_POLL_TIMEOUT_GRACE_S
 
 

--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -1548,6 +1548,7 @@ def _worker_poll_payload() -> dict[str, Any]:
 
 def _reexec_updated_worker_runtime() -> None:
     from .remote_worker_cli import _worker_run_exec_argv
+    from .remote_worker_service import cancel_worker_lock_reexec, prepare_worker_lock_reexec
     from .remote_worker_state import worker_runtime_dir
 
     runtime = worker_runtime_dir()
@@ -1557,7 +1558,11 @@ def _reexec_updated_worker_runtime() -> None:
         preferred + [entry for entry in current if entry not in preferred]
     )
     argv = _worker_run_exec_argv()
-    os.execv(argv[0], argv)
+    lock_fd = prepare_worker_lock_reexec()
+    try:
+        os.execv(argv[0], argv)
+    finally:
+        cancel_worker_lock_reexec(lock_fd)
 
 
 async def _upgrade_worker_runtime(server: str, target_version: str) -> None:

--- a/src/local_shell_mcp/remote_worker_cli.py
+++ b/src/local_shell_mcp/remote_worker_cli.py
@@ -11,11 +11,14 @@ from typing import Any
 from . import remote
 from .remote_worker_installer import install_or_update_runtime
 from .remote_worker_service import (
+    cancel_worker_lock_reexec,
     install_service,
+    prepare_worker_lock_reexec,
     service_status,
     start_service,
     stop_service,
     uninstall_service,
+    worker_run_lock,
 )
 from .remote_worker_state import (
     ensure_user_bin_on_path,
@@ -156,19 +159,24 @@ def _worker_run_exec_argv() -> list[str]:
 
 def _reexec_worker_run() -> None:
     argv = _worker_run_exec_argv()
-    os.execv(argv[0], argv)
+    lock_fd = prepare_worker_lock_reexec()
+    try:
+        os.execv(argv[0], argv)
+    finally:
+        cancel_worker_lock_reexec(lock_fd)
 
 
 async def _connect(args: argparse.Namespace) -> None:
-    await enroll_worker(
-        server=args.server,
-        invite=_read_invite(args),
-        name=args.name,
-        workdir=args.workdir,
-        runtime_digest=args.runtime_digest,
-        runtime_version=args.runtime_version,
-    )
-    _reexec_worker_run()
+    with worker_run_lock():
+        await enroll_worker(
+            server=args.server,
+            invite=_read_invite(args),
+            name=args.name,
+            workdir=args.workdir,
+            runtime_digest=args.runtime_digest,
+            runtime_version=args.runtime_version,
+        )
+        _reexec_worker_run()
 
 
 def _prepare_worker_start() -> None:

--- a/src/local_shell_mcp/remote_worker_service.py
+++ b/src/local_shell_mcp/remote_worker_service.py
@@ -33,6 +33,7 @@ _LAUNCHD_LABEL = "com.fwerkor.local-shell-mcp-worker"
 _WORKER_MANAGED_ENV = "LOCAL_SHELL_MCP_WORKER_MANAGED"
 _WORKER_LOCK_FD_ENV = "LOCAL_SHELL_MCP_WORKER_LOCK_FD"
 _WORKER_LOCK_RETRY_S = 5.0
+_WORKER_LOCK_HANDOFF_RETRY_S = 0.1
 _active_worker_lock_handle: Any | None = None
 
 
@@ -109,7 +110,9 @@ def worker_run_lock():  # noqa: ANN201
     path = worker_lock_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     handle = _adopt_worker_lock_handle()
-    locked = handle is not None
+    inherited = handle is not None
+    windows_handoff = inherited and os.name == "nt"
+    locked = inherited and not windows_handoff
     if handle is None:
         fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
         handle = os.fdopen(fd, "r+b", buffering=0)
@@ -124,19 +127,23 @@ def worker_run_lock():  # noqa: ANN201
             except OSError as exc:
                 if not _worker_lock_is_contended(exc):
                     raise
-                if os.getenv(_WORKER_MANAGED_ENV) != "1":
+                managed = os.getenv(_WORKER_MANAGED_ENV) == "1"
+                if not managed and not windows_handoff:
                     raise WorkerAlreadyRunningError(
                         "remote worker is already running; stop the existing process or use "
                         "`local-shell-mcp worker restart`"
                     ) from exc
-                if not waiting:
+                if managed and not waiting:
                     print(
                         "Status: another worker process is active; managed worker is waiting...",
                         file=sys.stderr,
                         flush=True,
                     )
                     waiting = True
-                time.sleep(_WORKER_LOCK_RETRY_S)
+                retry_s = (
+                    _WORKER_LOCK_HANDOFF_RETRY_S if windows_handoff else _WORKER_LOCK_RETRY_S
+                )
+                time.sleep(retry_s)
         with contextlib.suppress(OSError):
             os.chmod(path, 0o600)
         _active_worker_lock_handle = handle

--- a/src/local_shell_mcp/remote_worker_service.py
+++ b/src/local_shell_mcp/remote_worker_service.py
@@ -7,6 +7,7 @@ import json
 import os
 import platform
 import plistlib
+import re
 import shlex
 import shutil
 import signal
@@ -73,6 +74,42 @@ def _worker_lock_is_contended(exc: OSError) -> bool:
     return os.name == "nt" and getattr(exc, "winerror", None) in {32, 33}
 
 
+def _managed_service_pid() -> int | None:
+    system = platform.system()
+    if system == "Linux" and _systemd_unit_path().exists() and shutil.which("systemctl"):
+        result = _run(
+            [
+                "systemctl",
+                "--user",
+                "show",
+                "--property",
+                "MainPID",
+                "--value",
+                f"{_SERVICE_NAME}.service",
+            ],
+            check=False,
+        )
+        value = result.stdout.strip()
+        if result.returncode == 0 and value.isdigit() and int(value) > 0:
+            return int(value)
+    if system == "Darwin" and _launchd_plist_path().exists() and shutil.which("launchctl"):
+        result = _run(
+            ["launchctl", "print", f"gui/{_user_id()}/{_LAUNCHD_LABEL}"],
+            check=False,
+        )
+        if result.returncode == 0:
+            match = re.search(r"(?m)^\s*pid\s*=\s*(\d+)\s*$", result.stdout)
+            if match and int(match.group(1)) > 0:
+                return int(match.group(1))
+    return None
+
+
+def _current_worker_is_managed() -> bool:
+    if os.getenv(_WORKER_MANAGED_ENV) == "1":
+        return True
+    return _managed_service_pid() == os.getpid()
+
+
 def prepare_worker_lock_reexec() -> int | None:
     handle = _active_worker_lock_handle
     if handle is None:
@@ -127,7 +164,7 @@ def worker_run_lock():  # noqa: ANN201
             except OSError as exc:
                 if not _worker_lock_is_contended(exc):
                     raise
-                managed = os.getenv(_WORKER_MANAGED_ENV) == "1"
+                managed = _current_worker_is_managed()
                 if not managed and not windows_handoff:
                     raise WorkerAlreadyRunningError(
                         "remote worker is already running; stop the existing process or use "

--- a/src/local_shell_mcp/remote_worker_service.py
+++ b/src/local_shell_mcp/remote_worker_service.py
@@ -29,6 +29,10 @@ from .remote_worker_state import (
 
 _SERVICE_NAME = "local-shell-mcp-worker"
 _LAUNCHD_LABEL = "com.fwerkor.local-shell-mcp-worker"
+_WORKER_MANAGED_ENV = "LOCAL_SHELL_MCP_WORKER_MANAGED"
+_WORKER_LOCK_FD_ENV = "LOCAL_SHELL_MCP_WORKER_LOCK_FD"
+_WORKER_LOCK_RETRY_S = 5.0
+_active_worker_lock_handle: Any | None = None
 
 
 class WorkerAlreadyRunningError(RuntimeError):
@@ -61,49 +65,76 @@ def _unlock_worker_file(handle: Any) -> None:
     fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
-def _read_worker_lock_owner(handle: Any) -> dict[str, Any]:
+def prepare_worker_lock_reexec() -> int | None:
+    handle = _active_worker_lock_handle
+    if handle is None:
+        return None
+    fd = handle.fileno()
+    os.set_inheritable(fd, True)
+    os.environ[_WORKER_LOCK_FD_ENV] = str(fd)
+    return fd
+
+
+def cancel_worker_lock_reexec(fd: int | None) -> None:
+    if fd is None:
+        return
+    os.environ.pop(_WORKER_LOCK_FD_ENV, None)
+    with contextlib.suppress(OSError):
+        os.set_inheritable(fd, False)
+
+
+def _adopt_worker_lock_handle() -> Any | None:
+    raw_fd = os.environ.pop(_WORKER_LOCK_FD_ENV, "")
+    if not raw_fd:
+        return None
     try:
-        handle.seek(1)
-        raw = handle.read().decode("utf-8", errors="replace").strip()
-        data = json.loads(raw)
-    except (OSError, ValueError, json.JSONDecodeError):
-        return {}
-    return data if isinstance(data, dict) else {}
+        fd = int(raw_fd)
+        os.fstat(fd)
+    except (OSError, ValueError):
+        return None
+    return os.fdopen(fd, "r+b", buffering=0)
 
 
 @contextlib.contextmanager
 def worker_run_lock():  # noqa: ANN201
+    global _active_worker_lock_handle
+
     path = worker_lock_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
-    handle = os.fdopen(fd, "r+b", buffering=0)
-    locked = False
+    handle = _adopt_worker_lock_handle()
+    locked = handle is not None
+    if handle is None:
+        fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
+        handle = os.fdopen(fd, "r+b", buffering=0)
     try:
         if path.stat().st_size == 0:
             handle.write(b"\0")
-        try:
-            _lock_worker_file(handle)
-            locked = True
-        except OSError as exc:
-            owner = _read_worker_lock_owner(handle)
-            pid = owner.get("pid")
-            pid_detail = f" (PID {pid})" if isinstance(pid, int) and pid > 0 else ""
-            raise WorkerAlreadyRunningError(
-                f"remote worker is already running{pid_detail}; stop the existing process or use "
-                "`local-shell-mcp worker restart`"
-            ) from exc
-        handle.seek(1)
-        handle.truncate(1)
-        handle.write(
-            json.dumps(
-                {"version": 1, "pid": os.getpid(), "started_at": time.time()},
-                sort_keys=True,
-            ).encode("utf-8")
-        )
+        waiting = False
+        while not locked:
+            try:
+                _lock_worker_file(handle)
+                locked = True
+            except OSError as exc:
+                if os.getenv(_WORKER_MANAGED_ENV) != "1":
+                    raise WorkerAlreadyRunningError(
+                        "remote worker is already running; stop the existing process or use "
+                        "`local-shell-mcp worker restart`"
+                    ) from exc
+                if not waiting:
+                    print(
+                        "Status: another worker process is active; managed worker is waiting...",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+                    waiting = True
+                time.sleep(_WORKER_LOCK_RETRY_S)
         with contextlib.suppress(OSError):
             os.chmod(path, 0o600)
+        _active_worker_lock_handle = handle
         yield
     finally:
+        if _active_worker_lock_handle is handle:
+            _active_worker_lock_handle = None
         if locked:
             with contextlib.suppress(OSError):
                 _unlock_worker_file(handle)
@@ -157,6 +188,7 @@ ExecStart={launcher} worker run
 Restart=always
 RestartSec=5
 Environment=PYTHONUNBUFFERED=1
+Environment=LOCAL_SHELL_MCP_WORKER_MANAGED=1
 
 [Install]
 WantedBy=default.target
@@ -173,6 +205,7 @@ def _write_launchd_plist() -> Path:
         "ProgramArguments": [str(worker_launcher_path()), "worker", "run"],
         "RunAtLoad": True,
         "KeepAlive": True,
+        "EnvironmentVariables": {_WORKER_MANAGED_ENV: "1"},
         "StandardOutPath": str(worker_log_path()),
         "StandardErrorPath": str(worker_log_path()),
     }
@@ -303,6 +336,7 @@ def _process_environment() -> dict[str, str]:
     pythonpath = os.pathsep.join((str(runtime), str(runtime / "vendor")))
     env["PYTHONPATH"] = pythonpath + (os.pathsep + current if current else "")
     env["LOCAL_SHELL_MCP_WORKER_STATE_DIR"] = str(worker_state_dir().resolve())
+    env[_WORKER_MANAGED_ENV] = "1"
     return env
 
 

--- a/src/local_shell_mcp/remote_worker_service.py
+++ b/src/local_shell_mcp/remote_worker_service.py
@@ -20,6 +20,7 @@ from .remote_worker_state import (
     install_launcher,
     user_home,
     worker_launcher_path,
+    worker_lock_path,
     worker_log_path,
     worker_pid_path,
     worker_runtime_dir,
@@ -28,6 +29,85 @@ from .remote_worker_state import (
 
 _SERVICE_NAME = "local-shell-mcp-worker"
 _LAUNCHD_LABEL = "com.fwerkor.local-shell-mcp-worker"
+
+
+class WorkerAlreadyRunningError(RuntimeError):
+    pass
+
+
+def _lock_worker_file(handle: Any) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        return
+
+    import fcntl
+
+    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+
+def _unlock_worker_file(handle: Any) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        return
+
+    import fcntl
+
+    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _read_worker_lock_owner(handle: Any) -> dict[str, Any]:
+    try:
+        handle.seek(1)
+        raw = handle.read().decode("utf-8", errors="replace").strip()
+        data = json.loads(raw)
+    except (OSError, ValueError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+@contextlib.contextmanager
+def worker_run_lock():  # noqa: ANN201
+    path = worker_lock_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
+    handle = os.fdopen(fd, "r+b", buffering=0)
+    locked = False
+    try:
+        if path.stat().st_size == 0:
+            handle.write(b"\0")
+        try:
+            _lock_worker_file(handle)
+            locked = True
+        except OSError as exc:
+            owner = _read_worker_lock_owner(handle)
+            pid = owner.get("pid")
+            pid_detail = f" (PID {pid})" if isinstance(pid, int) and pid > 0 else ""
+            raise WorkerAlreadyRunningError(
+                f"remote worker is already running{pid_detail}; stop the existing process or use "
+                "`local-shell-mcp worker restart`"
+            ) from exc
+        handle.seek(1)
+        handle.truncate(1)
+        handle.write(
+            json.dumps(
+                {"version": 1, "pid": os.getpid(), "started_at": time.time()},
+                sort_keys=True,
+            ).encode("utf-8")
+        )
+        with contextlib.suppress(OSError):
+            os.chmod(path, 0o600)
+        yield
+    finally:
+        if locked:
+            with contextlib.suppress(OSError):
+                _unlock_worker_file(handle)
+        handle.close()
 
 
 def _systemd_unit_path() -> Path:

--- a/src/local_shell_mcp/remote_worker_service.py
+++ b/src/local_shell_mcp/remote_worker_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import errno
 import hashlib
 import json
 import os
@@ -65,6 +66,12 @@ def _unlock_worker_file(handle: Any) -> None:
     fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
+def _worker_lock_is_contended(exc: OSError) -> bool:
+    if isinstance(exc, BlockingIOError) or exc.errno in {errno.EACCES, errno.EAGAIN}:
+        return True
+    return os.name == "nt" and getattr(exc, "winerror", None) in {32, 33}
+
+
 def prepare_worker_lock_reexec() -> int | None:
     handle = _active_worker_lock_handle
     if handle is None:
@@ -115,6 +122,8 @@ def worker_run_lock():  # noqa: ANN201
                 _lock_worker_file(handle)
                 locked = True
             except OSError as exc:
+                if not _worker_lock_is_contended(exc):
+                    raise
                 if os.getenv(_WORKER_MANAGED_ENV) != "1":
                     raise WorkerAlreadyRunningError(
                         "remote worker is already running; stop the existing process or use "

--- a/src/local_shell_mcp/remote_worker_state.py
+++ b/src/local_shell_mcp/remote_worker_state.py
@@ -48,6 +48,10 @@ def worker_pid_path() -> Path:
     return worker_state_dir() / "worker.pid"
 
 
+def worker_lock_path() -> Path:
+    return worker_state_dir() / "worker.lock"
+
+
 def worker_launcher_path() -> Path:
     configured = os.getenv("LOCAL_SHELL_MCP_WORKER_BIN_DIR")
     root = Path(configured).expanduser() if configured else user_home() / ".local" / "bin"

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -91,6 +91,7 @@ async def test_poll_requires_upgrade_before_dequeuing_jobs(tmp_path, monkeypatch
     assert mismatch == {
         "job": None,
         "upgrade": {"required": True, "version": remote.__version__},
+        "poll_timeout_s": 25.0,
     }
     assert worker.queue.qsize() == 1
     assert worker.info["lsm_version"] == "0.0.0"
@@ -104,6 +105,34 @@ async def test_poll_requires_upgrade_before_dequeuing_jobs(tmp_path, monkeypatch
     )
     assert matched["job"]["id"] == "job-valid"
     assert matched["upgrade"] == {"required": False, "version": remote.__version__}
+    assert matched["poll_timeout_s"] == 25.0
+
+
+@pytest.mark.asyncio
+async def test_poll_clamps_to_worker_timeout_and_returns_current_controller_value(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(tmp_path / ".state"))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_REMOTE_POLL_TIMEOUT_S", "50")
+    get_settings.cache_clear()
+    manager = remote.RemoteManager()
+    worker = remote.RemoteWorker(name="worker-a", token="token-a")
+    manager.workers[worker.name] = worker
+    manager.tokens[worker.token] = worker.name
+    captured = []
+
+    async def fake_wait_for(awaitable, timeout):  # noqa: ANN001
+        captured.append(timeout)
+        awaitable.close()
+        raise TimeoutError
+
+    monkeypatch.setattr(remote.asyncio, "wait_for", fake_wait_for)
+
+    result = await manager.poll(worker.token, {"poll_timeout_s": 10})
+
+    assert captured == [pytest.approx(10)]
+    assert result["poll_timeout_s"] == 50.0
 
 
 @pytest.mark.asyncio
@@ -277,6 +306,14 @@ def test_worker_poll_request_timeout_uses_only_advertised_values():
     assert remote._worker_poll_request_timeout_s({}) is None  # noqa: SLF001
     for value in (None, 0, -1, "invalid", float("nan")):
         assert remote._worker_poll_request_timeout_s({"poll_timeout_s": value}) is None  # noqa: SLF001
+
+
+def test_worker_poll_payload_advertises_current_long_poll_budget():
+    assert remote._worker_poll_payload() == {  # noqa: SLF001
+        "protocol_version": remote.REMOTE_WORKER_POLL_PROTOCOL_VERSION,
+        "worker_version": remote.__version__,
+    }
+    assert remote._worker_poll_payload(27)["poll_timeout_s"] == 17  # noqa: SLF001
 
 
 def test_worker_retry_delay_is_capped():

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -230,7 +230,7 @@ def test_worker_post_json_falls_back_to_urllib_when_curl_unavailable(monkeypatch
     monkeypatch.setattr(remote.urllib.request, "urlopen", fake_urlopen)
 
     result = remote._worker_post_json(  # noqa: SLF001
-        "https://example.test/remote/poll",
+        "https://example.test/remote/heartbeat",
         {},
         {"Authorization": "Bearer token"},
         12,
@@ -240,6 +240,18 @@ def test_worker_post_json_falls_back_to_urllib_when_curl_unavailable(monkeypatch
     assert captured["timeout"] == 12
     assert captured["request"].headers["Authorization"] == "Bearer token"
     assert captured["request"].data == b"{}"
+
+
+def test_worker_post_json_requires_curl_for_bounded_poll(monkeypatch):
+    monkeypatch.setattr(remote.shutil, "which", lambda name: None)
+
+    with pytest.raises(RuntimeError, match="curl is required"):
+        remote._worker_post_json(  # noqa: SLF001
+            "https://example.test/remote/poll",
+            {},
+            {"Authorization": "Bearer token"},
+            35,
+        )
 
 
 def test_worker_post_json_urllib_reports_non_2xx_body(monkeypatch):
@@ -259,11 +271,12 @@ def test_worker_post_json_urllib_reports_non_2xx_body(monkeypatch):
         remote._worker_post_json("https://example.test/remote/result", {"job_id": "job_1"})  # noqa: SLF001
 
 
-def test_worker_poll_request_timeout_uses_advertised_value_and_safe_default():
+def test_worker_poll_request_timeout_uses_only_advertised_values():
     assert remote._worker_poll_request_timeout_s({"poll_timeout_s": 25}) == 35  # noqa: SLF001
     assert remote._worker_poll_request_timeout_s({"poll_timeout_s": 4.5}) == 14.5  # noqa: SLF001
+    assert remote._worker_poll_request_timeout_s({}) is None  # noqa: SLF001
     for value in (None, 0, -1, "invalid", float("nan")):
-        assert remote._worker_poll_request_timeout_s({"poll_timeout_s": value}) == 35  # noqa: SLF001
+        assert remote._worker_poll_request_timeout_s({"poll_timeout_s": value}) is None  # noqa: SLF001
 
 
 def test_worker_retry_delay_is_capped():

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -175,7 +175,15 @@ def test_worker_post_json_uses_curl_and_parses_success(monkeypatch):
 
     assert result == {"ok": True, "data": {"registered": True}}
     command, body, check = calls[0]
-    assert command[:4] == ["/usr/bin/curl", "--max-time", "30", "-sS"]
+    assert command[:7] == [
+        "/usr/bin/curl",
+        "--connect-timeout",
+        "10",
+        "--max-time",
+        "30",
+        "-sS",
+        "-L",
+    ]
     assert ["-H", "Authorization: Bearer token"] in [command[index : index + 2] for index in range(len(command) - 1)]
     assert command[-1] == "https://example.test/remote/register"
     assert body == b'{"invite": "abc"}'
@@ -249,6 +257,13 @@ def test_worker_post_json_urllib_reports_non_2xx_body(monkeypatch):
 
     with pytest.raises(RuntimeError, match="failed with 403: <html>Cloudflare 1010</html>"):
         remote._worker_post_json("https://example.test/remote/result", {"job_id": "job_1"})  # noqa: SLF001
+
+
+def test_worker_poll_request_timeout_uses_advertised_value_and_safe_default():
+    assert remote._worker_poll_request_timeout_s({"poll_timeout_s": 25}) == 35  # noqa: SLF001
+    assert remote._worker_poll_request_timeout_s({"poll_timeout_s": 4.5}) == 14.5  # noqa: SLF001
+    for value in (None, 0, -1, "invalid", float("nan")):
+        assert remote._worker_poll_request_timeout_s({"poll_timeout_s": value}) == 35  # noqa: SLF001
 
 
 def test_worker_retry_delay_is_capped():

--- a/tests/test_remote_complete.py
+++ b/tests/test_remote_complete.py
@@ -111,6 +111,7 @@ def test_controller_registration_resume_rename_revoke_and_defaults(tmp_path, mon
         )
     )
     assert registration["name"] == "alice@host"
+    assert registration["poll_timeout_s"] == 1
     token = registration["token"]
 
     with pytest.raises(ValueError, match="invalid invite"):
@@ -123,6 +124,7 @@ def test_controller_registration_resume_rename_revoke_and_defaults(tmp_path, mon
         )
     )
     assert resumed["name"] == "alice@host"
+    assert resumed["poll_timeout_s"] == 1
     assert manager.workers["alice@host"].workdir == "/new"
     with pytest.raises(ValueError, match="belongs"):
         asyncio.run(manager.resume_worker(token, {"name": "other"}))

--- a/tests/test_remote_worker_cli.py
+++ b/tests/test_remote_worker_cli.py
@@ -88,7 +88,10 @@ async def test_run_worker_reports_version_and_applies_poll_upgrade(tmp_path, mon
     async def fake_post(url, payload, headers=None, timeout=None, operation="request"):
         calls.append((url, payload, headers, timeout, operation))
         if url.endswith("/remote/register"):
-            return {"ok": True, "data": {"token": "access", "name": "worker"}}
+            return {
+                "ok": True,
+                "data": {"token": "access", "name": "worker", "poll_timeout_s": 17},
+            }
         return {
             "ok": True,
             "data": {
@@ -110,6 +113,7 @@ async def test_run_worker_reports_version_and_applies_poll_upgrade(tmp_path, mon
             "https://example.test", "invite", workdir=str(tmp_path)
         )
 
+    assert calls[1][3] == 27
     poll_payload = calls[1][1]
     assert poll_payload == {
         "protocol_version": cli.remote.REMOTE_WORKER_POLL_PROTOCOL_VERSION,

--- a/tests/test_remote_worker_cli.py
+++ b/tests/test_remote_worker_cli.py
@@ -6,6 +6,7 @@ import os
 import pytest
 
 from local_shell_mcp import remote_worker_cli as cli
+from local_shell_mcp import remote_worker_service as service
 from local_shell_mcp import remote_worker_state as state
 
 
@@ -358,6 +359,22 @@ def test_prepare_worker_start_installs_runtime_before_launcher(tmp_path, monkeyp
         ("launcher", None),
         ("path", None),
     ]
+
+
+@pytest.mark.asyncio
+async def test_connect_rejects_duplicate_before_enrollment(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    args = cli._parser().parse_args(  # noqa: SLF001
+        ["connect", "--server", "https://example.test", "--invite", "invite"]
+    )
+    monkeypatch.setattr(
+        cli,
+        "enroll_worker",
+        lambda **kwargs: pytest.fail("consumed invitation before acquiring worker lock"),
+    )
+
+    with cli.worker_run_lock(), pytest.raises(service.WorkerAlreadyRunningError):
+        await cli._connect(args)  # noqa: SLF001
 
 
 def test_all_remaining_lifecycle_command_branches(tmp_path, monkeypatch, capsys):

--- a/tests/test_remote_worker_cli.py
+++ b/tests/test_remote_worker_cli.py
@@ -119,6 +119,7 @@ async def test_run_worker_reports_version_and_applies_poll_upgrade(tmp_path, mon
     assert poll_payload == {
         "protocol_version": cli.remote.REMOTE_WORKER_POLL_PROTOCOL_VERSION,
         "worker_version": cli.remote.__version__,
+        "poll_timeout_s": 17,
     }
 
 

--- a/tests/test_remote_worker_service.py
+++ b/tests/test_remote_worker_service.py
@@ -215,12 +215,27 @@ def test_worker_run_lock_survives_reexec(tmp_path, monkeypatch):
     script.write_text(
         """
 import os
+import subprocess
 import sys
 
-from local_shell_mcp.remote_worker_service import prepare_worker_lock_reexec, worker_run_lock
+from local_shell_mcp.remote_worker_service import (
+    WorkerAlreadyRunningError,
+    prepare_worker_lock_reexec,
+    worker_run_lock,
+)
+
+if len(sys.argv) > 1 and sys.argv[1] == "probe":
+    try:
+        with worker_run_lock():
+            raise SystemExit(0)
+    except WorkerAlreadyRunningError:
+        raise SystemExit(2)
 
 if os.environ.get("LSM_LOCK_REEXEC_STAGE") == "2":
     with worker_run_lock():
+        probe = subprocess.run([sys.executable, __file__, "probe"], check=False)
+        if probe.returncode != 2:
+            raise SystemExit(f"competing worker acquired inherited lock: {probe.returncode}")
         print("lock inherited", flush=True)
 else:
     with worker_run_lock():

--- a/tests/test_remote_worker_service.py
+++ b/tests/test_remote_worker_service.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -122,6 +124,52 @@ def test_process_fallback_start_stop_and_stale_pid(tmp_path, monkeypatch):
     monkeypatch.setattr(service, "_process_identity", lambda pid: "different")
     assert service.service_status()["pid"] is None
     assert not service.worker_pid_path().exists()
+
+
+def test_worker_run_lock_rejects_duplicate_and_reports_owner(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+
+    with service.worker_run_lock():
+        raw = service.worker_lock_path().read_bytes()
+        owner = json.loads(raw[1:].decode("utf-8"))
+        assert owner["pid"] == os.getpid()
+        with (
+            pytest.raises(service.WorkerAlreadyRunningError, match=rf"PID {os.getpid()}"),
+            service.worker_run_lock(),
+        ):
+            pass
+
+    assert service.worker_lock_path().exists()
+    with service.worker_run_lock():
+        pass
+
+
+def test_worker_run_lock_recovers_after_process_exit(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    environment = os.environ.copy()
+    source_root = str(Path(__file__).resolve().parents[1] / "src")
+    environment["PYTHONPATH"] = os.pathsep.join(
+        part for part in (source_root, environment.get("PYTHONPATH", "")) if part
+    )
+    code = """
+import os
+from local_shell_mcp.remote_worker_service import worker_run_lock
+
+lock = worker_run_lock()
+lock.__enter__()
+os._exit(0)
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+    with service.worker_run_lock():
+        pass
 
 
 def test_process_environment_scrubs_inherited_worker_scope(tmp_path, monkeypatch):

--- a/tests/test_remote_worker_service.py
+++ b/tests/test_remote_worker_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import json
 import os
 import subprocess
@@ -164,6 +165,20 @@ def test_managed_worker_waits_for_existing_lock(tmp_path, monkeypatch):
 
     assert attempts == 2
     assert sleeps == [5.0]
+
+
+def test_worker_run_lock_propagates_non_contention_errors(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKER_MANAGED", "1")
+    monkeypatch.setattr(
+        service,
+        "_lock_worker_file",
+        lambda handle: (_ for _ in ()).throw(OSError(errno.EIO, "lock unavailable")),
+    )
+    monkeypatch.setattr(service.time, "sleep", lambda delay: pytest.fail("retried lock error"))
+
+    with pytest.raises(OSError, match="lock unavailable"), service.worker_run_lock():
+        pass
 
 
 def test_worker_run_lock_recovers_after_process_exit(tmp_path, monkeypatch):

--- a/tests/test_remote_worker_service.py
+++ b/tests/test_remote_worker_service.py
@@ -167,6 +167,58 @@ def test_managed_worker_waits_for_existing_lock(tmp_path, monkeypatch):
     assert sleeps == [5.0]
 
 
+@pytest.mark.parametrize(
+    ("system", "command_output"),
+    [
+        ("Linux", "123\n"),
+        ("Darwin", "service = {\n    pid = 123\n}\n"),
+    ],
+)
+def test_legacy_managed_service_is_identified_by_pid(
+    tmp_path, monkeypatch, system, command_output
+):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.delenv("LOCAL_SHELL_MCP_WORKER_MANAGED", raising=False)
+    monkeypatch.setattr(service.platform, "system", lambda: system)
+    monkeypatch.setattr(service.os, "getpid", lambda: 123)
+    monkeypatch.setattr(service.os, "getuid", lambda: 501, raising=False)
+    monkeypatch.setattr(service.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(
+        service,
+        "_run",
+        lambda command, check=False: subprocess.CompletedProcess(
+            command, 0, stdout=command_output, stderr=""
+        ),
+    )
+    if system == "Linux":
+        service._systemd_unit_path().parent.mkdir(parents=True, exist_ok=True)  # noqa: SLF001
+        service._systemd_unit_path().touch()  # noqa: SLF001
+    else:
+        service._launchd_plist_path().parent.mkdir(parents=True, exist_ok=True)  # noqa: SLF001
+        service._launchd_plist_path().touch()  # noqa: SLF001
+
+    assert service._current_worker_is_managed() is True  # noqa: SLF001
+
+
+def test_manual_worker_is_not_mistaken_for_managed_service(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.delenv("LOCAL_SHELL_MCP_WORKER_MANAGED", raising=False)
+    monkeypatch.setattr(service.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(service.os, "getpid", lambda: 456)
+    monkeypatch.setattr(service.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(
+        service,
+        "_run",
+        lambda command, check=False: subprocess.CompletedProcess(
+            command, 0, stdout="123\n", stderr=""
+        ),
+    )
+    service._systemd_unit_path().parent.mkdir(parents=True, exist_ok=True)  # noqa: SLF001
+    service._systemd_unit_path().touch()  # noqa: SLF001
+
+    assert service._current_worker_is_managed() is False  # noqa: SLF001
+
+
 def test_worker_run_lock_propagates_non_contention_errors(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
     monkeypatch.setenv("LOCAL_SHELL_MCP_WORKER_MANAGED", "1")

--- a/tests/test_remote_worker_service.py
+++ b/tests/test_remote_worker_service.py
@@ -33,6 +33,7 @@ def test_install_and_manage_systemd_service(tmp_path, monkeypatch):
     result = service.install_service(start=True)
     assert result["kind"] == "systemd"
     assert service._systemd_unit_path().exists()  # noqa: SLF001
+    assert "Environment=LOCAL_SHELL_MCP_WORKER_MANAGED=1" in service._systemd_unit_path().read_text()
     assert any(command[:3] == ["systemctl", "--user", "enable"] for command, _ in calls)
 
     status = service.service_status()
@@ -77,6 +78,7 @@ def test_launchd_install_start_and_status(tmp_path, monkeypatch):
     monkeypatch.setattr(service, "_run", fake_run)
     service.install_service(start=True)
     assert service._launchd_plist_path().exists()  # noqa: SLF001
+    assert b"LOCAL_SHELL_MCP_WORKER_MANAGED" in service._launchd_plist_path().read_bytes()
     assert service.service_status()["running"] is True
     service.start_service()
     service.stop_service()
@@ -131,7 +133,7 @@ def test_worker_run_lock_rejects_duplicate_and_reports_owner(tmp_path, monkeypat
 
     with (
         service.worker_run_lock(),
-        pytest.raises(service.WorkerAlreadyRunningError, match=rf"PID {os.getpid()}"),
+        pytest.raises(service.WorkerAlreadyRunningError, match="already running"),
         service.worker_run_lock(),
     ):
         pass
@@ -139,6 +141,29 @@ def test_worker_run_lock_rejects_duplicate_and_reports_owner(tmp_path, monkeypat
     assert service.worker_lock_path().exists()
     with service.worker_run_lock():
         pass
+
+
+def test_managed_worker_waits_for_existing_lock(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKER_MANAGED", "1")
+    attempts = 0
+    sleeps = []
+
+    def fake_lock(handle):  # noqa: ANN001, ARG001
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise BlockingIOError
+
+    monkeypatch.setattr(service, "_lock_worker_file", fake_lock)
+    monkeypatch.setattr(service, "_unlock_worker_file", lambda handle: None)
+    monkeypatch.setattr(service.time, "sleep", sleeps.append)
+
+    with service.worker_run_lock():
+        pass
+
+    assert attempts == 2
+    assert sleeps == [5.0]
 
 
 def test_worker_run_lock_recovers_after_process_exit(tmp_path, monkeypatch):
@@ -169,6 +194,45 @@ os._exit(0)
         pass
 
 
+def test_worker_run_lock_survives_reexec(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    script = tmp_path / "reexec-lock.py"
+    script.write_text(
+        """
+import os
+import sys
+
+from local_shell_mcp.remote_worker_service import prepare_worker_lock_reexec, worker_run_lock
+
+if os.environ.get("LSM_LOCK_REEXEC_STAGE") == "2":
+    with worker_run_lock():
+        print("lock inherited", flush=True)
+else:
+    with worker_run_lock():
+        os.environ["LSM_LOCK_REEXEC_STAGE"] = "2"
+        prepare_worker_lock_reexec()
+        os.execv(sys.executable, [sys.executable, __file__])
+""",
+        encoding="utf-8",
+    )
+    environment = os.environ.copy()
+    source_root = str(Path(__file__).resolve().parents[1] / "src")
+    environment["PYTHONPATH"] = os.pathsep.join(
+        part for part in (source_root, environment.get("PYTHONPATH", "")) if part
+    )
+
+    completed = subprocess.run(
+        [sys.executable, str(script)],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == "lock inherited"
+
+
 def test_process_environment_scrubs_inherited_worker_scope(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
     monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", "/stale/workspace")
@@ -177,6 +241,7 @@ def test_process_environment_scrubs_inherited_worker_scope(tmp_path, monkeypatch
     assert "LOCAL_SHELL_MCP_WORKSPACE_ROOT" not in env
     assert "LOCAL_SHELL_MCP_ALLOW_FULL_CONTAINER" not in env
     assert env["LOCAL_SHELL_MCP_WORKER_STATE_DIR"] == str((tmp_path / "state").resolve())
+    assert env["LOCAL_SHELL_MCP_WORKER_MANAGED"] == "1"
 
 
 def test_process_fallback_is_reported_without_native_service_file(tmp_path, monkeypatch):

--- a/tests/test_remote_worker_service.py
+++ b/tests/test_remote_worker_service.py
@@ -129,15 +129,12 @@ def test_process_fallback_start_stop_and_stale_pid(tmp_path, monkeypatch):
 def test_worker_run_lock_rejects_duplicate_and_reports_owner(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
 
-    with service.worker_run_lock():
-        raw = service.worker_lock_path().read_bytes()
-        owner = json.loads(raw[1:].decode("utf-8"))
-        assert owner["pid"] == os.getpid()
-        with (
-            pytest.raises(service.WorkerAlreadyRunningError, match=rf"PID {os.getpid()}"),
-            service.worker_run_lock(),
-        ):
-            pass
+    with (
+        service.worker_run_lock(),
+        pytest.raises(service.WorkerAlreadyRunningError, match=rf"PID {os.getpid()}"),
+        service.worker_run_lock(),
+    ):
+        pass
 
     assert service.worker_lock_path().exists()
     with service.worker_run_lock():


### PR DESCRIPTION
## Summary

Implements the first-stage fixes from #104 without adding server-side session fencing yet.

- hold an OS-backed process-lifetime lock for every remote worker execution path
- reject a second worker process with the current owner PID and an actionable restart command
- use `flock` on POSIX and `msvcrt.locking` on Windows; locks are released automatically after abnormal process exit
- advertise `poll_timeout_s` during register/resume
- bound each poll to the advertised long-poll interval plus 10 seconds of grace
- add a 10-second curl connect timeout to all worker control-plane requests

## Commit structure

1. `872161d` — process-wide worker single-instance lock and regressions
2. `e2228af` — advertised poll timing, connect/total deadlines, and regressions

## Validation

- `ruff check .`
- Python: 553 tests passed
- UI: 100 tests passed, type-check and build passed
- PTY smoke passed
- browser smoke passed
- combined branch coverage: 94.27%, all modules >= 90%

Refs #104
