### PR TITLE
fix(shell): keep tmux sessions alive for nologin services

### DIFF
--- a/src/local_shell_mcp/shell_ops.py
+++ b/src/local_shell_mcp/shell_ops.py
@@ -4,6 +4,7 @@ import asyncio
 import os
 import re
 import shlex
+import shutil
 import signal
 import subprocess
 import sys
@@ -392,18 +393,142 @@ async def public_run_shell(
     return await run_shell(command, cwd, public_run_shell_timeout(timeout_s), max_output_bytes)
 
 
+async def _run_exec(
+    argv: list[str],
+    *,
+    cwd: str = ".",
+    timeout_s: int = 10,
+    env: dict[str, str] | None = None,
+    bypass_limit: bool = False,
+) -> CommandResult:
+    resolved_cwd = resolve_path(cwd, must_exist=True)
+    command = shlex.join(argv)
+    check_command_policy(command)
+    start = time.time()
+    audit("run_shell_start", command=command, cwd=str(resolved_cwd))
+    timeout = clamp_timeout(timeout_s)
+    output_limit = _effective_output_limit()
+    stdout_tail = TailBuffer(output_limit, bytearray())
+    stderr_tail = TailBuffer(output_limit, bytearray())
+    reader_tasks: list[asyncio.Task[None]] = []
+    proc: asyncio.subprocess.Process | None = None
+    timed_out = False
+    termination_error = ""
+
+    async def spawn_and_wait() -> None:
+        nonlocal proc
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            cwd=str(resolved_cwd),
+            env=env,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            start_new_session=(sys.platform != "win32"),
+        )
+        reader_tasks.extend(
+            [
+                asyncio.create_task(_read_stream_tail(proc.stdout, stdout_tail)),
+                asyncio.create_task(_read_stream_tail(proc.stderr, stderr_tail)),
+            ]
+        )
+        await proc.wait()
+
+    semaphore = None if bypass_limit else _command_semaphore()
+    acquired = False
+    try:
+        try:
+            if semaphore is not None:
+                await asyncio.wait_for(semaphore.acquire(), timeout=timeout)
+                acquired = True
+                elapsed = max(0.0, time.time() - start)
+                timeout = max(0.001, timeout - elapsed)
+            await asyncio.wait_for(spawn_and_wait(), timeout=timeout)
+        except TimeoutError:
+            timed_out = True
+            if proc is None:
+                termination_error = "Timed out while starting subprocess"
+            else:
+                termination_error = await _terminate_process_group(proc)
+        except asyncio.CancelledError:
+            if proc is not None:
+                await asyncio.shield(_terminate_process_group(proc))
+            raise
+    finally:
+        if acquired and semaphore is not None:
+            semaphore.release()
+
+    try:
+        if reader_tasks:
+            await _finish_reader_tasks(reader_tasks)
+    finally:
+        if proc is not None:
+            await _close_process_transport(proc)
+
+    if termination_error:
+        stderr_tail.append(termination_error.encode())
+    stdout_b, stderr_b, total_truncated = _shared_tail_bytes(
+        bytes(stdout_tail.data), bytes(stderr_tail.data), output_limit
+    )
+    duration_ms = int((time.time() - start) * 1000)
+    result = CommandResult(
+        ok=(proc is not None and proc.returncode == 0 and not timed_out),
+        exit_code=proc.returncode if proc is not None else None,
+        timed_out=timed_out,
+        duration_ms=duration_ms,
+        cwd=relative_display(resolved_cwd),
+        command=command,
+        stdout=stdout_b.decode(errors="replace"),
+        stderr=stderr_b.decode(errors="replace"),
+        truncated=stdout_tail.truncated or stderr_tail.truncated or total_truncated,
+    )
+    audit(
+        "run_shell_end",
+        command=command,
+        cwd=str(resolved_cwd),
+        exit_code=proc.returncode if proc is not None else None,
+        timed_out=timed_out,
+        duration_ms=duration_ms,
+        truncated=result.truncated,
+    )
+    return result
+
+
 def _tmux_session_name(name: str | None = None) -> str:
     base = name or f"mcp-{uuid.uuid4().hex[:8]}"
     cleaned = re.sub(r"[^A-Za-z0-9_.-]", "-", base.strip())[:64].strip(".-")
     return cleaned or f"mcp-{uuid.uuid4().hex[:8]}"
 
 
-async def tmux(args: list[str], timeout_s: int = 10) -> CommandResult:
+def _tmux_session_cwd(args: list[str]) -> str:
+    if args and args[0] == "new-session":
+        with suppress(ValueError, IndexError):
+            return args[args.index("-c") + 1]
+    return "."
+
+
+def _resolved_tmux_shell(session_cwd: str = ".") -> str:
+    configured = os.path.expanduser(get_settings().shell_executable)
+    candidate = shutil.which(configured) or configured
+    if os.path.isabs(candidate):
+        return candidate
+    return os.path.abspath(os.path.join(session_cwd, candidate))
+
+
+async def tmux(
+    args: list[str], timeout_s: int = 10, *, bypass_limit: bool = False
+) -> CommandResult:
     selection = resolve_tmux()
     if selection.path is None:
         raise RuntimeError("tmux is unavailable and no bundled helper matches this platform")
-    cmd = " ".join(shlex.quote(x) for x in [selection.path, "-L", tmux_socket_name(), *args])
-    return await run_shell(cmd, cwd=".", timeout_s=timeout_s)
+    env = subprocess_env()
+    env["SHELL"] = _resolved_tmux_shell(_tmux_session_cwd(args))
+    return await _run_exec(
+        [selection.path, "-L", tmux_socket_name(), *args],
+        cwd=".",
+        timeout_s=timeout_s,
+        env=env,
+        bypass_limit=bypass_limit,
+    )
 
 
 async def _read_native_shell_stream(
@@ -628,6 +753,22 @@ async def _start_shell_unlocked(
     result = await tmux(cmd)
     if not result.ok:
         raise RuntimeError(result.stderr or result.stdout)
+    if not command:
+        alive = await tmux(
+            ["has-session", "-t", f"={session}"], timeout_s=5, bypass_limit=True
+        )
+        if not alive.ok:
+            with suppress(Exception):
+                await tmux(
+                    ["kill-session", "-t", f"={session}"],
+                    timeout_s=5,
+                    bypass_limit=True,
+                )
+            detail = (alive.stderr or alive.stdout).strip()
+            message = f"Persistent shell session exited during startup: {session}"
+            if detail:
+                message += f" ({detail})"
+            raise RuntimeError(message)
     backend = f"tmux-{selection.source}"
     audit("shell_start", session=session, cwd=str(resolved_cwd), command=initial, backend=backend)
     return {

--- a/tests/test_shell_ops.py
+++ b/tests/test_shell_ops.py
@@ -402,31 +402,39 @@ async def test_run_shell_shares_total_budget_between_streams(tmp_path, monkeypat
 
 
 @pytest.mark.asyncio
-async def test_tmux_command_uses_selected_binary_and_private_socket(monkeypatch):
+async def test_tmux_command_uses_selected_binary_and_private_socket(tmp_path, monkeypatch):
     from local_shell_mcp import shell_ops
     from local_shell_mcp.tmux_helper import TmuxSelection
 
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(tmp_path / ".state"))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_SHELL_EXECUTABLE", "/bin/bash")
+    get_settings.cache_clear()
     calls = []
 
-    async def fake_run_shell(command, cwd=".", timeout_s=None, max_output_bytes=None):
-        calls.append((command, cwd, timeout_s, max_output_bytes))
+    async def fake_run_exec(
+        argv, *, cwd=".", timeout_s=10, env=None, bypass_limit=False
+    ):
+        calls.append((argv, cwd, timeout_s, env, bypass_limit))
         return CommandResult(
             ok=True,
             exit_code=0,
             timed_out=False,
             duration_ms=1,
             cwd=cwd,
-            command=command,
+            command="tmux",
         )
 
     monkeypatch.setattr(shell_ops, "resolve_tmux", lambda: TmuxSelection("/opt/lsm/tmux", "bundled"))
     monkeypatch.setattr(shell_ops, "tmux_socket_name", lambda: "lsm-test")
-    monkeypatch.setattr(shell_ops, "run_shell", fake_run_shell)
+    monkeypatch.setattr(shell_ops, "_run_exec", fake_run_exec)
 
     result = await shell_ops.tmux(["list-sessions"], timeout_s=5)
 
     assert result.ok is True
-    assert calls == [("/opt/lsm/tmux -L lsm-test list-sessions", ".", 5, None)]
+    assert calls[0][:3] == (["/opt/lsm/tmux", "-L", "lsm-test", "list-sessions"], ".", 5)
+    assert calls[0][3]["SHELL"] == "/bin/bash"
+    assert calls[0][4] is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_shell_tmux.py
+++ b/tests/test_shell_tmux.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import sys
+
+import pytest
+
+import local_shell_mcp.shell_ops as shell
+from local_shell_mcp.models import CommandResult
+from local_shell_mcp.settings import get_settings
+from local_shell_mcp.tmux_helper import TmuxSelection, bundled_tmux_path
+
+
+def _result(
+    *,
+    ok: bool = True,
+    timed_out: bool = False,
+    stdout: str = "",
+    stderr: str = "",
+) -> CommandResult:
+    return CommandResult(
+        ok=ok,
+        exit_code=0 if ok else 1,
+        timed_out=timed_out,
+        duration_ms=1,
+        cwd=".",
+        command="tmux",
+        stdout=stdout,
+        stderr=stderr,
+        truncated=False,
+    )
+
+
+def _configure(tmp_path, monkeypatch, *, shell_executable: str = "/usr/bin/bash") -> None:
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(tmp_path / ".state"))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_AUDIT_LOG_PATH", str(tmp_path / "audit.jsonl"))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_AUTH_MODE", "none")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_SHELL_EXECUTABLE", shell_executable)
+    get_settings.cache_clear()
+
+
+def test_tmux_normalizes_inherited_shell(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setenv("SHELL", "/usr/sbin/nologin")
+    monkeypatch.setattr(shell, "resolve_tmux", lambda: TmuxSelection("/usr/bin/tmux", "system"))
+    captured = {}
+
+    async def fake_run_exec(argv, *, cwd, timeout_s, env, bypass_limit):
+        captured.update(
+            argv=argv,
+            cwd=cwd,
+            timeout_s=timeout_s,
+            env=env,
+            bypass_limit=bypass_limit,
+        )
+        return _result()
+
+    monkeypatch.setattr(shell, "_run_exec", fake_run_exec)
+
+    asyncio.run(shell.tmux(["list-sessions"], timeout_s=5))
+
+    assert captured["timeout_s"] == 5
+    assert captured["argv"] == [
+        "/usr/bin/tmux",
+        "-L",
+        shell.tmux_socket_name(),
+        "list-sessions",
+    ]
+    assert captured["env"]["SHELL"] == "/usr/bin/bash"
+    assert captured["bypass_limit"] is False
+
+
+def test_tmux_resolves_relative_configured_shell(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch, shell_executable="bash")
+    monkeypatch.setattr(shell, "resolve_tmux", lambda: TmuxSelection("/usr/bin/tmux", "system"))
+    monkeypatch.setattr(shell.shutil, "which", lambda value: "tools/bash" if value == "bash" else None)
+    session_cwd = tmp_path / "session"
+    session_cwd.mkdir()
+    expected_shell = os.path.abspath(session_cwd / "tools/bash")
+    captured = {}
+
+    async def fake_run_exec(argv, *, cwd, timeout_s, env, bypass_limit):
+        captured.update(
+            argv=argv,
+            cwd=cwd,
+            timeout_s=timeout_s,
+            env=env,
+            bypass_limit=bypass_limit,
+        )
+        return _result()
+
+    monkeypatch.setattr(shell, "_run_exec", fake_run_exec)
+
+    asyncio.run(
+        shell.tmux(
+            ["new-session", "-d", "-c", str(session_cwd), "bash"]
+        )
+    )
+
+    assert captured["env"]["SHELL"] == expected_shell
+
+
+def test_run_exec_restores_shell_command_auditing(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    events = []
+    monkeypatch.setattr(shell, "audit", lambda event, **fields: events.append((event, fields)))
+
+    result = asyncio.run(
+        shell._run_exec([sys.executable, "-c", "print('audit-ok')"], cwd=".")
+    )
+
+    assert result.ok is True
+    assert [event for event, _ in events] == ["run_shell_start", "run_shell_end"]
+    assert "audit-ok" in result.stdout
+    assert events[0][1]["command"] == result.command
+    assert events[1][1]["exit_code"] == 0
+
+
+def test_run_exec_enforces_command_policy(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_COMMAND_DENYLIST", "mkfs")
+    get_settings.cache_clear()
+
+    with pytest.raises(PermissionError, match="denylisted fragment"):
+        asyncio.run(shell._run_exec(["tmux", "send-keys", "mkfs /dev/sda"], cwd="."))
+
+
+def test_run_exec_respects_command_semaphore(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    blocked = asyncio.Semaphore(0)
+    monkeypatch.setattr(shell, "_command_semaphore", lambda: blocked)
+    monkeypatch.setattr(shell, "clamp_timeout", lambda timeout_s: 0.01)
+
+    result = asyncio.run(shell._run_exec(["tmux", "list-sessions"], cwd="."))
+
+    assert result.timed_out is True
+    assert result.exit_code is None
+    assert "Timed out while starting subprocess" in result.stderr
+
+
+def test_run_exec_reports_timeout_before_process_creation(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+
+    async def delayed_spawn(*args, **kwargs):
+        await asyncio.sleep(60)
+
+    monkeypatch.setattr(shell.asyncio, "create_subprocess_exec", delayed_spawn)
+    monkeypatch.setattr(shell, "clamp_timeout", lambda timeout_s: 0.01)
+
+    result = asyncio.run(shell._run_exec(["tmux"], cwd="."))
+
+    assert result.timed_out is True
+    assert result.exit_code is None
+    assert "Timed out while starting subprocess" in result.stderr
+
+
+def test_run_exec_terminates_process_after_timeout(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setattr(shell, "clamp_timeout", lambda timeout_s: 0.1)
+
+    result = asyncio.run(
+        shell._run_exec(
+            [
+                sys.executable,
+                "-c",
+                "import time; print('started', flush=True); time.sleep(30)",
+            ],
+            cwd=".",
+        )
+    )
+
+    assert result.timed_out is True
+    assert result.exit_code is not None
+    assert "started" in result.stdout
+
+
+def test_start_shell_rejects_session_that_exits_during_startup(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setattr(shell, "_use_windows_persistent_shell_backend", lambda: False)
+    monkeypatch.setattr(shell, "resolve_tmux", lambda: TmuxSelection("/usr/bin/tmux", "system"))
+    monkeypatch.setattr(shell, "list_shells", lambda: asyncio.sleep(0, result={"sessions": []}))
+    calls = []
+    responses = iter(
+        [
+            _result(),
+            _result(ok=False, timed_out=True, stderr="probe timed out"),
+            _result(),
+        ]
+    )
+
+    async def fake_tmux(args, timeout_s=10, *, bypass_limit=False):
+        calls.append((args, timeout_s, bypass_limit))
+        return next(responses)
+
+    monkeypatch.setattr(shell, "tmux", fake_tmux)
+
+    with pytest.raises(RuntimeError, match="exited during startup.*probe timed out"):
+        asyncio.run(shell._start_shell_unlocked(".", "dead-session"))
+
+    assert calls[1] == (["has-session", "-t", "=dead-session"], 5, True)
+    assert calls[2] == (["kill-session", "-t", "=dead-session"], 5, True)
+
+
+def test_start_shell_allows_explicit_command_to_finish_immediately(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setattr(shell, "_use_windows_persistent_shell_backend", lambda: False)
+    monkeypatch.setattr(shell, "resolve_tmux", lambda: TmuxSelection("/usr/bin/tmux", "system"))
+    monkeypatch.setattr(shell, "list_shells", lambda: asyncio.sleep(0, result={"sessions": []}))
+    calls = []
+
+    async def fake_tmux(args, timeout_s=10, *, bypass_limit=False):
+        calls.append((args, timeout_s, bypass_limit))
+        return _result()
+
+    monkeypatch.setattr(shell, "tmux", fake_tmux)
+
+    started = asyncio.run(shell._start_shell_unlocked(".", "quick-command", "exit 0"))
+
+    assert started["session_id"] == "quick-command"
+    assert len(calls) == 1
+
+
+@pytest.mark.skipif(os.name == "nt", reason="tmux backend is Unix-only")
+def test_tmux_session_survives_nologin_service_environment(tmp_path, monkeypatch):
+    nologin = shutil.which("nologin")
+    executable = shutil.which("bash")
+    tmux_path = shutil.which("tmux")
+    if tmux_path is None:
+        bundled = bundled_tmux_path()
+        tmux_path = str(bundled) if bundled is not None else None
+    if not nologin or not executable or not tmux_path:
+        pytest.skip("nologin, bash, and tmux are required for this regression test")
+
+    _configure(tmp_path, monkeypatch, shell_executable=executable)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_TMUX_BIN", tmux_path)
+    monkeypatch.setenv("SHELL", nologin)
+    get_settings.cache_clear()
+
+    async def exercise():
+        started = await shell.start_shell(".", "nologin-regression")
+        session_id = started["session_id"]
+        try:
+            await shell.send_shell(session_id, "printf 'issue108-alive\\n'")
+            sessions = await shell.list_shells()
+            deadline = asyncio.get_running_loop().time() + 5
+            while True:
+                output = await shell.read_shell(session_id, 20)
+                if "issue108-alive" in output["output"]:
+                    break
+                if asyncio.get_running_loop().time() >= deadline:
+                    pytest.fail("tmux did not render the marker before the deadline")
+                await asyncio.sleep(0.05)
+            return session_id, sessions, output
+        finally:
+            await shell.kill_shell(session_id)
+
+    session_id, sessions, output = asyncio.run(exercise())
+
+    assert session_id in {item["session_id"] for item in sessions["sessions"]}
+    assert "issue108-alive" in output["output"]


### PR DESCRIPTION
## Summary

- execute private tmux control commands directly as argv instead of parsing them through the configured interactive shell
- normalize tmux's `SHELL` environment to the configured `shell_executable`, resolving PATH-based and relative values to an absolute executable path anchored to the requested session cwd
- preserve command denylist enforcement and equivalent `run_shell_start` / `run_shell_end` auditing for tmux control input
- keep tmux clients under `max_concurrent_commands`, bypassing that queue only for startup liveness probes and cleanup
- verify newly created default interactive sessions with an exact `has-session` probe before reporting success
- clean up a session after a failed or timed-out liveness probe
- preserve short-lived explicit command sessions used by tracked jobs
- add unit coverage for environment normalization, policy enforcement, path resolution, auditing, concurrency bounds, liveness cleanup, fast explicit commands, and subprocess timeout paths, plus a real Linux `SHELL=nologin` regression test with bounded output polling

## Why

A controller launched under a dedicated service account can inherit `SHELL=/usr/sbin/nologin` even when `shell_executable` is explicitly configured as `/usr/bin/bash`. tmux inherits that stale service environment, causing its private server/session to exit immediately while `shell_start` still reports success.

## Validation

- reproduced the failure before the fix with `SHELL=/usr/sbin/nologin`
- repeated the same scenario after the fix and verified list/send/read/kill operations
- `ruff check .`
- `PYTHONPATH=src pytest -q` — 591 passed
- `shell_ops.py` branch coverage — 91.4%, above the 90% per-file floor

Fixes #108
