### PR TITLE
chore: prepare v3.1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "local-shell-mcp"
-version = "3.1.3"
+version = "3.1.4"
 description = "A ChatGPT-compatible OAuth MCP server that gives AI coding agents controlled shell, filesystem, remote-worker, and Playwright access inside a local container."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/local_shell_mcp/__init__.py
+++ b/src/local_shell_mcp/__init__.py
@@ -1,3 +1,3 @@
 """local-shell-mcp."""
 
-__version__ = "3.1.3"
+__version__ = "3.1.4"


### PR DESCRIPTION
## Summary

- bump the Python package version to `3.1.4`
- include macOS Homebrew worker PATH fixes, session-oriented fork documentation, and TUI pane navigation added since `v3.1.3`

## Validation

- version consistency check between `pyproject.toml` and `src/local_shell_mcp/__init__.py`
- `git diff --check`