### PR TITLE
Add keyboard navigation for scrollable TUI panes

### DIFF
--- a/ui/src/audit-screen.test.tsx
+++ b/ui/src/audit-screen.test.tsx
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { testRender } from "@opentui/react/test-utils"
+import { act } from "react"
+import { AuditScreen } from "./audit-screen"
+
+const originalFetch = globalThis.fetch
+const renderers: Array<{ destroy: () => void }> = []
+
+function success(data: unknown): Response {
+  return new Response(JSON.stringify({ ok: true, message: "", data }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+async function renderUntil(
+  setup: { renderOnce: () => Promise<void>; captureCharFrame: () => string },
+  predicate: () => boolean,
+  attempts = 30,
+): Promise<void> {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    await act(async () => {
+      await Promise.resolve()
+      await setup.renderOnce()
+    })
+    if (predicate()) return
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+  throw new Error("Timed out waiting for OpenTUI state")
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  const reactTestGlobal = globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  reactTestGlobal.IS_REACT_ACT_ENVIRONMENT = false
+  for (const renderer of renderers.splice(0)) renderer.destroy()
+})
+
+describe("AuditScreen pane navigation", () => {
+  test("scrolls the active result pane instead of changing the selected call", async () => {
+    let detailCalls = 0
+    const output = Object.fromEntries(
+      Array.from({ length: 40 }, (_, index) => [`result_${String(index).padStart(2, "0")}`, `value-${index}`]),
+    )
+    const input = Object.fromEntries(
+      Array.from({ length: 40 }, (_, index) => [`request_${String(index).padStart(2, "0")}`, `value-${index}`]),
+    )
+
+    globalThis.fetch = ((raw: RequestInfo | URL) => {
+      const parsed = new URL(String(raw))
+      const path = parsed.pathname.replace("/api/ui", "")
+      if (path === "/audit") {
+        return Promise.resolve(success({
+          entries: [{
+            id: "call:1",
+            ts: 1,
+            event: "tool_call",
+            node: "local",
+            operation: "files",
+            tool: "read",
+            status: "success",
+            ok: true,
+            paired: true,
+          }],
+          count: 1,
+          total_matched: 1,
+        }))
+      }
+      if (path === "/audit/detail") {
+        detailCalls += 1
+        return Promise.resolve(success({
+            id: "call:1",
+            ts: 1,
+            event: "tool_call",
+            node: "local",
+            operation: "files",
+            tool: "read",
+            status: "success",
+            ok: true,
+            paired: true,
+            source_events: ["tool_call_start", "tool_call_end"],
+            input,
+          output,
+        }))
+      }
+      throw new Error(`Unexpected request: ${parsed.pathname}${parsed.search}`)
+    }) as typeof fetch
+
+    const setup = await testRender(
+      <AuditScreen
+        machines={[{ name: "local", status: "online" }]}
+        width={180}
+        height={34}
+        setStatus={() => {}}
+        keyboardEnabled
+        onInteractionLockChange={() => {}}
+      />,
+      { width: 180, height: 34 },
+    )
+    renderers.push(setup.renderer)
+
+    await renderUntil(
+      setup,
+      () => detailCalls >= 1 && setup.captureCharFrame().includes("result_00"),
+    )
+
+    await act(async () => {
+      setup.mockInput.pressTab()
+      await setup.renderOnce()
+    })
+    await renderUntil(setup, () => setup.captureCharFrame().includes("j scroll down"))
+    for (let index = 0; index < 12; index += 1) {
+      await act(async () => {
+        setup.mockInput.pressKey("j")
+        await setup.renderOnce()
+      })
+    }
+
+    const scrolled = setup.captureCharFrame()
+    expect(scrolled).not.toContain("result_00")
+    expect(scrolled).toContain("result_12")
+    expect(scrolled).toContain("read")
+  })
+})

--- a/ui/src/audit-screen.tsx
+++ b/ui/src/audit-screen.tsx
@@ -1,4 +1,4 @@
-import type { Renderable } from "@opentui/core"
+import type { Renderable, ScrollBoxRenderable } from "@opentui/core"
 import { useKeyboard } from "@opentui/react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { api, formatError } from "./api"
@@ -15,6 +15,7 @@ import {
 import { EmptyState, KeyHint, Loading, Modal, Panel, useVisibleRows } from "./components"
 import { ImagePreviewView } from "./image-preview-view"
 import { handleSelectionScroll } from "./mouse"
+import { cyclePane, scrollPaneForKey } from "./pane-navigation"
 import { clampIndex, nextPreviewMeasurement } from "./state-utils"
 import { HighlightedText } from "./syntax-highlight"
 import { parseTerminalCellAspect } from "./terminal-geometry"
@@ -25,6 +26,8 @@ const colors = screenTheme.Audit
 const terminalCellAspect = parseTerminalCellAspect(process.env.LOCAL_SHELL_MCP_UI_CELL_ASPECT)
 
 type AuditDialog = { type: "none" } | { type: "search" } | { type: "event" } | { type: "session" }
+type AuditPane = "list" | "output" | "input"
+const AUDIT_PANES = ["list", "output", "input"] as const satisfies readonly AuditPane[]
 
 const TIME_RANGES = [
   { label: "15m", seconds: 15 * 60 },
@@ -83,6 +86,7 @@ export function AuditScreen({
   const [loading, setLoading] = useState(true)
   const [loaded, setLoaded] = useState(false)
   const [detail, setDetail] = useState<AuditEntry | null>(null)
+  const [activePane, setActivePane] = useState<AuditPane>("list")
   const [previewBounds, setPreviewBounds] = useState({ columns: 8, rows: 4 })
   const refreshRequest = useRef(0)
   const refreshController = useRef<AbortController | null>(null)
@@ -91,6 +95,8 @@ export function AuditScreen({
   const entriesRef = useRef<AuditEntry[]>([])
   const selectedRef = useRef(0)
   const measuredPreviewViewport = useRef("")
+  const outputScrollRef = useRef<ScrollBoxRenderable | null>(null)
+  const inputScrollRef = useRef<ScrollBoxRenderable | null>(null)
 
   const nodes = useMemo(() => ["", ...machines.map((machine) => machine.name)], [machines])
   const selectedNode = nodes[nodeIndex] || ""
@@ -225,17 +231,43 @@ export function AuditScreen({
     return () => clearInterval(timer)
   }, [refresh])
 
+  useEffect(() => {
+    outputScrollRef.current?.scrollTo(0)
+    inputScrollRef.current?.scrollTo(0)
+  }, [displayed?.id])
+
+  const cycleActivePane = (delta = 1) => {
+    setActivePane((value) => cyclePane(AUDIT_PANES, value, delta))
+  }
+
+  const moveOrScroll = (key: { name: string; shift?: boolean }) => {
+    if (activePane === "list") {
+      if (key.name === "j" || key.name === "down") {
+        selectIndex((value) => clampIndex(value + 1, entries.length))
+        return true
+      }
+      if (key.name === "k" || key.name === "up") {
+        selectIndex((value) => Math.max(0, value - 1))
+        return true
+      }
+      return false
+    }
+    return scrollPaneForKey(activePane === "output" ? outputScrollRef.current : inputScrollRef.current, key)
+  }
+
   useKeyboard((key) => {
     if (!keyboardEnabled) return
     if (dialog.type !== "none") {
       if (key.name === "escape") setDialog({ type: "none" })
       return
     }
-    if (key.name === "j" || key.name === "down") {
-      selectIndex((value) => clampIndex(value + 1, entries.length))
-    } else if (key.name === "k" || key.name === "up") {
-      selectIndex((value) => Math.max(0, value - 1))
-    } else if (key.name === "n") cycleNode()
+    if (key.name === "tab") {
+      key.preventDefault()
+      cycleActivePane(key.shift ? -1 : 1)
+    } else if (key.name === "left") cycleActivePane(-1)
+    else if (key.name === "right") cycleActivePane(1)
+    else if (moveOrScroll(key)) return
+    else if (key.name === "n") cycleNode()
     else if (key.name === "o") cycleOperation()
     else if (key.name === "t") cycleTime()
     else if (key.name === "s") toggleSort()
@@ -298,9 +330,10 @@ export function AuditScreen({
       <box style={{ flexGrow: 1, flexDirection: horizontal ? "row" : "column", gap: 1 }}>
         <Panel
           title={`Audit records · ${loaded ? entries.length : "—"}${loading ? " · syncing" : ""}`}
-          active
+          active={activePane === "list"}
           accent={colors.accent}
           activeBackground={colors.panel}
+          onMouseDown={() => setActivePane("list")}
           style={horizontal
             ? { width: listLayout.paneWidth, flexShrink: 0, paddingTop: 1 }
             : { flexGrow: 1, paddingTop: 1 }}
@@ -374,6 +407,10 @@ export function AuditScreen({
               />
               <Panel
                 title="Call result"
+                active={activePane === "output"}
+                accent={colors.accent}
+                activeBackground={colors.panel}
+                onMouseDown={() => setActivePane("output")}
                 style={{ flexGrow: 1, minHeight: 0, overflow: "hidden", padding: 1 }}
               >
                 <box
@@ -406,6 +443,7 @@ export function AuditScreen({
                     />
                   ) : (
                     <scrollbox
+                      ref={outputScrollRef}
                       focused={false}
                       style={{ flexGrow: 1, minWidth: 0, minHeight: 0 }}
                       scrollY
@@ -418,9 +456,14 @@ export function AuditScreen({
               </Panel>
               <Panel
                 title="Call input"
+                active={activePane === "input"}
+                accent={colors.accent}
+                activeBackground={colors.panel}
+                onMouseDown={() => setActivePane("input")}
                 style={{ flexGrow: 1, minHeight: 0, overflow: "hidden", padding: 1 }}
               >
                 <scrollbox
+                  ref={inputScrollRef}
                   focused={false}
                   style={{ flexGrow: 1, minWidth: 0, minHeight: 0 }}
                   scrollY
@@ -440,8 +483,9 @@ export function AuditScreen({
       <KeyHint
         accent={colors.accent}
         items={[
-          { key: "j", label: "down", onPress: () => selectIndex((value) => clampIndex(value + 1, entries.length)), disabled: footerLocked || entries.length === 0 },
-          { key: "k", label: "up", onPress: () => selectIndex((value) => Math.max(0, value - 1)), disabled: footerLocked || entries.length === 0 },
+          { key: "Tab", label: "pane", onPress: () => cycleActivePane(1), disabled: footerLocked },
+          { key: "j", label: activePane === "list" ? "down" : "scroll down", onPress: () => moveOrScroll({ name: "j" }), disabled: footerLocked || (activePane === "list" && entries.length === 0) },
+          { key: "k", label: activePane === "list" ? "up" : "scroll up", onPress: () => moveOrScroll({ name: "k" }), disabled: footerLocked || (activePane === "list" && entries.length === 0) },
           { key: "n", label: "node", onPress: cycleNode, disabled: footerLocked },
           { key: "o", label: "operation", onPress: cycleOperation, disabled: footerLocked },
           { key: "t", label: "time", onPress: cycleTime, disabled: footerLocked },

--- a/ui/src/files-screen.tsx
+++ b/ui/src/files-screen.tsx
@@ -1,4 +1,4 @@
-import type { Renderable, TextareaRenderable } from "@opentui/core"
+import type { Renderable, ScrollBoxRenderable, TextareaRenderable } from "@opentui/core"
 import { useKeyboard } from "@opentui/react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { api, formatError } from "./api"
@@ -11,6 +11,7 @@ import {
 } from "./file-navigation"
 import { calculateFilesLayout } from "./files-layout"
 import { handleSelectionScroll } from "./mouse"
+import { scrollPaneForKey } from "./pane-navigation"
 import { clampIndex, nextPreviewMeasurement, payloadMatches } from "./state-utils"
 import { HighlightedText } from "./syntax-highlight"
 import { ImagePreviewView } from "./image-preview-view"
@@ -116,11 +117,13 @@ function Preview({
   entry,
   showHidden,
   onDirectoryEntrySelect,
+  scrollRef,
 }: {
   preview: FilePreview | null
   entry?: FileEntry
   showHidden: boolean
   onDirectoryEntrySelect?: (entry: FileEntry) => void
+  scrollRef: { current: ScrollBoxRenderable | null }
 }) {
   const directoryEntries = preview?.kind === "directory"
     ? (preview.entries || []).filter((item) => showHidden || !item.hidden)
@@ -133,6 +136,7 @@ function Preview({
         <EmptyState title={entry.name} detail="Loading preview…" />
       ) : preview.kind === "directory" ? (
         <scrollbox
+          ref={scrollRef}
           focused={false}
           style={{ flexGrow: 1, minWidth: 0, minHeight: 0, paddingLeft: 1, paddingRight: 1 }}
           scrollY
@@ -160,6 +164,7 @@ function Preview({
         <ImagePreviewView preview={preview} title={entry.name} fallbackBytes={Number(entry.size || 0)} />
       ) : (
         <scrollbox
+          ref={scrollRef}
           focused={false}
           style={{ flexGrow: 1, minWidth: 0, minHeight: 0, paddingLeft: 1, paddingRight: 1 }}
           scrollY
@@ -213,6 +218,7 @@ export function FilesScreen({
   const [narrowPane, setNarrowPane] = useState<"list" | "preview">("list")
   const [previewBounds, setPreviewBounds] = useState<{ columns: number; rows: number } | null>(null)
   const editorRef = useRef<TextareaRenderable>(null)
+  const previewScrollRef = useRef<ScrollBoxRenderable | null>(null)
   const refreshRequest = useRef(0)
   const refreshController = useRef<AbortController | null>(null)
   const measuredPreviewViewport = useRef("")
@@ -318,6 +324,7 @@ export function FilesScreen({
 
   useEffect(() => {
     setPreview(null)
+    previewScrollRef.current?.scrollTo(0)
   }, [current?.path, machine])
 
   useEffect(() => {
@@ -474,6 +481,18 @@ export function FilesScreen({
     if (narrow) setNarrowPane("list")
   }
   const toggleNarrowPane = () => setNarrowPane((value) => (value === "list" ? "preview" : "list"))
+  const moveOrScroll = (key: { name: string; shift?: boolean }) => {
+    if (narrowPane === "preview") return scrollPaneForKey(previewScrollRef.current, key)
+    if (key.name === "j" || key.name === "down") {
+      moveSelection(1)
+      return true
+    }
+    if (key.name === "k" || key.name === "up") {
+      moveSelection(-1)
+      return true
+    }
+    return false
+  }
   const createFile = () => setDialog({
     type: "input",
     action: "new-file",
@@ -561,14 +580,13 @@ export function FilesScreen({
       return
     }
 
-    if (narrow && key.name === "tab") {
+    if (key.name === "tab") {
       key.preventDefault()
       toggleNarrowPane()
       return
     }
-    if (key.name === "j" || key.name === "down") moveSelection(1)
-    else if (key.name === "k" || key.name === "up") moveSelection(-1)
-    else if (key.name === "g" && key.shift) setSelected(Math.max(0, entries.length - 1))
+    if (moveOrScroll(key)) return
+    if (key.name === "g" && key.shift && narrowPane === "list") setSelected(Math.max(0, entries.length - 1))
     else if (key.name === "g") setSelected(0)
     else if (key.name === "h" || key.name === "left" || key.name === "backspace") goToParent()
     else if (key.name === "l" || key.name === "right" || key.name === "return") activateCurrent()
@@ -688,9 +706,10 @@ export function FilesScreen({
             {(!narrow || narrowPane === "list") && (
               <Panel
                 title="Current"
-                active
+                active={narrowPane === "list"}
                 accent={colors.accent}
                 activeBackground={colors.panel}
+                onMouseDown={() => setNarrowPane("list")}
                 style={{
                   width: filesLayout.currentWidth,
                   flexGrow: 0,
@@ -717,6 +736,10 @@ export function FilesScreen({
             {(!narrow || narrowPane === "preview") && (
               <Panel
                 title="Preview"
+                active={narrowPane === "preview"}
+                accent={colors.accent}
+                activeBackground={colors.panel}
+                onMouseDown={() => setNarrowPane("preview")}
                 style={{
                   width: filesLayout.previewWidth,
                   flexGrow: 0,
@@ -754,6 +777,7 @@ export function FilesScreen({
                       entry={current}
                       showHidden={showHidden}
                       onDirectoryEntrySelect={selectPreviewEntry}
+                      scrollRef={previewScrollRef}
                     />
                   )}
                 </box>
@@ -765,9 +789,9 @@ export function FilesScreen({
       <KeyHint
         accent={colors.accent}
         items={[
-          ...(narrow ? [{ key: "Tab", label: "switch pane", onPress: toggleNarrowPane, disabled: footerLocked }] : []),
-          { key: "j", label: "down", onPress: () => moveSelection(1), disabled: footerLocked || entries.length === 0 },
-          { key: "k", label: "up", onPress: () => moveSelection(-1), disabled: footerLocked || entries.length === 0 },
+          { key: "Tab", label: "pane", onPress: toggleNarrowPane, disabled: footerLocked },
+          { key: "j", label: narrowPane === "preview" ? "scroll down" : "down", onPress: () => moveOrScroll({ name: "j" }), disabled: footerLocked || (narrowPane === "list" && entries.length === 0) },
+          { key: "k", label: narrowPane === "preview" ? "scroll up" : "up", onPress: () => moveOrScroll({ name: "k" }), disabled: footerLocked || (narrowPane === "list" && entries.length === 0) },
           { key: "h", label: "parent", onPress: goToParent, disabled: footerLocked },
           { key: "l", label: "open", onPress: activateCurrent, disabled: footerLocked || !current },
           { key: "n", label: "new file", onPress: createFile, disabled: footerLocked },

--- a/ui/src/files-screen.tsx
+++ b/ui/src/files-screen.tsx
@@ -586,9 +586,9 @@ export function FilesScreen({
       return
     }
     if (moveOrScroll(key)) return
-    if (key.name === "g" && key.shift && narrowPane === "list") setSelected(Math.max(0, entries.length - 1))
-    else if (key.name === "g") setSelected(0)
-    else if (key.name === "h" || key.name === "left" || key.name === "backspace") goToParent()
+    if (key.name === "g" && narrowPane === "list") {
+      setSelected(key.shift ? Math.max(0, entries.length - 1) : 0)
+    } else if (key.name === "h" || key.name === "left" || key.name === "backspace") goToParent()
     else if (key.name === "l" || key.name === "right" || key.name === "return") activateCurrent()
     else if (key.name === "." || key.name === "period") setShowHidden((value) => !value)
     else if (key.name === "r" && !key.shift) renameCurrent()

--- a/ui/src/pane-navigation.test.ts
+++ b/ui/src/pane-navigation.test.ts
@@ -17,8 +17,8 @@ describe("pane navigation", () => {
       scrollBy(delta: number, unit?: string) {
         calls.push(["by", delta, unit])
       },
-      scrollTo(position: number) {
-        calls.push(["to", position])
+      scrollTo(position: number, unit?: string) {
+        calls.push(["to", position, unit])
       },
     } as unknown as ScrollBoxRenderable
 

--- a/ui/src/pane-navigation.test.ts
+++ b/ui/src/pane-navigation.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test"
+import type { ScrollBoxRenderable } from "@opentui/core"
+import { cyclePane, scrollPaneForKey } from "./pane-navigation"
+
+describe("pane navigation", () => {
+  test("cycles in both directions", () => {
+    const panes = ["list", "output", "input"] as const
+    expect(cyclePane(panes, "list", 1)).toBe("output")
+    expect(cyclePane(panes, "list", -1)).toBe("input")
+    expect(cyclePane(panes, "input", 1)).toBe("list")
+  })
+
+  test("maps navigation keys to imperative scrolling", () => {
+    const calls: Array<[string, number, string?]> = []
+    const pane = {
+      scrollHeight: 42,
+      scrollBy(delta: number, unit?: string) {
+        calls.push(["by", delta, unit])
+      },
+      scrollTo(position: number) {
+        calls.push(["to", position])
+      },
+    } as unknown as ScrollBoxRenderable
+
+    expect(scrollPaneForKey(pane, { name: "j" })).toBe(true)
+    expect(scrollPaneForKey(pane, { name: "pageup" })).toBe(true)
+    expect(scrollPaneForKey(pane, { name: "home" })).toBe(true)
+    expect(scrollPaneForKey(pane, { name: "end" })).toBe(true)
+    expect(scrollPaneForKey(pane, { name: "x" })).toBe(false)
+    expect(calls).toEqual([
+      ["by", 1, undefined],
+      ["by", -0.8, "viewport"],
+      ["to", 0, undefined],
+      ["to", 42, undefined],
+    ])
+  })
+})

--- a/ui/src/pane-navigation.ts
+++ b/ui/src/pane-navigation.ts
@@ -1,0 +1,45 @@
+import type { ScrollBoxRenderable } from "@opentui/core"
+
+export interface PaneNavigationKey {
+  name: string
+  shift?: boolean
+}
+
+export function cyclePane<T>(panes: readonly T[], current: T, delta = 1): T {
+  if (panes.length === 0) return current
+  const currentIndex = Math.max(0, panes.indexOf(current))
+  const nextIndex = (currentIndex + delta + panes.length) % panes.length
+  return panes[nextIndex]!
+}
+
+export function scrollPaneForKey(
+  pane: ScrollBoxRenderable | null | undefined,
+  key: PaneNavigationKey,
+): boolean {
+  if (!pane) return false
+  if (key.name === "j" || key.name === "down") {
+    pane.scrollBy(1)
+    return true
+  }
+  if (key.name === "k" || key.name === "up") {
+    pane.scrollBy(-1)
+    return true
+  }
+  if (key.name === "pagedown") {
+    pane.scrollBy(0.8, "viewport")
+    return true
+  }
+  if (key.name === "pageup") {
+    pane.scrollBy(-0.8, "viewport")
+    return true
+  }
+  if (key.name === "home") {
+    pane.scrollTo(0)
+    return true
+  }
+  if (key.name === "end") {
+    pane.scrollTo(pane.scrollHeight)
+    return true
+  }
+  return false
+}

--- a/ui/src/remotes-screen.tsx
+++ b/ui/src/remotes-screen.tsx
@@ -1,14 +1,19 @@
+import type { ScrollBoxRenderable } from "@opentui/core"
 import { useKeyboard } from "@opentui/react"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { api, formatError } from "./api"
 import { EmptyState, KeyHint, Loading, Modal, Panel, formatAge, useVisibleRows } from "./components"
 import { handleSelectionScroll } from "./mouse"
+import { cyclePane, scrollPaneForKey } from "./pane-navigation"
 import { remoteSystemInfo, remoteVersion } from "./remotes-utils"
 import { clampIndex } from "./state-utils"
 import { screenTheme, theme } from "./theme"
 import type { InvitePayload, Machine } from "./types"
 
 const colors = screenTheme.Remotes
+
+type RemotePane = "list" | "details"
+const REMOTE_PANES = ["list", "details"] as const satisfies readonly RemotePane[]
 
 type RemoteDialog =
   | { type: "none" }
@@ -60,10 +65,12 @@ export function RemotesScreen({
   const [machines, setMachines] = useState<Machine[]>([])
   const [enabled, setEnabled] = useState(true)
   const [selected, setSelected] = useState(0)
+  const [activePane, setActivePane] = useState<RemotePane>("list")
   const [dialog, setDialog] = useState<RemoteDialog>({ type: "none" })
   const [loading, setLoading] = useState(true)
   const [loaded, setLoaded] = useState(false)
   const refreshRequest = useRef(0)
+  const detailsScrollRef = useRef<ScrollBoxRenderable | null>(null)
   const refreshController = useRef<AbortController | null>(null)
   const current = machines[selected]
   const compact = width < 92
@@ -111,6 +118,10 @@ export function RemotesScreen({
   }, [refresh])
 
   useEffect(() => {
+    detailsScrollRef.current?.scrollTo(0)
+  }, [current?.name])
+
+  useEffect(() => {
     onInteractionLockChange(dialog.type !== "none")
     return () => onInteractionLockChange(false)
   }, [dialog.type, onInteractionLockChange])
@@ -142,6 +153,21 @@ export function RemotesScreen({
   const moveSelection = (delta: number) => {
     setSelected((value) => clampIndex(value + delta, machines.length))
   }
+  const cycleActivePane = (delta = 1) => {
+    setActivePane((value) => cyclePane(REMOTE_PANES, value, delta))
+  }
+  const moveOrScroll = (key: { name: string; shift?: boolean }) => {
+    if (activePane === "details") return scrollPaneForKey(detailsScrollRef.current, key)
+    if (key.name === "j" || key.name === "down") {
+      moveSelection(1)
+      return true
+    }
+    if (key.name === "k" || key.name === "up") {
+      moveSelection(-1)
+      return true
+    }
+    return false
+  }
   const createRemoteInvite = () => enabled && setDialog({ type: "invite" })
   const renameCurrent = () => current && enabled && setDialog({ type: "rename", machine: current })
   const revokeCurrent = () => current && enabled && setDialog({ type: "revoke", machine: current })
@@ -170,8 +196,12 @@ export function RemotesScreen({
       }
       return
     }
-    if (key.name === "j" || key.name === "down") moveSelection(1)
-    else if (key.name === "k" || key.name === "up") moveSelection(-1)
+    if (key.name === "tab") {
+      key.preventDefault()
+      cycleActivePane(key.shift ? -1 : 1)
+    } else if (key.name === "left") cycleActivePane(-1)
+    else if (key.name === "right") cycleActivePane(1)
+    else if (moveOrScroll(key)) return
     else if (key.name === "n") createRemoteInvite()
     else if (key.name === "e") renameCurrent()
     else if (key.name === "d") revokeCurrent()
@@ -209,7 +239,14 @@ export function RemotesScreen({
         </box>
       )}
       <box style={{ flexGrow: 1, flexDirection: compact ? "column" : "row", gap: 1 }}>
-        <Panel title="Remote nodes" active accent={colors.accent} activeBackground={colors.panel} style={{ flexGrow: 1, paddingTop: 1 }}>
+        <Panel
+          title="Remote nodes"
+          active={activePane === "list"}
+          accent={colors.accent}
+          activeBackground={colors.panel}
+          onMouseDown={() => setActivePane("list")}
+          style={{ flexGrow: 1, minHeight: 0, paddingTop: 1, overflow: "hidden" }}
+        >
           {!loaded ? (
             loading ? <Loading label="Loading remote nodes" /> : <EmptyState title="Remotes unavailable" detail="Press r to try again" />
           ) : machines.length === 0 ? (
@@ -264,6 +301,10 @@ export function RemotesScreen({
         </Panel>
         <Panel
           title="Node details"
+          active={activePane === "details"}
+          accent={colors.accent}
+          activeBackground={colors.panel}
+          onMouseDown={() => setActivePane("details")}
           style={{
             width: compact ? "100%" : "34%",
             height: compact ? 11 : "100%",
@@ -272,6 +313,7 @@ export function RemotesScreen({
         >
           {current ? (
             <scrollbox
+              ref={detailsScrollRef}
               focused={false}
               style={{ flexGrow: 1 }}
               scrollY
@@ -296,8 +338,9 @@ export function RemotesScreen({
       <KeyHint
         accent={colors.accent}
         items={[
-          { key: "j", label: "down", onPress: () => moveSelection(1), disabled: footerLocked || machines.length === 0 },
-          { key: "k", label: "up", onPress: () => moveSelection(-1), disabled: footerLocked || machines.length === 0 },
+          { key: "Tab", label: "pane", onPress: () => cycleActivePane(1), disabled: footerLocked },
+          { key: "j", label: activePane === "details" ? "scroll down" : "down", onPress: () => moveOrScroll({ name: "j" }), disabled: footerLocked || (activePane === "list" && machines.length === 0) },
+          { key: "k", label: activePane === "details" ? "scroll up" : "up", onPress: () => moveOrScroll({ name: "k" }), disabled: footerLocked || (activePane === "list" && machines.length === 0) },
           { key: "n", label: "new invite", onPress: createRemoteInvite, disabled: footerLocked || !enabled },
           { key: "e", label: "rename", onPress: renameCurrent, disabled: footerLocked || !enabled || !current },
           { key: "d", label: "revoke", onPress: revokeCurrent, disabled: footerLocked || !enabled || !current },

--- a/ui/src/tui.tsx
+++ b/ui/src/tui.tsx
@@ -26,7 +26,8 @@ function Help({ close }: { close: () => void }) {
       <text fg={theme.muted} content="Alt+Q     quit the TUI" />
       <text fg={theme.muted} content="F1        show this guide" />
       <text fg={theme.borderBright} content="\nScreen conventions" />
-      <text fg={theme.muted} content="j/k or arrows move selection · Enter activates · Esc closes dialogs" />
+      <text fg={theme.muted} content="Tab chooses a pane · j/k or arrows select rows or scroll the active pane" />
+      <text fg={theme.muted} content="Enter activates · PgUp/PgDn/Home/End scroll read-only panes · Esc closes dialogs" />
       <text fg={theme.muted} content="[ / ] switches Files machines · Alt+[ / ] switches Terminal machines" />
       <text fg={theme.muted} content="Terminals: Alt+N new · Alt+W kill · PgUp/PgDn scroll · Alt+R refresh" />
       <text fg={theme.muted} content="The footer on every screen lists its contextual commands." />


### PR DESCRIPTION
## Summary

- add reusable pane cycling and imperative scroll-key handling for OpenTUI scrollboxes
- let Audit switch between records, call result, and call input panes with `Tab` / `Shift+Tab` or left/right
- let Files switch between the current listing and preview even in wide layouts, then scroll the active preview
- let Remotes switch between the node list and details pane, with mouse activation matching keyboard focus
- document `PgUp` / `PgDn` / `Home` / `End` scrolling in the built-in keyboard guide

This is the upstream-applicable subset of the pane navigation work first developed in rijuyuezhu/local-shell-mcp#96. It is implemented directly on current upstream `main` and intentionally excludes the fork-only Sessions UI changes.

## Validation

- `cd ui && bun run typecheck`
- `cd ui && bun test` — 103 passed
- `cd ui && bun run build:tui`
- `uv run ruff check .`
- `uv run --extra dev pytest -q` — 597 passed
