### PR TITLE
fix(worker): avoid Cloudflare 403 during runtime updates

### DIFF
--- a/src/local_shell_mcp/remote_worker_installer.py
+++ b/src/local_shell_mcp/remote_worker_installer.py
@@ -11,6 +11,7 @@ import urllib.request
 from pathlib import Path
 from typing import Any
 
+from . import __version__
 from .remote_worker_state import (
     read_worker_config,
     update_runtime_metadata,
@@ -24,7 +25,11 @@ _WORKER_MANIFEST_PATH = "/remote/worker-bundle.tgz?manifest=1"
 def _fetch_bytes(url: str, timeout: float = 60) -> bytes:
     request = urllib.request.Request(
         url,
-        headers={"Cache-Control": "no-cache", "Pragma": "no-cache"},
+        headers={
+            "Cache-Control": "no-cache",
+            "Pragma": "no-cache",
+            "User-Agent": f"local-shell-mcp-worker/{__version__}",
+        },
     )
     with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
         return response.read()

--- a/tests/test_remote_worker_installer.py
+++ b/tests/test_remote_worker_installer.py
@@ -135,6 +135,7 @@ def test_fetch_bytes_uses_urlopen(monkeypatch):
     assert request.full_url == "https://example.test/file"
     assert request.headers["Cache-control"] == "no-cache"
     assert request.headers["Pragma"] == "no-cache"
+    assert request.headers["User-agent"] == f"local-shell-mcp-worker/{installer.__version__}"
     assert timeout == 7
 
 


### PR DESCRIPTION
## Summary

- send a stable `local-shell-mcp-worker/<version>` User-Agent for worker manifest and bundle downloads
- keep the existing no-cache request headers
- add regression coverage for the constructed urllib request

## Why

Cloudflare Browser Integrity Check rejects the default `Python-urllib/*` User-Agent with HTTP 403, so `worker update --force` and persistent installation fail even though the same endpoints work through curl.

Related to #107; the issue remains open.

## Validation

- `ruff check src/local_shell_mcp/remote_worker_installer.py tests/test_remote_worker_installer.py`
- `PYTHONPATH=src pytest -q tests/test_remote_worker_installer.py tests/test_remote_worker_cli.py` — 26 passed