### PR TITLE
chore: prepare v3.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "local-shell-mcp"
-version = "3.1.2"
+version = "3.1.3"
 description = "A ChatGPT-compatible OAuth MCP server that gives AI coding agents controlled shell, filesystem, remote-worker, and Playwright access inside a local container."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/local_shell_mcp/__init__.py
+++ b/src/local_shell_mcp/__init__.py
@@ -1,3 +1,3 @@
 """local-shell-mcp."""
 
-__version__ = "3.1.2"
+__version__ = "3.1.3"


### PR DESCRIPTION
## Summary

- bump the project version to 3.1.3
- keep the runtime package version synchronized

## Validation

- verified both version declarations resolve to 3.1.3
- `git diff --check`