### PR TITLE
chore: prepare v3.1.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "local-shell-mcp"
-version = "3.1.4"
+version = "3.1.5"
 description = "A ChatGPT-compatible OAuth MCP server that gives AI coding agents controlled shell, filesystem, remote-worker, and Playwright access inside a local container."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/local_shell_mcp/__init__.py
+++ b/src/local_shell_mcp/__init__.py
@@ -1,3 +1,3 @@
 """local-shell-mcp."""
 
-__version__ = "3.1.4"
+__version__ = "3.1.5"


### PR DESCRIPTION
## Summary

- bump the Python package version to 3.1.5
- prepare the patch release containing WebUI TUI invite-copy fixes
- constrain the MCP SDK to the compatible 1.x API range

## Validation

- project and package versions both resolve to 3.1.5
- PR #121 completed all 41 CI jobs successfully before this release bump