### PR TITLE
fix: report shell startup failures correctly

### DIFF
--- a/src/local_shell_mcp/conpty_ops.py
+++ b/src/local_shell_mcp/conpty_ops.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from .audit import audit
+from .errors import process_start_not_found_error
 from .fs_ops import relative_display, resolve_path
 from .settings import get_settings
 from .shell_environment import (
@@ -227,7 +228,16 @@ async def start_shell(
     initial = command or get_settings().shell_executable
     if check_command_policy is not None:
         check_command_policy(initial)
-    process = await asyncio.to_thread(_spawn_pty, _persistent_shell_args(command), resolved_cwd)
+    args = _persistent_shell_args(command)
+    try:
+        process = await asyncio.to_thread(_spawn_pty, args, resolved_cwd)
+    except FileNotFoundError as exc:
+        raise process_start_not_found_error(
+            exc,
+            executable=str(args[0]),
+            command=initial,
+            cwd=resolved_cwd,
+        ) from exc
     session = ConPtyShellSession(
         session_id=session_id,
         process=process,

--- a/src/local_shell_mcp/errors.py
+++ b/src/local_shell_mcp/errors.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+class PathNotFoundError(FileNotFoundError):
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        super().__init__(str(self.path))
+
+
+class ShellExecutableNotFoundError(FileNotFoundError):
+    """Raised when a configured shell executable cannot be started."""
+
+    def __init__(self, executable: str, command: str, cwd: str, original_error: str) -> None:
+        self.executable = executable
+        self.command = command
+        self.cwd = cwd
+        self.original_error = original_error
+        super().__init__(f"Shell executable not found: {executable}")
+
+
+def process_start_not_found_error(
+    exc: FileNotFoundError,
+    *,
+    executable: str,
+    command: str,
+    cwd: str | Path,
+) -> FileNotFoundError:
+    cwd_path = Path(cwd)
+    missing = Path(exc.filename) if exc.filename else None
+    if missing is not None and os.path.normcase(os.path.abspath(missing)) == os.path.normcase(
+        os.path.abspath(cwd_path)
+    ):
+        return PathNotFoundError(cwd_path)
+    if not cwd_path.exists():
+        return PathNotFoundError(cwd_path)
+    return ShellExecutableNotFoundError(executable, command, str(cwd_path), str(exc))
+
+
+def workspace_path_not_found_error(
+    exc: FileNotFoundError,
+    workspace_root: str | Path,
+) -> PathNotFoundError | None:
+    root = Path(os.path.abspath(workspace_root))
+    for value in (exc.filename, exc.filename2):
+        if not value:
+            continue
+        candidate = Path(value)
+        if not candidate.is_absolute():
+            continue
+        lexical = Path(os.path.abspath(candidate))
+        try:
+            lexical.relative_to(root)
+        except ValueError:
+            continue
+        return PathNotFoundError(lexical)
+    return None

--- a/src/local_shell_mcp/errors.py
+++ b/src/local_shell_mcp/errors.py
@@ -44,6 +44,7 @@ def workspace_path_not_found_error(
     workspace_root: str | Path,
 ) -> PathNotFoundError | None:
     root = Path(os.path.abspath(workspace_root))
+    candidates: list[Path] = []
     for value in (exc.filename, exc.filename2):
         if not value:
             continue
@@ -55,5 +56,8 @@ def workspace_path_not_found_error(
             lexical.relative_to(root)
         except ValueError:
             continue
-        return PathNotFoundError(lexical)
+        candidates.append(lexical)
+    for candidate in candidates:
+        if not candidate.exists():
+            return PathNotFoundError(candidate)
     return None

--- a/src/local_shell_mcp/fs_ops.py
+++ b/src/local_shell_mcp/fs_ops.py
@@ -14,18 +14,13 @@ from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 
+from .errors import PathNotFoundError
 from .settings import get_settings
 
 BINARY_CHECK_BYTES = 8192
 BINARY_CONTROL_RATIO = 0.30
 BINARY_PREVIEW_BYTES = 256
 BINARY_MESSAGE = "Refusing to read binary file as text"
-
-
-class PathNotFoundError(FileNotFoundError):
-    def __init__(self, path: str | Path) -> None:
-        self.path = Path(path)
-        super().__init__(str(self.path))
 
 
 class FileConflictError(RuntimeError):

--- a/src/local_shell_mcp/fs_ops.py
+++ b/src/local_shell_mcp/fs_ops.py
@@ -22,6 +22,12 @@ BINARY_PREVIEW_BYTES = 256
 BINARY_MESSAGE = "Refusing to read binary file as text"
 
 
+class PathNotFoundError(FileNotFoundError):
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        super().__init__(str(self.path))
+
+
 class FileConflictError(RuntimeError):
     pass
 
@@ -223,9 +229,9 @@ def resolve_path(
 
     exists = resolved.exists() if follow_final_symlink else os.path.lexists(resolved)
     if must_exist and not exists:
-        raise FileNotFoundError(str(resolved))
+        raise PathNotFoundError(resolved)
     if not allow_missing_parent and not resolved.parent.exists():
-        raise FileNotFoundError(str(resolved.parent))
+        raise PathNotFoundError(resolved.parent)
     return resolved
 
 
@@ -560,7 +566,7 @@ def perform_file_action(
     )
     with _path_locks([source, target]):
         if not os.path.lexists(source):
-            raise FileNotFoundError(str(source))
+            raise PathNotFoundError(source)
         if os.path.lexists(target):
             raise FileExistsError(str(target))
         if source == target:
@@ -659,7 +665,7 @@ def delete_path(path: str, recursive: bool = False) -> dict:
     p = resolve_path(path, must_exist=True, follow_final_symlink=False)
     with _path_lock(p):
         if not os.path.lexists(p):
-            raise FileNotFoundError(str(p))
+            raise PathNotFoundError(p)
         if p.is_symlink():
             p.unlink()
             return {"path": relative_display(p), "deleted": "link"}

--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -29,11 +29,17 @@ from typing import Any
 
 from . import __version__
 from .audit import audit, suppress_audit
+from .errors import (
+    PathNotFoundError,
+    ShellExecutableNotFoundError,
+    workspace_path_not_found_error,
+)
 from .fs_ops import (
     delete_path,
     edit_text,
     glob_paths,
     list_dir,
+    missing_path_context,
     perform_file_action,
     prune_temp_dir,
     read_texts,
@@ -683,13 +689,18 @@ class RemoteManager:
                     self.pending_machines.pop(job_id, None)
                     self.claimed_jobs.discard(job_id)
         if not result.get("ok", False):
-            return _ok(
-                {
+            data = result.get("data")
+            if not isinstance(data, dict):
+                data = {
                     "status": "error",
                     "error_type": result.get("error", "remote_error"),
                     "message": result.get("message", "remote job failed"),
                 }
-            )
+            return {
+                "ok": False,
+                "message": result.get("message", data.get("message", "remote job failed")),
+                "data": data,
+            }
         return _ok(result.get("data"))
 
     def list_machines(self) -> dict[str, Any]:
@@ -954,7 +965,41 @@ def _assert_worker_text_input_size(label: str, text: str) -> None:
 
 
 def _handled_remote_exception(exc: Exception) -> dict[str, Any]:
-    return {"ok": False, "error": type(exc).__name__, "message": str(exc)}
+    if isinstance(exc, ShellExecutableNotFoundError):
+        message = f"Shell executable not found: {exc.executable}"
+        data = {
+            "status": "executable_not_found",
+            "error_type": "FileNotFoundError",
+            "message": str(exc),
+            "executable": exc.executable,
+            "command": exc.command,
+            "cwd": exc.cwd,
+            "original_error": exc.original_error,
+        }
+        return {"ok": False, "error": "FileNotFoundError", "message": message, "data": data}
+
+    path_error = exc if isinstance(exc, PathNotFoundError) else None
+    if isinstance(exc, FileNotFoundError) and path_error is None:
+        path_error = workspace_path_not_found_error(exc, get_settings().workspace_root)
+    if path_error is not None:
+        with contextlib.suppress(Exception):
+            context = missing_path_context(path_error.path)
+            message = f"Path not found: {context['path']}"
+            data = {
+                "status": "not_found",
+                "error_type": "FileNotFoundError",
+                "message": str(exc),
+                **context,
+            }
+            return {"ok": False, "error": "FileNotFoundError", "message": message, "data": data}
+
+    message = str(exc) or type(exc).__name__
+    data = {
+        "status": "error",
+        "error_type": type(exc).__name__,
+        "message": message,
+    }
+    return {"ok": False, "error": type(exc).__name__, "message": message, "data": data}
 
 
 async def _apply_patch_text(patch: str, cwd: str = ".") -> dict[str, Any]:

--- a/src/local_shell_mcp/shell_ops.py
+++ b/src/local_shell_mcp/shell_ops.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 from . import conpty_ops
 from .audit import audit
+from .errors import process_start_not_found_error
 from .fs_ops import relative_display, resolve_path
 from .models import CommandResult
 from .settings import get_settings
@@ -80,17 +81,6 @@ class NativeShellSession:
     output: TailBuffer
     readers: list
     lock: object
-
-
-class ShellExecutableNotFoundError(FileNotFoundError):
-    """Raised when the configured shell executable cannot be started."""
-
-    def __init__(self, executable: str, command: str, cwd: str, original_error: str) -> None:
-        self.executable = executable
-        self.command = command
-        self.cwd = cwd
-        self.original_error = original_error
-        super().__init__(f"Shell executable not found: {executable}")
 
 
 def check_command_policy(command: str) -> None:
@@ -227,7 +217,12 @@ async def _spawn_process(command: str, cwd: str) -> asyncio.subprocess.Process:
             start_new_session=(sys.platform != "win32"),
         )
     except FileNotFoundError as exc:
-        raise ShellExecutableNotFoundError(str(args[0]), command, cwd, str(exc)) from exc
+        raise process_start_not_found_error(
+            exc,
+            executable=str(args[0]),
+            command=command,
+            cwd=cwd,
+        ) from exc
 
 
 async def _read_stream_tail(stream: asyncio.StreamReader | None, tail: TailBuffer) -> None:
@@ -474,8 +469,11 @@ async def _native_start_shell(
             start_new_session=(sys.platform != "win32"),
         )
     except FileNotFoundError as exc:
-        raise ShellExecutableNotFoundError(
-            str(args[0]), initial, str(resolved_cwd), str(exc)
+        raise process_start_not_found_error(
+            exc,
+            executable=str(args[0]),
+            command=initial,
+            cwd=resolved_cwd,
         ) from exc
     session = NativeShellSession(
         session_id=session_id,

--- a/src/local_shell_mcp/shell_ops.py
+++ b/src/local_shell_mcp/shell_ops.py
@@ -82,6 +82,17 @@ class NativeShellSession:
     lock: object
 
 
+class ShellExecutableNotFoundError(FileNotFoundError):
+    """Raised when the configured shell executable cannot be started."""
+
+    def __init__(self, executable: str, command: str, cwd: str, original_error: str) -> None:
+        self.executable = executable
+        self.command = command
+        self.cwd = cwd
+        self.original_error = original_error
+        super().__init__(f"Shell executable not found: {executable}")
+
+
 def check_command_policy(command: str) -> None:
     settings = get_settings()
     normalized = command.casefold()
@@ -205,14 +216,18 @@ def _use_windows_persistent_shell_backend() -> bool:
 
 
 async def _spawn_process(command: str, cwd: str) -> asyncio.subprocess.Process:
-    return await asyncio.create_subprocess_exec(
-        *_shell_command_args(command),
-        cwd=cwd,
-        env=subprocess_env(),
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        start_new_session=(sys.platform != "win32"),
-    )
+    args = _shell_command_args(command)
+    try:
+        return await asyncio.create_subprocess_exec(
+            *args,
+            cwd=cwd,
+            env=subprocess_env(),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            start_new_session=(sys.platform != "win32"),
+        )
+    except FileNotFoundError as exc:
+        raise ShellExecutableNotFoundError(str(args[0]), command, cwd, str(exc)) from exc
 
 
 async def _read_stream_tail(stream: asyncio.StreamReader | None, tail: TailBuffer) -> None:
@@ -447,15 +462,21 @@ async def _native_start_shell(
 
     initial = command or get_settings().shell_executable
     check_command_policy(initial)
-    proc = await asyncio.create_subprocess_exec(
-        *_persistent_shell_args(command),
-        cwd=str(resolved_cwd),
-        env=subprocess_env(),
-        stdin=asyncio.subprocess.PIPE,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.STDOUT,
-        start_new_session=(sys.platform != "win32"),
-    )
+    args = _persistent_shell_args(command)
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *args,
+            cwd=str(resolved_cwd),
+            env=subprocess_env(),
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            start_new_session=(sys.platform != "win32"),
+        )
+    except FileNotFoundError as exc:
+        raise ShellExecutableNotFoundError(
+            str(args[0]), initial, str(resolved_cwd), str(exc)
+        ) from exc
     session = NativeShellSession(
         session_id=session_id,
         process=proc,

--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -22,8 +22,12 @@ from pydantic import BaseModel, ConfigDict, Field
 from .audit import audit, audit_call_context, audit_result_ok
 from .auth import require_current_scopes
 from .downloads import create_share_link, list_share_links, revoke_share_link
-from .fs_ops import (
+from .errors import (
     PathNotFoundError,
+    ShellExecutableNotFoundError,
+    workspace_path_not_found_error,
+)
+from .fs_ops import (
     delete_path,
     edit_text,
     glob_paths,
@@ -66,7 +70,6 @@ from .shell_ops import (
     PUBLIC_RUN_SHELL_DEFAULT_TIMEOUT_S,
     PUBLIC_RUN_SHELL_TIMEOUT_CAP_S,
     PUBLIC_TOOL_WATCHDOG_TIMEOUT_S,
-    ShellExecutableNotFoundError,
     kill_shell,
     list_shells,
     public_run_shell,
@@ -150,9 +153,12 @@ def _handled_error(exc: Exception) -> CallToolResult:
             },
             message,
         )
-    if isinstance(exc, PathNotFoundError):
+    path_error = exc if isinstance(exc, PathNotFoundError) else None
+    if isinstance(exc, FileNotFoundError) and path_error is None:
+        path_error = workspace_path_not_found_error(exc, get_settings().workspace_root)
+    if path_error is not None:
         with suppress(Exception):
-            context = missing_path_context(exc.path)
+            context = missing_path_context(path_error.path)
             return _error_call_result(
                 {
                     "status": "not_found",
@@ -1374,7 +1380,24 @@ async def _remote_call(
     try:
         if not settings.remote_enabled:
             raise RuntimeError("Remote workers are disabled")
-        return await remote_manager().call(machine, tool, args, timeout_s)
+        result = await remote_manager().call(machine, tool, args, timeout_s)
+        data = result.get("data") if isinstance(result, dict) else None
+        failed_status = (
+            isinstance(data, dict)
+            and data.get("status") in {"error", "not_found", "executable_not_found"}
+        )
+        if not result.get("ok", False) or failed_status:
+            if not isinstance(data, dict):
+                data = {
+                    "status": "error",
+                    "error_type": "remote_error",
+                    "message": result.get("message", "remote job failed"),
+                }
+            return _error_call_result(
+                data,
+                result.get("message") or data.get("message") or "Remote tool failed",
+            )
+        return result
     except Exception as exc:
         return _handled_error(exc)
 

--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -23,6 +23,7 @@ from .audit import audit, audit_call_context, audit_result_ok
 from .auth import require_current_scopes
 from .downloads import create_share_link, list_share_links, revoke_share_link
 from .fs_ops import (
+    PathNotFoundError,
     delete_path,
     edit_text,
     glob_paths,
@@ -65,6 +66,7 @@ from .shell_ops import (
     PUBLIC_RUN_SHELL_DEFAULT_TIMEOUT_S,
     PUBLIC_RUN_SHELL_TIMEOUT_CAP_S,
     PUBLIC_TOOL_WATCHDOG_TIMEOUT_S,
+    ShellExecutableNotFoundError,
     kill_shell,
     list_shells,
     public_run_shell,
@@ -118,27 +120,56 @@ class ViewImageResult(BaseModel):
     error_type: str | None = None
 
 
-def _handled_error(exc: Exception) -> dict:
+def _error_call_result(data: dict[str, Any], message: str) -> CallToolResult:
+    structured = {"ok": False, "message": message, "data": data}
+    return CallToolResult(
+        content=[
+            TextContent(
+                type="text",
+                text=json.dumps(structured, ensure_ascii=False, indent=2),
+            )
+        ],
+        structuredContent=structured,
+        isError=True,
+    )
+
+
+def _handled_error(exc: Exception) -> CallToolResult:
     audit("tool_error", error=repr(exc))
-    if isinstance(exc, FileNotFoundError) and str(exc):
+    if isinstance(exc, ShellExecutableNotFoundError):
+        message = f"Shell executable not found: {exc.executable}"
+        return _error_call_result(
+            {
+                "status": "executable_not_found",
+                "error_type": "FileNotFoundError",
+                "message": str(exc),
+                "executable": exc.executable,
+                "command": exc.command,
+                "cwd": exc.cwd,
+                "original_error": exc.original_error,
+            },
+            message,
+        )
+    if isinstance(exc, PathNotFoundError):
         with suppress(Exception):
-            context = missing_path_context(str(exc))
-            return _ok(
+            context = missing_path_context(exc.path)
+            return _error_call_result(
                 {
                     "status": "not_found",
-                    "error_type": type(exc).__name__,
+                    "error_type": "FileNotFoundError",
                     "message": str(exc),
                     **context,
                 },
-                message=f"Path not found: {context['path']}",
+                f"Path not found: {context['path']}",
             )
-    return _ok(
+    message = str(exc) or type(exc).__name__
+    return _error_call_result(
         {
             "status": "error",
             "error_type": type(exc).__name__,
-            "message": str(exc),
+            "message": message,
         },
-        message=f"Tool handled {type(exc).__name__}",
+        message,
     )
 
 

--- a/tests/test_conpty_backend.py
+++ b/tests/test_conpty_backend.py
@@ -5,6 +5,7 @@ import pytest
 
 import local_shell_mcp.conpty_ops as conpty_ops
 import local_shell_mcp.shell_ops as ops
+from local_shell_mcp.errors import ShellExecutableNotFoundError
 from local_shell_mcp.settings import get_settings
 
 
@@ -148,6 +149,29 @@ async def test_windows_falls_back_to_native_when_pywinpty_unavailable(tmp_path, 
 
     assert session["session_id"] == "native-fallback"
     assert session["backend"] == "native"
+
+
+@pytest.mark.asyncio
+async def test_conpty_reports_missing_shell_executable(tmp_path, monkeypatch):
+    executable = "missing-conpty-shell"
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_SHELL_EXECUTABLE", executable)
+    get_settings.cache_clear()
+    monkeypatch.setattr(ops, "_use_native_persistent_shell_backend", lambda: True)
+
+    class MissingPtyProcess:
+        @classmethod
+        def spawn(cls, argv, cwd=None, env=None):  # noqa: ARG003
+            raise FileNotFoundError(2, "The system cannot find the file specified", executable)
+
+    monkeypatch.setattr(conpty_ops, "winpty", SimpleNamespace(PtyProcess=MissingPtyProcess))
+
+    with pytest.raises(ShellExecutableNotFoundError) as raised:
+        await ops.start_shell(cwd=".", name="missing-conpty")
+
+    assert raised.value.executable == executable
+    assert raised.value.command == executable
+    assert raised.value.cwd == str(tmp_path)
 
 
 @pytest.mark.asyncio

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,28 @@
+from local_shell_mcp.errors import (
+    PathNotFoundError,
+    process_start_not_found_error,
+    workspace_path_not_found_error,
+)
+
+
+def test_process_start_detects_missing_cwd_without_matching_filename(tmp_path):
+    missing_cwd = tmp_path / "vanished"
+    exc = FileNotFoundError(2, "No such file or directory", "/bin/sh")
+
+    result = process_start_not_found_error(
+        exc,
+        executable="/bin/sh",
+        command="echo ok",
+        cwd=missing_cwd,
+    )
+
+    assert isinstance(result, PathNotFoundError)
+    assert result.path == missing_cwd
+
+
+def test_workspace_path_detection_ignores_non_workspace_paths(tmp_path):
+    relative = FileNotFoundError(2, "No such file or directory", "relative.txt")
+    outside = FileNotFoundError(2, "No such file or directory", str(tmp_path.parent / "outside"))
+
+    assert workspace_path_not_found_error(relative, tmp_path) is None
+    assert workspace_path_not_found_error(outside, tmp_path) is None

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -26,3 +26,16 @@ def test_workspace_path_detection_ignores_non_workspace_paths(tmp_path):
 
     assert workspace_path_not_found_error(relative, tmp_path) is None
     assert workspace_path_not_found_error(outside, tmp_path) is None
+
+
+def test_workspace_path_detection_prefers_missing_second_endpoint(tmp_path):
+    source = tmp_path / "source.txt"
+    source.write_text("data", encoding="utf-8")
+    missing_destination = tmp_path / "removed-parent" / "destination.txt"
+    exc = FileNotFoundError(2, "No such file or directory", str(source))
+    exc.filename2 = str(missing_destination)
+
+    result = workspace_path_not_found_error(exc, tmp_path)
+
+    assert isinstance(result, PathNotFoundError)
+    assert result.path == missing_destination

--- a/tests/test_fs_ops.py
+++ b/tests/test_fs_ops.py
@@ -8,6 +8,7 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
+from mcp.types import CallToolResult
 
 from local_shell_mcp.fs_ops import (
     BINARY_CHECK_BYTES,
@@ -238,9 +239,15 @@ async def test_read_file_rejects_too_many_files(tmp_path, monkeypatch):
     (tmp_path / "b.txt").write_text("b", encoding="utf-8")
 
     response = await build_mcp().call_tool("read_file", {"path": ["a.txt", "b.txt"]})
-    payload = response[0][0].text
 
-    assert "Refusing to read 2 files; max is 1" in payload
+    assert isinstance(response, CallToolResult)
+    assert response.isError is True
+    assert response.structuredContent["ok"] is False
+    assert response.structuredContent["data"] == {
+        "status": "error",
+        "error_type": "ValueError",
+        "message": "Refusing to read 2 files; max is 1",
+    }
 
 
 def test_reject_path_escape(tmp_path, monkeypatch):

--- a/tests/test_remote_complete.py
+++ b/tests/test_remote_complete.py
@@ -13,6 +13,7 @@ from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
 import local_shell_mcp.remote as remote
+from local_shell_mcp.errors import ShellExecutableNotFoundError
 from local_shell_mcp.models import CommandResult
 from local_shell_mcp.settings import get_settings
 
@@ -180,6 +181,7 @@ def test_controller_poll_result_errors_and_cancellation(tmp_path, monkeypatch):
         return await task
 
     failed = asyncio.run(failed_call())
+    assert failed["ok"] is False
     assert failed["data"]["status"] == "error"
     assert failed["data"]["error_type"] == "Boom"
 
@@ -615,6 +617,13 @@ def test_worker_upload_protocol_and_generated_execution_edges(tmp_path, monkeypa
     script = asyncio.run(remote._run_python("print('ok')", ".", 5))
     assert script["script_path"].endswith(".py")
     assert remote._handled_remote_exception(ValueError("bad"))["error"] == "ValueError"
+    shell_error = remote._handled_remote_exception(
+        ShellExecutableNotFoundError("missing-shell", "echo ok", ".", "[WinError 2]")
+    )
+    assert shell_error["ok"] is False
+    assert shell_error["data"]["status"] == "executable_not_found"
+    assert shell_error["data"]["executable"] == "missing-shell"
+    assert shell_error["data"]["command"] == "echo ok"
 
 
 @pytest.mark.asyncio

--- a/tests/test_search_ops.py
+++ b/tests/test_search_ops.py
@@ -5,7 +5,7 @@ import pytest
 from mcp.types import CallToolResult
 
 import local_shell_mcp.search_ops as search_ops_module
-from local_shell_mcp.fs_ops import PathNotFoundError
+from local_shell_mcp.errors import PathNotFoundError
 from local_shell_mcp.search_ops import grep, tree
 from local_shell_mcp.settings import get_settings
 from local_shell_mcp.tools import _handled_error
@@ -100,6 +100,20 @@ def test_os_file_not_found_message_is_not_treated_as_workspace_path(tmp_path, mo
     assert data["error_type"] == "FileNotFoundError"
     assert "path" not in data
     assert str(tmp_path) not in result.structuredContent["message"]
+
+
+def test_syscall_file_not_found_inside_workspace_keeps_path_context(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    get_settings.cache_clear()
+    missing = tmp_path / "removed-during-read.txt"
+
+    result = _handled_error(FileNotFoundError(2, "No such file or directory", str(missing)))
+
+    assert isinstance(result, CallToolResult)
+    assert result.isError is True
+    data = result.structuredContent["data"]
+    assert data["status"] == "not_found"
+    assert data["path"] == str(missing)
 
 
 @pytest.mark.asyncio

--- a/tests/test_search_ops.py
+++ b/tests/test_search_ops.py
@@ -2,8 +2,10 @@ import asyncio
 import shutil
 
 import pytest
+from mcp.types import CallToolResult
 
 import local_shell_mcp.search_ops as search_ops_module
+from local_shell_mcp.fs_ops import PathNotFoundError
 from local_shell_mcp.search_ops import grep, tree
 from local_shell_mcp.settings import get_settings
 from local_shell_mcp.tools import _handled_error
@@ -54,31 +56,50 @@ async def test_tree_returns_context_for_missing_directory(tmp_path, monkeypatch)
     assert "Path does not exist" in result["message"]
 
 
-def test_tool_error_returns_successful_not_found_result(tmp_path, monkeypatch):
+def test_tool_error_returns_failed_not_found_result(tmp_path, monkeypatch):
     monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
     get_settings.cache_clear()
     (tmp_path / "actual").mkdir()
 
-    result = _handled_error(FileNotFoundError(str(tmp_path / "missing" / "project")))
+    result = _handled_error(PathNotFoundError(tmp_path / "missing" / "project"))
 
-    assert result["ok"] is True
-    assert result["data"]["status"] == "not_found"
-    assert result["data"]["error_type"] == "FileNotFoundError"
-    assert result["data"]["exists"] is False
-    assert result["data"]["nearest_existing_parent"] == str(tmp_path)
-    assert "actual/" in result["data"]["nearest_parent_entries"]
+    assert isinstance(result, CallToolResult)
+    assert result.isError is True
+    assert result.structuredContent["ok"] is False
+    data = result.structuredContent["data"]
+    assert data["status"] == "not_found"
+    assert data["error_type"] == "FileNotFoundError"
+    assert data["exists"] is False
+    assert data["nearest_existing_parent"] == str(tmp_path)
+    assert "actual/" in data["nearest_parent_entries"]
 
 
-def test_tool_error_returns_successful_error_result():
+def test_tool_error_returns_failed_error_result():
     result = _handled_error(ValueError("bad input"))
 
-    assert result["ok"] is True
-    assert "error" not in result
-    assert result["data"] == {
+    assert isinstance(result, CallToolResult)
+    assert result.isError is True
+    assert result.structuredContent["ok"] is False
+    assert result.structuredContent["data"] == {
         "status": "error",
         "error_type": "ValueError",
         "message": "bad input",
     }
+
+
+def test_os_file_not_found_message_is_not_treated_as_workspace_path(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    get_settings.cache_clear()
+
+    result = _handled_error(FileNotFoundError(2, "The system cannot find the file specified"))
+
+    assert isinstance(result, CallToolResult)
+    assert result.isError is True
+    data = result.structuredContent["data"]
+    assert data["status"] == "error"
+    assert data["error_type"] == "FileNotFoundError"
+    assert "path" not in data
+    assert str(tmp_path) not in result.structuredContent["message"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_shell_ops.py
+++ b/tests/test_shell_ops.py
@@ -8,7 +8,9 @@ from fastapi.testclient import TestClient
 from mcp.types import CallToolResult, TextContent
 
 import local_shell_mcp.http_app as http_app_module
+import local_shell_mcp.shell_ops as shell_ops_module
 import local_shell_mcp.tools as tools_module
+from local_shell_mcp.errors import PathNotFoundError
 from local_shell_mcp.http_app import build_http_app
 from local_shell_mcp.models import CommandResult
 from local_shell_mcp.settings import get_settings
@@ -236,6 +238,21 @@ async def test_run_shell_tool_reports_missing_shell_executable(tmp_path, monkeyp
     assert data["command"] == "echo ok"
     assert "path" not in data
     assert str(tmp_path) not in result.structuredContent["message"]
+
+
+@pytest.mark.asyncio
+async def test_spawn_process_reports_vanished_cwd_as_path_error(tmp_path, monkeypatch):
+    missing_cwd = tmp_path / "vanished"
+
+    async def fail_spawn(*args, **kwargs):  # noqa: ANN002, ANN003, ARG001
+        raise FileNotFoundError(2, "No such file or directory", str(missing_cwd))
+
+    monkeypatch.setattr(shell_ops_module.asyncio, "create_subprocess_exec", fail_spawn)
+
+    with pytest.raises(PathNotFoundError) as raised:
+        await shell_ops_module._spawn_process("echo ok", str(missing_cwd))
+
+    assert raised.value.path == missing_cwd
 
 
 @pytest.mark.asyncio

--- a/tests/test_shell_ops.py
+++ b/tests/test_shell_ops.py
@@ -5,6 +5,7 @@ import time
 import pytest
 from conftest import python_shell_command
 from fastapi.testclient import TestClient
+from mcp.types import CallToolResult, TextContent
 
 import local_shell_mcp.http_app as http_app_module
 import local_shell_mcp.tools as tools_module
@@ -22,6 +23,11 @@ from local_shell_mcp.shell_ops import (
 )
 from local_shell_mcp.tmux_helper import TmuxSelection
 from local_shell_mcp.tools import build_mcp
+
+
+def _mcp_error_text(result: CallToolResult) -> str:
+    assert result.isError is True
+    return next(item.text for item in result.content if isinstance(item, TextContent))
 
 
 def test_public_tool_watchdog_allows_shell_timeout_cleanup():
@@ -62,7 +68,8 @@ async def test_run_shell_tool_rejects_timeout_above_public_cap(tmp_path, monkeyp
     response = await build_mcp().call_tool(
         "run_shell_tool", {"command": "echo ok", "timeout_s": 3600}
     )
-    payload = response[0][0].text
+    assert isinstance(response, CallToolResult)
+    payload = _mcp_error_text(response)
 
     assert "timeout_s must be <= 120 seconds for public run_shell" in payload
 
@@ -79,7 +86,8 @@ async def test_mcp_tool_watchdog_returns_handled_timeout(tmp_path, monkeypatch):
     monkeypatch.setattr(tools_module, "tree", hanging_tree)
 
     response = await build_mcp().call_tool("tree_view", {"cwd": "."})
-    payload = response[0][0].text
+    assert isinstance(response, CallToolResult)
+    payload = _mcp_error_text(response)
 
     assert "tree_view exceeded 0.01 second public tool timeout" in payload
 
@@ -132,7 +140,8 @@ async def test_mcp_tool_watchdog_times_out_sync_tool(tmp_path, monkeypatch):
     monkeypatch.setattr(tools_module, "list_dir", blocking_list_dir)
 
     response = await build_mcp().call_tool("list_files", {"path": "."})
-    payload = response[0][0].text
+    assert isinstance(response, CallToolResult)
+    payload = _mcp_error_text(response)
 
     assert "list_files exceeded 0.01 second public tool timeout" in payload
 
@@ -204,6 +213,29 @@ async def test_run_shell_fast_command_succeeds(tmp_path, monkeypatch):
     assert result.ok is True
     assert result.timed_out is False
     assert "ok" in result.stdout
+
+
+@pytest.mark.asyncio
+async def test_run_shell_tool_reports_missing_shell_executable(tmp_path, monkeypatch):
+    executable = "local-shell-mcp-missing-shell-issue-106"
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_AUTH_MODE", "none")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_SHELL_EXECUTABLE", executable)
+    get_settings.cache_clear()
+
+    result = await build_mcp().call_tool("run_shell_tool", {"command": "echo ok"})
+
+    assert isinstance(result, CallToolResult)
+    assert result.isError is True
+    assert result.structuredContent["ok"] is False
+    assert result.structuredContent["message"] == f"Shell executable not found: {executable}"
+    data = result.structuredContent["data"]
+    assert data["status"] == "executable_not_found"
+    assert data["error_type"] == "FileNotFoundError"
+    assert data["executable"] == executable
+    assert data["command"] == "echo ok"
+    assert "path" not in data
+    assert str(tmp_path) not in result.structuredContent["message"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_tools_complete.py
+++ b/tests/test_tools_complete.py
@@ -5,9 +5,11 @@ import json
 import subprocess
 
 import pytest
+from mcp.types import CallToolResult
 
 import local_shell_mcp.downloads as downloads
 import local_shell_mcp.tools as tools
+from local_shell_mcp.fs_ops import PathNotFoundError
 from local_shell_mcp.models import CommandResult
 from local_shell_mcp.settings import get_settings
 
@@ -40,6 +42,12 @@ def _raw_tool(mcp, name: str):
     wrapped = mcp._tool_manager._tools[name].fn
     original = wrapped.__kwdefaults__["__original"]
     return original
+
+
+def _handled_error_data(result: CallToolResult) -> dict:
+    assert result.isError is True
+    assert result.structuredContent["ok"] is False
+    return result.structuredContent["data"]
 
 
 class FakeRemoteManager:
@@ -310,7 +318,8 @@ async def test_tool_wrapper_error_paths_and_remote_disabled(tmp_path, monkeypatc
         if name in {"search", "fetch"}:
             assert isinstance(result, str)
         else:
-            assert result["data"]["status"] == "error", name
+            assert isinstance(result, CallToolResult), name
+            assert _handled_error_data(result)["status"] == "error", name
 
     _configure(tmp_path, monkeypatch, remote_enabled=False)
     disabled = tools.build_mcp()
@@ -354,7 +363,8 @@ def test_tool_helpers_audit_serialization_timeout_and_tail(tmp_path, monkeypatch
     fetch = json.loads(tools._timeout_payload_for_tool("fetch", TimeoutError("x")))
     assert fetch["metadata"]["error"] == "TimeoutError"
     generic = tools._timeout_payload_for_tool("other", TimeoutError("x"))
-    assert generic["data"]["status"] == "error"
+    assert isinstance(generic, CallToolResult)
+    assert _handled_error_data(generic)["status"] == "error"
 
     audit_path = tmp_path / "audit.jsonl"
     audit_path.write_text(
@@ -474,11 +484,11 @@ def test_transport_security_secret_helpers_and_remote_unwrap(tmp_path, monkeypat
 
 def test_handled_error_missing_path_and_sync(monkeypatch, tmp_path):
     _configure(tmp_path, monkeypatch)
-    result = tools._handled_error(FileNotFoundError("missing.txt"))
-    assert result["data"]["status"] == "not_found"
-    assert result["data"]["path"].endswith("missing.txt")
+    result = tools._handled_error(PathNotFoundError("missing.txt"))
+    assert _handled_error_data(result)["status"] == "not_found"
+    assert _handled_error_data(result)["path"].endswith("missing.txt")
     generic = tools._handled_error(ValueError("bad"))
-    assert generic["data"]["error_type"] == "ValueError"
+    assert _handled_error_data(generic)["error_type"] == "ValueError"
 
     async def value():
         return 42

--- a/tests/test_tools_complete.py
+++ b/tests/test_tools_complete.py
@@ -9,7 +9,7 @@ from mcp.types import CallToolResult
 
 import local_shell_mcp.downloads as downloads
 import local_shell_mcp.tools as tools
-from local_shell_mcp.fs_ops import PathNotFoundError
+from local_shell_mcp.errors import PathNotFoundError
 from local_shell_mcp.models import CommandResult
 from local_shell_mcp.settings import get_settings
 
@@ -499,3 +499,37 @@ def test_handled_error_missing_path_and_sync(monkeypatch, tmp_path):
         assert tools._sync(value()) == 42
     finally:
         loop.close()
+
+
+@pytest.mark.asyncio
+async def test_remote_shell_failure_returns_mcp_error(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+
+    class FailedRemoteManager:
+        async def call(self, machine, tool, args, timeout_s=None):  # noqa: ARG002
+            return {
+                "ok": False,
+                "message": "Shell executable not found: missing-shell",
+                "data": {
+                    "status": "executable_not_found",
+                    "error_type": "FileNotFoundError",
+                    "message": "Shell executable not found: missing-shell",
+                    "executable": "missing-shell",
+                    "command": "echo ok",
+                    "cwd": "/workspace",
+                    "original_error": "[WinError 2]",
+                },
+            }
+
+    monkeypatch.setattr(tools, "remote_manager", lambda: FailedRemoteManager())
+
+    result = await tools.build_mcp().call_tool(
+        "run_shell_tool",
+        {"command": "echo ok", "machine": "node"},
+    )
+
+    assert isinstance(result, CallToolResult)
+    assert result.isError is True
+    assert result.structuredContent["ok"] is False
+    assert result.structuredContent["data"]["status"] == "executable_not_found"
+    assert result.structuredContent["data"]["executable"] == "missing-shell"


### PR DESCRIPTION
## Summary

- distinguish confirmed workspace path misses from unrelated `FileNotFoundError` exceptions
- report missing configured shell executables with the executable, command, working directory, and original OS error
- return handled tool failures as MCP errors with `ok: false` and `isError: true`
- add regression coverage for Windows-style process startup errors and the end-to-end missing-shell case

## Validation

- `ruff check .`
- `pytest -q` — 565 passed

Fixes #106
