### PR TITLE
fix: expose Homebrew tools to macOS worker service

### DIFF
--- a/src/local_shell_mcp/remote_worker_cli.py
+++ b/src/local_shell_mcp/remote_worker_cli.py
@@ -14,6 +14,8 @@ from .remote_worker_service import (
     cancel_worker_lock_reexec,
     install_service,
     prepare_worker_lock_reexec,
+    prepare_worker_service_environment,
+    refresh_installed_service_definition,
     service_status,
     start_service,
     stop_service,
@@ -184,6 +186,7 @@ def _prepare_worker_start() -> None:
     install_or_update_runtime(str(config["server"]))
     install_launcher()
     ensure_user_bin_on_path()
+    refresh_installed_service_definition()
 
 
 def _add_enrollment_arguments(parser: argparse.ArgumentParser) -> None:
@@ -238,6 +241,7 @@ def _run_command(args: argparse.Namespace) -> None:
     elif args.command == "connect":
         asyncio.run(_connect(args))
     elif args.command == "run":
+        prepare_worker_service_environment()
         asyncio.run(run_enrolled_worker())
     elif args.command == "start":
         _prepare_worker_start()
@@ -254,9 +258,11 @@ def _run_command(args: argparse.Namespace) -> None:
         config = _load_config_or_migrate()
         before = service_status()
         result = install_or_update_runtime(str(config["server"]), force=args.force)
-        if result["updated"] and before["running"]:
-            stop_service()
-            start_service()
+        if result["updated"]:
+            refresh_installed_service_definition()
+            if before["running"]:
+                stop_service()
+                start_service()
         _print_result(result)
     elif args.command == "install-service":
         config = _load_config_or_migrate()

--- a/src/local_shell_mcp/remote_worker_service.py
+++ b/src/local_shell_mcp/remote_worker_service.py
@@ -7,6 +7,7 @@ import json
 import os
 import platform
 import plistlib
+import posixpath
 import re
 import shlex
 import shutil
@@ -32,6 +33,19 @@ from .remote_worker_state import (
 _SERVICE_NAME = "local-shell-mcp-worker"
 _LAUNCHD_LABEL = "com.fwerkor.local-shell-mcp-worker"
 _WORKER_MANAGED_ENV = "LOCAL_SHELL_MCP_WORKER_MANAGED"
+_LAUNCHD_PATH_SEPARATOR = ":"
+_LAUNCHD_HOMEBREW_DIRS = (
+    "/opt/homebrew/bin",
+    "/opt/homebrew/sbin",
+    "/usr/local/bin",
+    "/usr/local/sbin",
+)
+_LAUNCHD_SYSTEM_DIRS = (
+    "/usr/bin",
+    "/bin",
+    "/usr/sbin",
+    "/sbin",
+)
 _WORKER_LOCK_FD_ENV = "LOCAL_SHELL_MCP_WORKER_LOCK_FD"
 _WORKER_LOCK_RETRY_S = 5.0
 _WORKER_LOCK_HANDOFF_RETRY_S = 0.1
@@ -251,20 +265,83 @@ WantedBy=default.target
     return path
 
 
-def _write_launchd_plist() -> Path:
+def _launchd_session_path_entries() -> tuple[str, ...]:
+    if platform.system() != "Darwin" or not shutil.which("launchctl"):
+        return ()
+    result = _run(["launchctl", "getenv", "PATH"], check=False)
+    if result.returncode:
+        return ()
+    return tuple(
+        entry
+        for entry in result.stdout.strip().split(_LAUNCHD_PATH_SEPARATOR)
+        if entry and posixpath.isabs(entry)
+    )
+
+
+def _installed_launchd_launcher_path() -> Path | None:
+    try:
+        payload = plistlib.loads(_launchd_plist_path().read_bytes())
+    except (OSError, TypeError, ValueError, plistlib.InvalidFileException):
+        return None
+    arguments = payload.get("ProgramArguments")
+    if not isinstance(arguments, list) or not arguments:
+        return None
+    launcher = arguments[0]
+    if not isinstance(launcher, str):
+        return None
+    path = Path(launcher)
+    return path if path.is_absolute() else None
+
+
+def _launchd_path(launcher: Path | None = None) -> str:
+    launcher = launcher or worker_launcher_path()
+    directories = (
+        str(launcher.parent),
+        *_LAUNCHD_HOMEBREW_DIRS,
+        *_launchd_session_path_entries(),
+        *_LAUNCHD_SYSTEM_DIRS,
+    )
+    return _LAUNCHD_PATH_SEPARATOR.join(dict.fromkeys(directories))
+
+
+def _write_launchd_plist(launcher: Path | None = None) -> Path:
+    launcher = launcher or worker_launcher_path()
     path = _launchd_plist_path()
     payload = {
         "Label": _LAUNCHD_LABEL,
-        "ProgramArguments": [str(worker_launcher_path()), "worker", "run"],
+        "ProgramArguments": [str(launcher), "worker", "run"],
         "RunAtLoad": True,
         "KeepAlive": True,
-        "EnvironmentVariables": {_WORKER_MANAGED_ENV: "1"},
+        "EnvironmentVariables": {
+            _WORKER_MANAGED_ENV: "1",
+            "PATH": _launchd_path(launcher),
+        },
         "StandardOutPath": str(worker_log_path()),
         "StandardErrorPath": str(worker_log_path()),
     }
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(plistlib.dumps(payload, fmt=plistlib.FMT_XML, sort_keys=False))
     return path
+
+
+def refresh_installed_service_definition() -> Path | None:
+    if service_kind() != "launchd" or not _launchd_plist_path().exists():
+        return None
+    launcher = _installed_launchd_launcher_path() or worker_launcher_path()
+    return _write_launchd_plist(launcher)
+
+
+def prepare_worker_service_environment() -> Path | None:
+    if (
+        platform.system() != "Darwin"
+        or service_kind() != "launchd"
+        or not _launchd_plist_path().exists()
+        or not _current_worker_is_managed()
+    ):
+        return None
+    launcher = _installed_launchd_launcher_path() or worker_launcher_path()
+    os.environ["PATH"] = _launchd_path(launcher)
+    return _write_launchd_plist(launcher)
 
 
 def _pid_is_running(pid: int) -> bool:
@@ -466,7 +543,7 @@ def install_service(*, start: bool = True) -> dict[str, Any]:
         _run(command)
     elif kind == "launchd":
         _stop_process()
-        service_file = _write_launchd_plist()
+        service_file = _write_launchd_plist(launcher)
         domain = f"gui/{_user_id()}"
         _run(["launchctl", "bootout", domain, str(service_file)], check=False)
         if start:

--- a/tests/test_remote_worker_cli.py
+++ b/tests/test_remote_worker_cli.py
@@ -243,6 +243,20 @@ def test_cli_legacy_and_lifecycle_dispatch(tmp_path, monkeypatch, capsys):
     assert calls == ["prepare", "start", "stop", "prepare", "start"]
 
 
+def test_cli_run_prepares_managed_service_environment(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        cli, "prepare_worker_service_environment", lambda: calls.append("prepare")
+    )
+
+    async def fake_run():
+        calls.append("run")
+
+    monkeypatch.setattr(cli, "run_enrolled_worker", fake_run)
+    cli.run_worker_cli(["run"])
+    assert calls == ["prepare", "run"]
+
+
 def test_cli_update_restarts_running_service(tmp_path, monkeypatch, capsys):
     _configure(tmp_path, monkeypatch)
     state.write_worker_config(server="https://example.test", name="worker", workdir=str(tmp_path))
@@ -253,11 +267,38 @@ def test_cli_update_restarts_running_service(tmp_path, monkeypatch, capsys):
         "install_or_update_runtime",
         lambda server, force=False: {"updated": True, "server": server, "force": force},
     )
+    monkeypatch.setattr(
+        cli,
+        "refresh_installed_service_definition",
+        lambda: calls.append("refresh"),
+    )
     monkeypatch.setattr(cli, "stop_service", lambda: calls.append("stop"))
     monkeypatch.setattr(cli, "start_service", lambda: calls.append("start"))
     cli.run_worker_cli(["update", "--force"])
-    assert calls == ["stop", "start"]
+    assert calls == ["refresh", "stop", "start"]
     assert '"force": true' in capsys.readouterr().out
+
+
+def test_cli_update_refreshes_stopped_service_definition(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    state.write_worker_config(server="https://example.test", name="worker", workdir=str(tmp_path))
+    calls = []
+    monkeypatch.setattr(cli, "service_status", lambda: {"running": False})
+    monkeypatch.setattr(
+        cli,
+        "install_or_update_runtime",
+        lambda server, force=False: {"updated": True, "server": server, "force": force},
+    )
+    monkeypatch.setattr(
+        cli,
+        "refresh_installed_service_definition",
+        lambda: calls.append("refresh"),
+    )
+    monkeypatch.setattr(cli, "stop_service", lambda: pytest.fail("stopped inactive service"))
+    monkeypatch.setattr(cli, "start_service", lambda: pytest.fail("started inactive service"))
+
+    cli.run_worker_cli(["update"])
+    assert calls == ["refresh"]
 
 
 def test_cli_errors_are_clean(monkeypatch, capsys):

--- a/tests/test_remote_worker_service.py
+++ b/tests/test_remote_worker_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import errno
 import json
 import os
+import plistlib
 import subprocess
 import sys
 from pathlib import Path
@@ -78,12 +79,121 @@ def test_launchd_install_start_and_status(tmp_path, monkeypatch):
 
     monkeypatch.setattr(service, "_run", fake_run)
     service.install_service(start=True)
-    assert service._launchd_plist_path().exists()  # noqa: SLF001
-    assert b"LOCAL_SHELL_MCP_WORKER_MANAGED" in service._launchd_plist_path().read_bytes()
+    plist_path = service._launchd_plist_path()  # noqa: SLF001
+    assert plist_path.exists()
+    environment = plistlib.loads(plist_path.read_bytes())["EnvironmentVariables"]
+    assert environment["LOCAL_SHELL_MCP_WORKER_MANAGED"] == "1"
+    assert environment["PATH"] == ":".join(
+        [
+            str(service.worker_launcher_path().parent),
+            "/opt/homebrew/bin",
+            "/opt/homebrew/sbin",
+            "/usr/local/bin",
+            "/usr/local/sbin",
+            "/usr/bin",
+            "/bin",
+            "/usr/sbin",
+            "/sbin",
+        ]
+    )
     assert service.service_status()["running"] is True
     service.start_service()
     service.stop_service()
     assert any(command[1] == "bootstrap" for command, _ in calls if command[0] == "launchctl")
+
+
+def test_launchd_plist_path_does_not_inherit_installer_environment(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    first = service._write_launchd_plist().read_bytes()  # noqa: SLF001
+    monkeypatch.setenv("PATH", "/tmp/transient-bin:/usr/bin")
+    second = service._write_launchd_plist().read_bytes()  # noqa: SLF001
+
+    assert second == first
+    path = plistlib.loads(second)["EnvironmentVariables"]["PATH"]
+    assert "/tmp/transient-bin" not in path
+
+
+def test_launchd_path_preserves_sanitized_session_entries(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setattr(service.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(service.shutil, "which", lambda name: "/bin/launchctl")
+
+    def fake_run(command, *, check=True):
+        assert command == ["launchctl", "getenv", "PATH"]
+        assert check is False
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout="/nix/var/nix/profiles/default/bin:relative::/opt/local/bin:/usr/bin\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(service, "_run", fake_run)
+    assert service._launchd_path() == ":".join(  # noqa: SLF001
+        [
+            str(service.worker_launcher_path().parent),
+            "/opt/homebrew/bin",
+            "/opt/homebrew/sbin",
+            "/usr/local/bin",
+            "/usr/local/sbin",
+            "/nix/var/nix/profiles/default/bin",
+            "/opt/local/bin",
+            "/usr/bin",
+            "/bin",
+            "/usr/sbin",
+            "/sbin",
+        ]
+    )
+
+
+def test_prepare_launchd_worker_environment_preserves_custom_launcher(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    custom_launcher = tmp_path / "custom-bin" / "local-shell-mcp"
+    plist_path = service._launchd_plist_path()  # noqa: SLF001
+    plist_path.parent.mkdir(parents=True, exist_ok=True)
+    plist_path.write_bytes(
+        plistlib.dumps(
+            {
+                "Label": "com.fwerkor.local-shell-mcp-worker",
+                "ProgramArguments": [str(custom_launcher), "worker", "run"],
+            }
+        )
+    )
+    monkeypatch.setattr(service.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(service, "service_kind", lambda: "launchd")
+    monkeypatch.setattr(service, "_current_worker_is_managed", lambda: True)
+    monkeypatch.setattr(
+        service, "_launchd_session_path_entries", lambda: ("/opt/local/bin",)
+    )
+
+    assert service.prepare_worker_service_environment() == plist_path
+    expected_path = [
+        str(custom_launcher.parent),
+        "/opt/homebrew/bin",
+        "/opt/homebrew/sbin",
+        "/usr/local/bin",
+        "/usr/local/sbin",
+        "/opt/local/bin",
+        "/usr/bin",
+        "/bin",
+        "/usr/sbin",
+        "/sbin",
+    ]
+    assert os.environ["PATH"] == ":".join(expected_path)
+    payload = plistlib.loads(plist_path.read_bytes())
+    assert payload["ProgramArguments"][0] == str(custom_launcher)
+    assert payload["EnvironmentVariables"]["PATH"] == ":".join(expected_path)
+
+
+def test_prepare_worker_environment_ignores_darwin_process_fallback(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setenv("PATH", "/custom/bin:/usr/bin")
+    monkeypatch.setattr(service.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(service, "service_kind", lambda: "process")
+    monkeypatch.setattr(service, "_current_worker_is_managed", lambda: True)
+
+    assert service.prepare_worker_service_environment() is None
+    assert os.environ["PATH"] == "/custom/bin:/usr/bin"
 
 
 def test_process_fallback_start_stop_and_stale_pid(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- add an explicit macOS LaunchAgent `PATH` containing the installed worker launcher directory, Apple Silicon and Intel Homebrew `bin`/`sbin` prefixes, and standard system directories
- preserve persistent custom launchd session paths from `launchctl getenv PATH` while rejecting empty and relative entries
- avoid inheriting the invoking shell's transient `PATH` or sourcing interactive shell profiles
- refresh existing LaunchAgent plists during worker start/update and before managed worker reconnects, so upgrades from older installations take effect immediately
- preserve custom worker launcher locations when rewriting an existing plist
- leave the Darwin process fallback environment unchanged
- add regression coverage for plist contents, custom launchd paths, custom launcher preservation, managed startup, and running/stopped updates

## Validation

- `pytest -q tests/test_remote_worker_service.py tests/test_remote_worker_cli.py`
- `ruff check src/local_shell_mcp/remote_worker_service.py src/local_shell_mcp/remote_worker_cli.py tests/test_remote_worker_service.py tests/test_remote_worker_cli.py`
- `pytest -q`

Fixes #114