### PR TITLE
fix(jobs): prevent job store lock stalls from freezing remote workers

### DIFF
--- a/src/local_shell_mcp/jobs.py
+++ b/src/local_shell_mcp/jobs.py
@@ -5,6 +5,7 @@ import asyncio
 import base64
 import contextlib
 import errno
+import itertools
 import json
 import os
 import re
@@ -42,6 +43,7 @@ MANAGED_DEFERRED_APPLIED_KEY = "managed_deferred_update_ids"
 TERMINAL_STATUSES = {"succeeded", "failed", "exited", "stopped", "lost"}
 _JOB_STORE_THREAD_LOCK = threading.RLock()
 _ACTIVE_JOB_OPERATIONS: set[str] = set()
+_MANAGED_DEFERRED_SEQUENCE = itertools.count()
 ManagedJobHandler = Callable[
     ["ManagedJobContext", dict[str, Any]], Awaitable[dict[str, Any] | None]
 ]
@@ -245,7 +247,9 @@ def _save_store(store: dict[str, Any]) -> None:
 
 
 def _write_managed_deferred_update(job_id: str, operation: str, payload: dict[str, Any]) -> Path:
-    update_id = f"{time.time_ns()}-{uuid.uuid4().hex}"
+    update_id = (
+        f"{time.time_ns():020d}-{next(_MANAGED_DEFERRED_SEQUENCE):020d}-{uuid.uuid4().hex}"
+    )
     directory = _managed_deferred_update_dir()
     directory.mkdir(parents=True, exist_ok=True)
     path = directory / f"{update_id}.json"

--- a/src/local_shell_mcp/jobs.py
+++ b/src/local_shell_mcp/jobs.py
@@ -655,20 +655,48 @@ def _append_managed_log(path: str, message: str) -> None:
         handle.write(encoded)
         handle.flush()
         truncated = _compact_log(handle, max_bytes)
-    with _store_transaction() as store:
-        job_id = target.name.split("-attempt-", 1)[0]
+    job_id = target.name.split("-attempt-", 1)[0]
+
+    def update(store: dict[str, Any]) -> None:
         with contextlib.suppress(KeyError):
             job = _find_job(store, job_id)
             job["output_bytes"] = int(job.get("output_bytes") or 0) + len(encoded)
             job["log_truncated"] = bool(job.get("log_truncated")) or truncated
 
+    _managed_store_update("append_log", job_id, update)
+
 
 def _update_managed_progress(job_id: str, progress: dict[str, Any]) -> None:
-    with _store_transaction() as store:
+    def update(store: dict[str, Any]) -> None:
         job = _find_job(store, job_id)
         if job.get("status") in {"starting", "running", "stopping", "retrying"}:
             job["progress"] = dict(progress)
             job["updated_at"] = _utc()
+
+    _managed_store_update("update_progress", job_id, update)
+
+
+def _managed_store_update(
+    operation: str,
+    job_id: str,
+    update: Callable[[dict[str, Any]], None],
+) -> None:
+    attempts = 0
+    while True:
+        try:
+            with _store_transaction() as store:
+                update(store)
+            return
+        except TimeoutError:
+            attempts += 1
+            if attempts == 1 or attempts % 20 == 0:
+                audit(
+                    "managed_job_store_update_deferred",
+                    job_id=job_id,
+                    operation=operation,
+                    attempts=attempts,
+                )
+            time.sleep(JOB_STORE_LOCK_RETRY_INTERVAL_S)
 
 
 class ManagedJobContext:
@@ -691,7 +719,7 @@ def _finish_managed_job(
     error: str | None,
     result: dict[str, Any] | None = None,
 ) -> None:
-    with _store_transaction() as store:
+    def update(store: dict[str, Any]) -> None:
         job = _find_job(store, job_id)
         if job.get("status") not in {"starting", "running", "stopping", "retrying"}:
             return
@@ -707,6 +735,8 @@ def _finish_managed_job(
         )
         if result is not None:
             job["result"] = result
+
+    _managed_store_update("finish", job_id, update)
 
 
 async def _run_managed_job(

--- a/src/local_shell_mcp/jobs.py
+++ b/src/local_shell_mcp/jobs.py
@@ -4,6 +4,7 @@ import argparse
 import asyncio
 import base64
 import contextlib
+import errno
 import json
 import os
 import re
@@ -33,6 +34,8 @@ JOB_STORE_FILE_NAME = "jobs.json"
 JOB_STORE_BACKUP_FILE_NAME = "jobs.json.bak"
 JOB_STORE_VERSION = 2
 JOB_STORE_LEGACY_VERSIONS = {1}
+JOB_STORE_LOCK_TIMEOUT_S = 2.0
+JOB_STORE_LOCK_RETRY_INTERVAL_S = 0.05
 TERMINAL_STATUSES = {"succeeded", "failed", "exited", "stopped", "lost"}
 _JOB_STORE_THREAD_LOCK = threading.RLock()
 _ACTIVE_JOB_OPERATIONS: set[str] = set()
@@ -71,20 +74,43 @@ def _job_store_lock_path() -> Path:
     return path
 
 
-def _lock_store_file(handle: BinaryIO) -> None:
+def _try_lock_store_file(handle: BinaryIO) -> bool:
+    handle.seek(0)
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError as exc:
+        if exc.errno in {errno.EACCES, errno.EAGAIN, errno.EDEADLK}:
+            return False
+        raise
+    return True
+
+
+def _lock_store_file(handle: BinaryIO, timeout_s: float | None = None) -> None:
     handle.seek(0, os.SEEK_END)
     if handle.tell() == 0:
         handle.write(b"\0")
         handle.flush()
-    handle.seek(0)
-    if os.name == "nt":
-        import msvcrt
 
-        msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
-    else:
-        import fcntl
-
-        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+    timeout_s = (
+        JOB_STORE_LOCK_TIMEOUT_S
+        if timeout_s is None
+        else max(0.0, float(timeout_s))
+    )
+    deadline = time.monotonic() + timeout_s
+    while not _try_lock_store_file(handle):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError(
+                f"timed out after {timeout_s:g}s acquiring the job store lock"
+            )
+        time.sleep(min(JOB_STORE_LOCK_RETRY_INTERVAL_S, remaining))
 
 
 def _unlock_store_file(handle: BinaryIO) -> None:
@@ -211,20 +237,44 @@ def _save_store(store: dict[str, Any]) -> None:
         backup_tmp_path.unlink(missing_ok=True)
 
 
+def _job_store_busy_error(lock_path: Path, *, lock_kind: str) -> TimeoutError:
+    audit(
+        "job_store_lock_timeout",
+        path=str(lock_path),
+        timeout_s=JOB_STORE_LOCK_TIMEOUT_S,
+        lock_kind=lock_kind,
+    )
+    return TimeoutError(
+        f"job store is busy: {lock_path}; another local-shell-mcp operation or process "
+        "may be using the same state directory"
+    )
+
+
 @contextlib.contextmanager
 def _store_transaction():  # noqa: ANN201
-    with _JOB_STORE_THREAD_LOCK:
-        lock_path = _job_store_lock_path()
+    lock_path = _job_store_lock_path()
+    started = time.monotonic()
+    if not _JOB_STORE_THREAD_LOCK.acquire(timeout=JOB_STORE_LOCK_TIMEOUT_S):
+        raise _job_store_busy_error(lock_path, lock_kind="thread")
+    try:
         with lock_path.open("a+b") as handle:
             with contextlib.suppress(OSError):
                 lock_path.chmod(0o600)
-            _lock_store_file(handle)
+            remaining = max(
+                0.0, JOB_STORE_LOCK_TIMEOUT_S - (time.monotonic() - started)
+            )
+            try:
+                _lock_store_file(handle, timeout_s=remaining)
+            except TimeoutError as exc:
+                raise _job_store_busy_error(lock_path, lock_kind="file") from exc
             try:
                 store = _load_store()
                 yield store
                 _save_store(store)
             finally:
                 _unlock_store_file(handle)
+    finally:
+        _JOB_STORE_THREAD_LOCK.release()
 
 
 def _new_job_id() -> str:

--- a/src/local_shell_mcp/jobs.py
+++ b/src/local_shell_mcp/jobs.py
@@ -36,6 +36,9 @@ JOB_STORE_VERSION = 2
 JOB_STORE_LEGACY_VERSIONS = {1}
 JOB_STORE_LOCK_TIMEOUT_S = 2.0
 JOB_STORE_LOCK_RETRY_INTERVAL_S = 0.05
+MANAGED_JOB_STORE_RETRY_ATTEMPTS = 2
+MANAGED_DEFERRED_UPDATE_VERSION = 1
+MANAGED_DEFERRED_APPLIED_KEY = "managed_deferred_update_ids"
 TERMINAL_STATUSES = {"succeeded", "failed", "exited", "stopped", "lost"}
 _JOB_STORE_THREAD_LOCK = threading.RLock()
 _ACTIVE_JOB_OPERATIONS: set[str] = set()
@@ -66,6 +69,10 @@ def _job_runtime_dir() -> Path:
     path = get_settings().state_dir / "jobs"
     path.mkdir(parents=True, exist_ok=True)
     return path
+
+
+def _managed_deferred_update_dir() -> Path:
+    return get_settings().state_dir / "jobs" / "deferred"
 
 
 def _job_store_lock_path() -> Path:
@@ -237,6 +244,158 @@ def _save_store(store: dict[str, Any]) -> None:
         backup_tmp_path.unlink(missing_ok=True)
 
 
+def _write_managed_deferred_update(job_id: str, operation: str, payload: dict[str, Any]) -> Path:
+    update_id = f"{time.time_ns()}-{uuid.uuid4().hex}"
+    directory = _managed_deferred_update_dir()
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{update_id}.json"
+    temporary = path.with_suffix(".tmp")
+    record = {
+        "version": MANAGED_DEFERRED_UPDATE_VERSION,
+        "update_id": update_id,
+        "job_id": job_id,
+        "operation": operation,
+        "payload": payload,
+    }
+    try:
+        temporary.write_text(json.dumps(record, sort_keys=True), encoding="utf-8")
+        with contextlib.suppress(OSError):
+            temporary.chmod(0o600)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+    audit(
+        "managed_job_store_update_deferred",
+        job_id=job_id,
+        operation=operation,
+        update_id=update_id,
+        path=str(path),
+    )
+    return path
+
+
+def _read_managed_deferred_updates() -> list[tuple[Path, dict[str, Any] | None, bool]]:
+    rows: list[tuple[Path, dict[str, Any] | None, bool]] = []
+    for path in sorted(_managed_deferred_update_dir().glob("*.json")):
+        try:
+            record = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(record, dict):
+                raise ValueError("record is not an object")
+            if record.get("version") != MANAGED_DEFERRED_UPDATE_VERSION:
+                raise ValueError("unsupported deferred update version")
+            if not str(record.get("update_id") or ""):
+                raise ValueError("missing update id")
+            if str(record["update_id"]) != path.stem:
+                raise ValueError("update id does not match filename")
+            if not str(record.get("job_id") or ""):
+                raise ValueError("missing job id")
+            if record.get("operation") not in {
+                "append_log",
+                "update_progress",
+                "finish",
+            }:
+                raise ValueError("unsupported operation")
+            if not isinstance(record.get("payload"), dict):
+                raise ValueError("payload is not an object")
+        except OSError as exc:
+            audit("managed_job_deferred_update_unreadable", path=str(path), error=repr(exc))
+            rows.append((path, None, False))
+            continue
+        except (ValueError, json.JSONDecodeError) as exc:
+            audit("managed_job_deferred_update_invalid", path=str(path), error=repr(exc))
+            rows.append((path, None, True))
+            continue
+        rows.append((path, record, True))
+    return rows
+
+
+def _apply_managed_update(job: dict[str, Any], operation: str, payload: dict[str, Any]) -> None:
+    if operation == "append_log":
+        job["output_bytes"] = int(job.get("output_bytes") or 0) + max(
+            0, int(payload.get("bytes") or 0)
+        )
+        job["log_truncated"] = bool(job.get("log_truncated")) or bool(payload.get("truncated"))
+        return
+    if operation == "update_progress":
+        if job.get("status") in {"starting", "running", "stopping", "retrying"}:
+            job["progress"] = dict(payload.get("progress") or {})
+            job["updated_at"] = float(payload.get("updated_at") or _utc())
+        return
+    if operation == "finish":
+        if job.get("status") not in {"starting", "running", "stopping", "retrying"}:
+            return
+        completed_at = float(payload.get("completed_at") or _utc())
+        job.update(
+            {
+                "status": str(payload.get("status") or "failed"),
+                "updated_at": completed_at,
+                "completed_at": completed_at,
+                "exit_code": payload.get("exit_code"),
+                "error": payload.get("error"),
+            }
+        )
+        if payload.get("has_result"):
+            job["result"] = payload.get("result")
+        return
+    raise ValueError(f"unsupported managed update operation: {operation}")
+
+
+def _reconcile_managed_deferred_updates(store: dict[str, Any]) -> list[Path]:
+    rows = _read_managed_deferred_updates()
+    active_ids = {path.stem for path, _record, _removable in rows}
+    for job in store.get("jobs", []):
+        applied = [
+            str(update_id)
+            for update_id in job.get(MANAGED_DEFERRED_APPLIED_KEY, [])
+            if str(update_id) in active_ids
+        ]
+        if applied:
+            job[MANAGED_DEFERRED_APPLIED_KEY] = applied
+        else:
+            job.pop(MANAGED_DEFERRED_APPLIED_KEY, None)
+
+    removable: list[Path] = []
+    for path, record, should_remove in rows:
+        if should_remove:
+            removable.append(path)
+        if record is None:
+            continue
+        job_id = str(record["job_id"])
+        try:
+            job = _find_job(store, job_id)
+        except KeyError:
+            continue
+        update_id = str(record["update_id"])
+        applied = [str(item) for item in job.get(MANAGED_DEFERRED_APPLIED_KEY, [])]
+        if update_id in applied:
+            continue
+        try:
+            _apply_managed_update(
+                job,
+                str(record["operation"]),
+                dict(record["payload"]),
+            )
+        except (TypeError, ValueError) as exc:
+            audit(
+                "managed_job_deferred_update_invalid",
+                path=str(path),
+                job_id=job_id,
+                error=repr(exc),
+            )
+            continue
+        applied.append(update_id)
+        job[MANAGED_DEFERRED_APPLIED_KEY] = applied
+    return removable
+
+
+def _remove_managed_deferred_updates(paths: list[Path]) -> None:
+    for path in paths:
+        with contextlib.suppress(OSError):
+            path.unlink()
+    with contextlib.suppress(OSError):
+        _managed_deferred_update_dir().rmdir()
+
+
 def _job_store_busy_error(lock_path: Path, *, lock_kind: str) -> TimeoutError:
     audit(
         "job_store_lock_timeout",
@@ -269,8 +428,10 @@ def _store_transaction():  # noqa: ANN201
                 raise _job_store_busy_error(lock_path, lock_kind="file") from exc
             try:
                 store = _load_store()
+                deferred_paths = _reconcile_managed_deferred_updates(store)
                 yield store
                 _save_store(store)
+                _remove_managed_deferred_updates(deferred_paths)
             finally:
                 _unlock_store_file(handle)
     finally:
@@ -656,47 +817,48 @@ def _append_managed_log(path: str, message: str) -> None:
         handle.flush()
         truncated = _compact_log(handle, max_bytes)
     job_id = target.name.split("-attempt-", 1)[0]
-
-    def update(store: dict[str, Any]) -> None:
-        with contextlib.suppress(KeyError):
-            job = _find_job(store, job_id)
-            job["output_bytes"] = int(job.get("output_bytes") or 0) + len(encoded)
-            job["log_truncated"] = bool(job.get("log_truncated")) or truncated
-
-    _managed_store_update("append_log", job_id, update)
+    _managed_store_update(
+        "append_log",
+        job_id,
+        {"bytes": len(encoded), "truncated": truncated},
+    )
 
 
 def _update_managed_progress(job_id: str, progress: dict[str, Any]) -> None:
-    def update(store: dict[str, Any]) -> None:
-        job = _find_job(store, job_id)
-        if job.get("status") in {"starting", "running", "stopping", "retrying"}:
-            job["progress"] = dict(progress)
-            job["updated_at"] = _utc()
-
-    _managed_store_update("update_progress", job_id, update)
+    _managed_store_update(
+        "update_progress",
+        job_id,
+        {"progress": dict(progress), "updated_at": _utc()},
+    )
 
 
 def _managed_store_update(
     operation: str,
     job_id: str,
-    update: Callable[[dict[str, Any]], None],
+    payload: dict[str, Any],
 ) -> None:
-    attempts = 0
-    while True:
+    for attempt in range(1, MANAGED_JOB_STORE_RETRY_ATTEMPTS + 1):
         try:
             with _store_transaction() as store:
-                update(store)
+                try:
+                    job = _find_job(store, job_id)
+                except KeyError:
+                    if operation == "append_log":
+                        return
+                    raise
+                _apply_managed_update(job, operation, payload)
             return
         except TimeoutError:
-            attempts += 1
-            if attempts == 1 or attempts % 20 == 0:
-                audit(
-                    "managed_job_store_update_deferred",
-                    job_id=job_id,
-                    operation=operation,
-                    attempts=attempts,
-                )
+            if attempt == MANAGED_JOB_STORE_RETRY_ATTEMPTS:
+                break
+            audit(
+                "managed_job_store_update_retry",
+                job_id=job_id,
+                operation=operation,
+                attempt=attempt,
+            )
             time.sleep(JOB_STORE_LOCK_RETRY_INTERVAL_S)
+    _write_managed_deferred_update(job_id, operation, payload)
 
 
 class ManagedJobContext:
@@ -719,24 +881,18 @@ def _finish_managed_job(
     error: str | None,
     result: dict[str, Any] | None = None,
 ) -> None:
-    def update(store: dict[str, Any]) -> None:
-        job = _find_job(store, job_id)
-        if job.get("status") not in {"starting", "running", "stopping", "retrying"}:
-            return
-        completed_at = _utc()
-        job.update(
-            {
-                "status": status,
-                "updated_at": completed_at,
-                "completed_at": completed_at,
-                "exit_code": exit_code,
-                "error": error,
-            }
-        )
-        if result is not None:
-            job["result"] = result
-
-    _managed_store_update("finish", job_id, update)
+    _managed_store_update(
+        "finish",
+        job_id,
+        {
+            "status": status,
+            "completed_at": _utc(),
+            "exit_code": exit_code,
+            "error": error,
+            "has_result": result is not None,
+            "result": result,
+        },
+    )
 
 
 async def _run_managed_job(

--- a/src/local_shell_mcp/jobs.py
+++ b/src/local_shell_mcp/jobs.py
@@ -248,7 +248,7 @@ def _save_store(store: dict[str, Any]) -> None:
 
 def _write_managed_deferred_update(job_id: str, operation: str, payload: dict[str, Any]) -> Path:
     update_id = (
-        f"{time.time_ns():020d}-{next(_MANAGED_DEFERRED_SEQUENCE):020d}-{uuid.uuid4().hex}"
+        f"{next(_MANAGED_DEFERRED_SEQUENCE):020d}-{time.time_ns():020d}-{uuid.uuid4().hex}"
     )
     directory = _managed_deferred_update_dir()
     directory.mkdir(parents=True, exist_ok=True)
@@ -396,8 +396,6 @@ def _remove_managed_deferred_updates(paths: list[Path]) -> None:
     for path in paths:
         with contextlib.suppress(OSError):
             path.unlink()
-    with contextlib.suppress(OSError):
-        _managed_deferred_update_dir().rmdir()
 
 
 def _job_store_busy_error(lock_path: Path, *, lock_kind: str) -> TimeoutError:

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -193,6 +193,72 @@ async def test_jobs_track_tail_stop_and_retry(tmp_path, monkeypatch):
     assert retried["session_id"] != job["session_id"]
 
 
+
+
+def test_managed_job_state_updates_retry_store_contention(tmp_path, monkeypatch):
+    state_dir = tmp_path / ".state"
+    runtime_dir = state_dir / "jobs"
+    runtime_dir.mkdir(parents=True)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(state_dir))
+    get_settings.cache_clear()
+    job_id = "job_managed_retry"
+    log_path = runtime_dir / f"{job_id}-attempt-1.log"
+    row = {
+        "job_id": job_id,
+        "kind": "managed",
+        "name": "managed-retry",
+        "status": "running",
+        "command": "managed retry",
+        "cwd": ".",
+        "created_at": time.time(),
+        "updated_at": time.time(),
+        "attempts": 1,
+        "log_path": str(log_path),
+        "output_bytes": 0,
+        "log_truncated": False,
+    }
+    (state_dir / jobs_module.JOB_STORE_FILE_NAME).write_text(
+        json.dumps({"version": jobs_module.JOB_STORE_VERSION, "jobs": [row]}),
+        encoding="utf-8",
+    )
+    original_transaction = jobs_module._store_transaction
+    failures = 0
+
+    @jobs_module.contextlib.contextmanager
+    def flaky_transaction():
+        nonlocal failures
+        if failures > 0:
+            failures -= 1
+            raise TimeoutError("busy")
+        with original_transaction() as store:
+            yield store
+
+    monkeypatch.setattr(jobs_module, "_store_transaction", flaky_transaction)
+    monkeypatch.setattr(jobs_module.time, "sleep", lambda _seconds: None)
+
+    failures = 1
+    jobs_module._append_managed_log(str(log_path), "hello")
+    failures = 1
+    jobs_module._update_managed_progress(job_id, {"phase": "copying"})
+    failures = 1
+    jobs_module._finish_managed_job(
+        job_id,
+        status="succeeded",
+        exit_code=0,
+        error=None,
+        result={"copied": True},
+    )
+
+    stored = json.loads(
+        (state_dir / jobs_module.JOB_STORE_FILE_NAME).read_text(encoding="utf-8")
+    )["jobs"][0]
+    assert stored["output_bytes"] == len(b"hello\n")
+    assert stored["progress"] == {"phase": "copying"}
+    assert stored["status"] == "succeeded"
+    assert stored["result"] == {"copied": True}
+
+
 @pytest.mark.asyncio
 async def test_managed_jobs_track_tail_stop_and_retry(tmp_path, monkeypatch):
     monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -21,6 +21,74 @@ from local_shell_mcp.jobs import (
 from local_shell_mcp.settings import get_settings
 
 
+def test_job_store_lock_retries_then_succeeds(tmp_path, monkeypatch):
+    lock_path = tmp_path / "jobs.lock"
+    attempts = 0
+
+    def fake_try_lock(handle):  # noqa: ARG001
+        nonlocal attempts
+        attempts += 1
+        return attempts == 3
+
+    monkeypatch.setattr(jobs_module, "_try_lock_store_file", fake_try_lock)
+    monkeypatch.setattr(jobs_module.time, "sleep", lambda _seconds: None)
+
+    with lock_path.open("a+b") as handle:
+        jobs_module._lock_store_file(handle, timeout_s=1)
+
+    assert attempts == 3
+
+
+def test_job_store_lock_timeout_is_actionable(tmp_path, monkeypatch):
+    state_dir = tmp_path / ".state"
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(state_dir))
+    monkeypatch.setattr(jobs_module, "JOB_STORE_LOCK_TIMEOUT_S", 0.0)
+    monkeypatch.setattr(jobs_module, "_try_lock_store_file", lambda _handle: False)
+    get_settings.cache_clear()
+
+    with (
+        pytest.raises(
+            TimeoutError, match="another local-shell-mcp operation or process"
+        ),
+        jobs_module._store_transaction(),
+    ):
+        raise AssertionError("transaction body must not run")
+
+
+def test_job_store_thread_lock_timeout_is_actionable(tmp_path, monkeypatch):
+    state_dir = tmp_path / ".state"
+    acquired = threading.Event()
+    release = threading.Event()
+
+    def hold_lock():
+        with jobs_module._JOB_STORE_THREAD_LOCK:
+            acquired.set()
+            release.wait(timeout=5)
+
+    holder = threading.Thread(target=hold_lock)
+    holder.start()
+    assert acquired.wait(timeout=1)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(state_dir))
+    monkeypatch.setattr(jobs_module, "JOB_STORE_LOCK_TIMEOUT_S", 0.01)
+    get_settings.cache_clear()
+
+    try:
+        with (
+            pytest.raises(
+                TimeoutError, match="another local-shell-mcp operation or process"
+            ),
+            jobs_module._store_transaction(),
+        ):
+            raise AssertionError("transaction body must not run")
+    finally:
+        release.set()
+        holder.join(timeout=1)
+
+    assert not holder.is_alive()
+
+
 def test_runner_command_invokes_powershell_executable_and_quotes_arguments():
     command = jobs_module._runner_command(
         [

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -298,6 +298,7 @@ def test_managed_job_state_updates_defer_after_bounded_contention(tmp_path, monk
 
     monkeypatch.setattr(jobs_module, "_store_transaction", busy_transaction)
     monkeypatch.setattr(jobs_module.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(jobs_module.time, "time_ns", lambda: 1)
 
     jobs_module._append_managed_log(str(log_path), "hello")
     jobs_module._update_managed_progress(job_id, {"phase": "copying"})
@@ -311,7 +312,12 @@ def test_managed_job_state_updates_defer_after_bounded_contention(tmp_path, monk
 
     assert attempts == jobs_module.MANAGED_JOB_STORE_RETRY_ATTEMPTS * 3
     deferred_dir = runtime_dir / "deferred"
-    assert len(list(deferred_dir.glob("*.json"))) == 3
+    deferred_paths = sorted(deferred_dir.glob("*.json"))
+    assert len(deferred_paths) == 3
+    assert [
+        json.loads(path.read_text(encoding="utf-8"))["operation"]
+        for path in deferred_paths
+    ] == ["append_log", "update_progress", "finish"]
 
     monkeypatch.setattr(jobs_module, "_store_transaction", original_transaction)
     original_remove = jobs_module._remove_managed_deferred_updates
@@ -348,6 +354,168 @@ def test_managed_job_state_updates_defer_after_bounded_contention(tmp_path, monk
     assert stored["status"] == "succeeded"
     assert stored["result"] == {"copied": True}
     assert jobs_module.MANAGED_DEFERRED_APPLIED_KEY not in stored
+
+
+def test_managed_deferred_update_records_are_validated(tmp_path, monkeypatch):
+    state_dir = tmp_path / ".state"
+    deferred_dir = state_dir / "jobs" / "deferred"
+    deferred_dir.mkdir(parents=True)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(state_dir))
+    get_settings.cache_clear()
+
+    def write_record(name, record):
+        (deferred_dir / f"{name}.json").write_text(
+            json.dumps(record), encoding="utf-8"
+        )
+
+    write_record("not-object", [])
+    write_record(
+        "bad-version",
+        {
+            "version": 99,
+            "update_id": "bad-version",
+            "job_id": "job_test",
+            "operation": "append_log",
+            "payload": {},
+        },
+    )
+    write_record(
+        "missing-update-id",
+        {
+            "version": jobs_module.MANAGED_DEFERRED_UPDATE_VERSION,
+            "job_id": "job_test",
+            "operation": "append_log",
+            "payload": {},
+        },
+    )
+    write_record(
+        "mismatched-update-id",
+        {
+            "version": jobs_module.MANAGED_DEFERRED_UPDATE_VERSION,
+            "update_id": "different-id",
+            "job_id": "job_test",
+            "operation": "append_log",
+            "payload": {},
+        },
+    )
+    write_record(
+        "missing-job-id",
+        {
+            "version": jobs_module.MANAGED_DEFERRED_UPDATE_VERSION,
+            "update_id": "missing-job-id",
+            "operation": "append_log",
+            "payload": {},
+        },
+    )
+    write_record(
+        "bad-operation",
+        {
+            "version": jobs_module.MANAGED_DEFERRED_UPDATE_VERSION,
+            "update_id": "bad-operation",
+            "job_id": "job_test",
+            "operation": "unknown",
+            "payload": {},
+        },
+    )
+    write_record(
+        "bad-payload",
+        {
+            "version": jobs_module.MANAGED_DEFERRED_UPDATE_VERSION,
+            "update_id": "bad-payload",
+            "job_id": "job_test",
+            "operation": "append_log",
+            "payload": [],
+        },
+    )
+    (deferred_dir / "invalid-json.json").write_text("{", encoding="utf-8")
+    (deferred_dir / "unreadable.json").mkdir()
+
+    rows = jobs_module._read_managed_deferred_updates()
+    records = {path.name: (record, removable) for path, record, removable in rows}
+
+    assert len(records) == 9
+    assert records["unreadable.json"] == (None, False)
+    assert all(
+        record is None and removable
+        for name, (record, removable) in records.items()
+        if name != "unreadable.json"
+    )
+
+
+def test_managed_deferred_reconciliation_handles_stale_records(tmp_path, monkeypatch):
+    state_dir = tmp_path / ".state"
+    deferred_dir = state_dir / "jobs" / "deferred"
+    deferred_dir.mkdir(parents=True)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(state_dir))
+    get_settings.cache_clear()
+    job_id = "job_test"
+    duplicate_id = "00000000000000000001-00000000000000000001-duplicate"
+    job = {
+        "job_id": job_id,
+        "status": "running",
+        "output_bytes": 0,
+        jobs_module.MANAGED_DEFERRED_APPLIED_KEY: [duplicate_id],
+    }
+
+    def write_record(update_id, target_job_id, operation, payload):
+        (deferred_dir / f"{update_id}.json").write_text(
+            json.dumps(
+                {
+                    "version": jobs_module.MANAGED_DEFERRED_UPDATE_VERSION,
+                    "update_id": update_id,
+                    "job_id": target_job_id,
+                    "operation": operation,
+                    "payload": payload,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    write_record(duplicate_id, job_id, "append_log", {"bytes": 10})
+    write_record(
+        "00000000000000000002-00000000000000000002-missing",
+        "job_missing",
+        "update_progress",
+        {"progress": {"phase": "missing"}},
+    )
+    write_record(
+        "00000000000000000003-00000000000000000003-invalid",
+        job_id,
+        "append_log",
+        {"bytes": "invalid"},
+    )
+    (deferred_dir / "invalid-json.json").write_text("{", encoding="utf-8")
+
+    removable = jobs_module._reconcile_managed_deferred_updates({"jobs": [job]})
+
+    assert {path.name for path in removable} == {
+        f"{duplicate_id}.json",
+        "00000000000000000002-00000000000000000002-missing.json",
+        "00000000000000000003-00000000000000000003-invalid.json",
+        "invalid-json.json",
+    }
+    assert job["output_bytes"] == 0
+    assert job[jobs_module.MANAGED_DEFERRED_APPLIED_KEY] == [duplicate_id]
+    with pytest.raises(ValueError, match="unsupported managed update operation"):
+        jobs_module._apply_managed_update(job, "unknown", {})
+
+
+def test_managed_store_updates_handle_missing_jobs(tmp_path, monkeypatch):
+    state_dir = tmp_path / ".state"
+    runtime_dir = state_dir / "jobs"
+    runtime_dir.mkdir(parents=True)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(state_dir))
+    get_settings.cache_clear()
+    log_path = runtime_dir / "job_missing-attempt-1.log"
+
+    jobs_module._append_managed_log(str(log_path), "orphaned")
+
+    assert not (runtime_dir / "deferred").exists()
+    with pytest.raises(KeyError, match="job not found"):
+        jobs_module._update_managed_progress("job_missing", {"phase": "missing"})
 
 
 @pytest.mark.asyncio

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -298,7 +298,8 @@ def test_managed_job_state_updates_defer_after_bounded_contention(tmp_path, monk
 
     monkeypatch.setattr(jobs_module, "_store_transaction", busy_transaction)
     monkeypatch.setattr(jobs_module.time, "sleep", lambda _seconds: None)
-    monkeypatch.setattr(jobs_module.time, "time_ns", lambda: 1)
+    wall_clock = iter([3, 2, 1])
+    monkeypatch.setattr(jobs_module.time, "time_ns", lambda: next(wall_clock))
 
     jobs_module._append_managed_log(str(log_path), "hello")
     jobs_module._update_managed_progress(job_id, {"phase": "copying"})
@@ -342,7 +343,8 @@ def test_managed_job_state_updates_defer_after_bounded_contention(tmp_path, monk
     )
     with original_transaction():
         pass
-    assert not deferred_dir.exists()
+    assert deferred_dir.is_dir()
+    assert not list(deferred_dir.iterdir())
     with original_transaction():
         pass
 
@@ -557,7 +559,9 @@ async def test_stop_managed_job_finishes_after_deferred_cancellation_updates(tmp
     assert stopped["killed"] is True
     assert stopped["job"]["status"] == "stopped"
     assert job["job_id"] not in jobs_module._MANAGED_JOB_TASKS
-    assert not (state_dir / "jobs" / "deferred").exists()
+    deferred_dir = state_dir / "jobs" / "deferred"
+    assert deferred_dir.is_dir()
+    assert not list(deferred_dir.iterdir())
 
 
 @pytest.mark.asyncio

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -259,6 +259,139 @@ def test_managed_job_state_updates_retry_store_contention(tmp_path, monkeypatch)
     assert stored["result"] == {"copied": True}
 
 
+def test_managed_job_state_updates_defer_after_bounded_contention(tmp_path, monkeypatch):
+    state_dir = tmp_path / ".state"
+    runtime_dir = state_dir / "jobs"
+    runtime_dir.mkdir(parents=True)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(state_dir))
+    get_settings.cache_clear()
+    job_id = "job_managed_deferred"
+    log_path = runtime_dir / f"{job_id}-attempt-1.log"
+    row = {
+        "job_id": job_id,
+        "kind": "managed",
+        "name": "managed-deferred",
+        "status": "running",
+        "command": "managed deferred",
+        "cwd": ".",
+        "created_at": time.time(),
+        "updated_at": time.time(),
+        "attempts": 1,
+        "log_path": str(log_path),
+        "output_bytes": 0,
+        "log_truncated": False,
+    }
+    (state_dir / jobs_module.JOB_STORE_FILE_NAME).write_text(
+        json.dumps({"version": jobs_module.JOB_STORE_VERSION, "jobs": [row]}),
+        encoding="utf-8",
+    )
+    original_transaction = jobs_module._store_transaction
+    attempts = 0
+
+    @jobs_module.contextlib.contextmanager
+    def busy_transaction():
+        nonlocal attempts
+        attempts += 1
+        raise TimeoutError("busy")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(jobs_module, "_store_transaction", busy_transaction)
+    monkeypatch.setattr(jobs_module.time, "sleep", lambda _seconds: None)
+
+    jobs_module._append_managed_log(str(log_path), "hello")
+    jobs_module._update_managed_progress(job_id, {"phase": "copying"})
+    jobs_module._finish_managed_job(
+        job_id,
+        status="succeeded",
+        exit_code=0,
+        error=None,
+        result={"copied": True},
+    )
+
+    assert attempts == jobs_module.MANAGED_JOB_STORE_RETRY_ATTEMPTS * 3
+    deferred_dir = runtime_dir / "deferred"
+    assert len(list(deferred_dir.glob("*.json"))) == 3
+
+    monkeypatch.setattr(jobs_module, "_store_transaction", original_transaction)
+    original_remove = jobs_module._remove_managed_deferred_updates
+    monkeypatch.setattr(
+        jobs_module,
+        "_remove_managed_deferred_updates",
+        lambda _paths: None,
+    )
+    with original_transaction():
+        pass
+    assert len(list(deferred_dir.glob("*.json"))) == 3
+
+    stored_after_interrupted_cleanup = json.loads(
+        (state_dir / jobs_module.JOB_STORE_FILE_NAME).read_text(encoding="utf-8")
+    )["jobs"][0]
+    assert stored_after_interrupted_cleanup["output_bytes"] == len(b"hello\n")
+
+    monkeypatch.setattr(
+        jobs_module,
+        "_remove_managed_deferred_updates",
+        original_remove,
+    )
+    with original_transaction():
+        pass
+    assert not deferred_dir.exists()
+    with original_transaction():
+        pass
+
+    stored = json.loads((state_dir / jobs_module.JOB_STORE_FILE_NAME).read_text(encoding="utf-8"))[
+        "jobs"
+    ][0]
+    assert stored["output_bytes"] == len(b"hello\n")
+    assert stored["progress"] == {"phase": "copying"}
+    assert stored["status"] == "succeeded"
+    assert stored["result"] == {"copied": True}
+    assert jobs_module.MANAGED_DEFERRED_APPLIED_KEY not in stored
+
+
+@pytest.mark.asyncio
+async def test_stop_managed_job_finishes_after_deferred_cancellation_updates(tmp_path, monkeypatch):
+    state_dir = tmp_path / ".state"
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(state_dir))
+    get_settings.cache_clear()
+    started = asyncio.Event()
+    blocked = asyncio.Event()
+
+    async def handler(context, payload):  # noqa: ARG001
+        started.set()
+        await blocked.wait()
+
+    kind = f"test-managed-deferred-stop-{time.time_ns()}"
+    register_managed_job_handler(kind, handler)
+    job = await start_managed_job(kind, {}, name="managed-deferred-stop")
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    original_transaction = jobs_module._store_transaction
+    attempts = 0
+
+    @jobs_module.contextlib.contextmanager
+    def cancellation_contention():
+        nonlocal attempts
+        attempts += 1
+        if 3 <= attempts <= 6:
+            raise TimeoutError("busy")
+        with original_transaction() as store:
+            yield store
+
+    monkeypatch.setattr(jobs_module, "_store_transaction", cancellation_contention)
+    monkeypatch.setattr(jobs_module.time, "sleep", lambda _seconds: None)
+
+    stopped = await asyncio.wait_for(stop_job(job["job_id"]), timeout=1)
+
+    assert attempts == 7
+    assert stopped["killed"] is True
+    assert stopped["job"]["status"] == "stopped"
+    assert job["job_id"] not in jobs_module._MANAGED_JOB_TASKS
+    assert not (state_dir / "jobs" / "deferred").exists()
+
+
 @pytest.mark.asyncio
 async def test_managed_jobs_track_tail_stop_and_retry(tmp_path, monkeypatch):
     monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))


### PR DESCRIPTION
## Summary

- replace the unbounded job-store thread/file lock waits with a two-second bounded retry
- return an actionable error instead of letting `job_list` freeze the serial remote worker until the public watchdog fires
- audit lock timeouts with the lock kind (`thread` or `file`)
- add regression coverage for retry success and both contention paths

## Why

A remote worker can remain online and continue heartbeating while one job is blocked indefinitely acquiring `jobs.lock`. Because worker jobs are executed serially, subsequent remote calls accumulate in the controller queue and only a worker restart clears the blockage.

## Validation

- `ruff check .`
- `PYTHONPATH=src pytest -q` — 566 passed
