### PR TITLE
fix(oauth): rate limit admin PIN failures

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@
 # Example: https://local-shell-mcp.example.com
 LOCAL_SHELL_MCP_PUBLIC_BASE_URL=https://your-public-host.example.com
 
+# Trusted reverse-proxy addresses for X-Forwarded-* handling. The Compose file
+# defaults this to * because its published service port is bound to localhost.
+LOCAL_SHELL_MCP_FORWARDED_ALLOW_IPS=*
+
 # ChatGPT custom connectors should use OAuth mode. Do not expose this service publicly with auth_mode=none.
 LOCAL_SHELL_MCP_AUTH_MODE=oauth
 

--- a/.env.example
+++ b/.env.example
@@ -6,10 +6,6 @@
 # Example: https://local-shell-mcp.example.com
 LOCAL_SHELL_MCP_PUBLIC_BASE_URL=https://your-public-host.example.com
 
-# Trusted reverse-proxy addresses for X-Forwarded-* handling. The Compose file
-# defaults this to * because its published service port is bound to localhost.
-LOCAL_SHELL_MCP_FORWARDED_ALLOW_IPS=*
-
 # ChatGPT custom connectors should use OAuth mode. Do not expose this service publicly with auth_mode=none.
 LOCAL_SHELL_MCP_AUTH_MODE=oauth
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,9 @@ services:
       LOCAL_SHELL_MCP_MODE: "mcp"
       LOCAL_SHELL_MCP_HOST: "0.0.0.0"
       LOCAL_SHELL_MCP_PORT: "8765"
+      # The published port is loopback-only; trust proxy headers from the optional
+      # cloudflared sidecar so request.client contains the public caller address.
+      LOCAL_SHELL_MCP_FORWARDED_ALLOW_IPS: "${LOCAL_SHELL_MCP_FORWARDED_ALLOW_IPS:-*}"
       LOCAL_SHELL_MCP_WORKSPACE_ROOT: "/workspace"
       LOCAL_SHELL_MCP_AUTH_MODE: "${LOCAL_SHELL_MCP_AUTH_MODE:-oauth}"
       LOCAL_SHELL_MCP_MCP_SESSION_IDLE_TIMEOUT_S: "${LOCAL_SHELL_MCP_MCP_SESSION_IDLE_TIMEOUT_S:-180}"

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -103,6 +103,7 @@ http://local-shell-mcp:8765
 ```
 
 This is Cloudflare Tunnel, not Cloudflare Access. `local-shell-mcp` still handles its own OAuth for ChatGPT.
+The Compose service trusts forwarded headers because its published port is restricted to localhost; this preserves the public caller address for OAuth PIN rate limiting. If you expose the container port directly, replace `LOCAL_SHELL_MCP_FORWARDED_ALLOW_IPS=*` with the explicit addresses of your trusted reverse proxies.
 
 ## Reverse proxy without tunnel sidecar
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -28,6 +28,7 @@ For local-only testing, `auth_bypass_localhost` is enabled by default. Do not ex
 |---|---|---|---|
 | `host` | `LOCAL_SHELL_MCP_HOST` | `'0.0.0.0'` |  |
 | `port` | `LOCAL_SHELL_MCP_PORT` | `8765` |  |
+| `forwarded_allow_ips` | `LOCAL_SHELL_MCP_FORWARDED_ALLOW_IPS` | `'127.0.0.1'` | Comma-separated trusted proxy IPs for Uvicorn forwarded-header handling. Use `*` only when direct ingress is restricted. |
 | `mode` | `LOCAL_SHELL_MCP_MODE` | `'mcp'` | `mcp`, `http`, `stdio`, or reserved `both` value. |
 | `workspace_root` | `LOCAL_SHELL_MCP_WORKSPACE_ROOT` | `PosixPath('/workspace')` |  |
 | `state_dir` | `LOCAL_SHELL_MCP_STATE_DIR` | `PosixPath('/workspace/.local-shell-mcp')` |  |

--- a/src/local_shell_mcp/main.py
+++ b/src/local_shell_mcp/main.py
@@ -94,7 +94,12 @@ def run_mcp() -> None:
         return
 
     if hasattr(mcp, "streamable_http_app"):
-        uvicorn.run(_build_mcp_http_app(mcp), host=settings.host, port=settings.port)
+        uvicorn.run(
+            _build_mcp_http_app(mcp),
+            host=settings.host,
+            port=settings.port,
+            forwarded_allow_ips=settings.forwarded_allow_ips,
+        )
         return
     if hasattr(mcp, "sse_app"):
         from .auth import AuthMiddleware, RequestBodyLimitMiddleware
@@ -103,7 +108,12 @@ def run_mcp() -> None:
         if settings.auth_mode != "none":
             app.add_middleware(AuthMiddleware)
         app.add_middleware(RequestBodyLimitMiddleware)
-        uvicorn.run(app, host=settings.host, port=settings.port)
+        uvicorn.run(
+            app,
+            host=settings.host,
+            port=settings.port,
+            forwarded_allow_ips=settings.forwarded_allow_ips,
+        )
         return
 
     try:
@@ -121,7 +131,12 @@ def run_http() -> None:
     settings = get_settings()
     validate_public_oauth_configuration(settings)
     app = build_http_app()
-    uvicorn.run(app, host=settings.host, port=settings.port)
+    uvicorn.run(
+        app,
+        host=settings.host,
+        port=settings.port,
+        forwarded_allow_ips=settings.forwarded_allow_ips,
+    )
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/src/local_shell_mcp/oauth.py
+++ b/src/local_shell_mcp/oauth.py
@@ -12,7 +12,7 @@ import re
 import secrets
 import threading
 import time
-from collections import deque
+from collections import OrderedDict, deque
 from dataclasses import dataclass, field
 from functools import lru_cache
 from importlib.resources import files
@@ -63,6 +63,7 @@ OAUTH_CLIENT_STORE_VERSION = 1
 OAUTH_CLIENT_STORE_FILE_NAME = "oauth-clients.json"
 OAUTH_PIN_FAILURE_LIMIT = 5
 OAUTH_PIN_FAILURE_WINDOW_S = 5 * 60
+MAX_OAUTH_PIN_SOURCES = 4_096
 ALL_OAUTH_SCOPES = (
     "shell:read",
     "shell:write",
@@ -75,7 +76,7 @@ _LEGACY_CLIENT_ID_RE = re.compile(r"local-shell-mcp-[A-Za-z0-9_-]{16,128}\Z")
 _CLIENT_STORE_LOCK = threading.RLock()
 _LOADED_CLIENT_STORE_PATH: Path | None = None
 _PIN_FAILURE_LOCK = threading.Lock()
-_PIN_FAILURES: dict[str, deque[float]] = {}
+_PIN_FAILURES: OrderedDict[str, deque[float]] = OrderedDict()
 
 
 def public_base_url(request: Request | None = None) -> str:
@@ -574,6 +575,8 @@ def _pin_retry_after(source: str) -> int:
     with _PIN_FAILURE_LOCK:
         _prune_pin_failures_locked(now)
         failures = _PIN_FAILURES.get(source)
+        if failures is not None:
+            _PIN_FAILURES.move_to_end(source)
         return _pin_retry_after_locked(failures, now) if failures else 0
 
 
@@ -581,7 +584,14 @@ def _record_pin_failure(source: str) -> int:
     now = time.monotonic()
     with _PIN_FAILURE_LOCK:
         _prune_pin_failures_locked(now)
-        failures = _PIN_FAILURES.setdefault(source, deque())
+        failures = _PIN_FAILURES.get(source)
+        if failures is None:
+            while len(_PIN_FAILURES) >= MAX_OAUTH_PIN_SOURCES:
+                _PIN_FAILURES.popitem(last=False)
+            failures = deque()
+            _PIN_FAILURES[source] = failures
+        else:
+            _PIN_FAILURES.move_to_end(source)
         failures.append(now)
         return _pin_retry_after_locked(failures, now)
 

--- a/src/local_shell_mcp/oauth.py
+++ b/src/local_shell_mcp/oauth.py
@@ -6,11 +6,13 @@ import hashlib
 import hmac
 import html as html_lib
 import json
+import math
 import os
 import re
 import secrets
 import threading
 import time
+from collections import deque
 from dataclasses import dataclass, field
 from functools import lru_cache
 from importlib.resources import files
@@ -59,6 +61,8 @@ MAX_CLIENT_NAME_LENGTH = 200
 OAUTH_PENDING_CLIENT_TTL_S = 24 * 60 * 60
 OAUTH_CLIENT_STORE_VERSION = 1
 OAUTH_CLIENT_STORE_FILE_NAME = "oauth-clients.json"
+OAUTH_PIN_FAILURE_LIMIT = 5
+OAUTH_PIN_FAILURE_WINDOW_S = 5 * 60
 ALL_OAUTH_SCOPES = (
     "shell:read",
     "shell:write",
@@ -70,6 +74,8 @@ ALL_OAUTH_SCOPES = (
 _LEGACY_CLIENT_ID_RE = re.compile(r"local-shell-mcp-[A-Za-z0-9_-]{16,128}\Z")
 _CLIENT_STORE_LOCK = threading.RLock()
 _LOADED_CLIENT_STORE_PATH: Path | None = None
+_PIN_FAILURE_LOCK = threading.Lock()
+_PIN_FAILURES: dict[str, deque[float]] = {}
 
 
 def public_base_url(request: Request | None = None) -> str:
@@ -498,7 +504,13 @@ def _scope_items(scope: str) -> str:
     return "\n".join(items)
 
 
-def _authorize_form(params: dict[str, str], error: str | None = None) -> HTMLResponse:
+def _authorize_form(
+    params: dict[str, str],
+    error: str | None = None,
+    *,
+    status_code: int = 200,
+    headers: dict[str, str] | None = None,
+) -> HTMLResponse:
     settings = get_settings()
     scope = _scope_value()
     resource = params.get("resource") or resource_url()
@@ -534,7 +546,59 @@ def _authorize_form(params: dict[str, str], error: str | None = None) -> HTMLRes
         pin_field=pin_field,
         security_notice=html_lib.escape(security_notice),
     )
-    return HTMLResponse(html, headers={"Cache-Control": "no-store"})
+    response_headers = {"Cache-Control": "no-store", **(headers or {})}
+    return HTMLResponse(html, status_code=status_code, headers=response_headers)
+
+
+def _pin_source(request: Request) -> str:
+    return request.client.host if request.client else "unknown"
+
+
+def _prune_pin_failures_locked(now: float) -> None:
+    cutoff = now - OAUTH_PIN_FAILURE_WINDOW_S
+    for source, failures in list(_PIN_FAILURES.items()):
+        while failures and failures[0] <= cutoff:
+            failures.popleft()
+        if not failures:
+            _PIN_FAILURES.pop(source, None)
+
+
+def _pin_retry_after_locked(failures: deque[float], now: float) -> int:
+    if len(failures) < OAUTH_PIN_FAILURE_LIMIT:
+        return 0
+    return max(1, math.ceil(failures[0] + OAUTH_PIN_FAILURE_WINDOW_S - now))
+
+
+def _pin_retry_after(source: str) -> int:
+    now = time.monotonic()
+    with _PIN_FAILURE_LOCK:
+        _prune_pin_failures_locked(now)
+        failures = _PIN_FAILURES.get(source)
+        return _pin_retry_after_locked(failures, now) if failures else 0
+
+
+def _record_pin_failure(source: str) -> int:
+    now = time.monotonic()
+    with _PIN_FAILURE_LOCK:
+        _prune_pin_failures_locked(now)
+        failures = _PIN_FAILURES.setdefault(source, deque())
+        failures.append(now)
+        return _pin_retry_after_locked(failures, now)
+
+
+def _clear_pin_failures(source: str) -> None:
+    with _PIN_FAILURE_LOCK:
+        _PIN_FAILURES.pop(source, None)
+
+
+def _pin_rate_limited_form(params: dict[str, str], source: str, retry_after: int) -> HTMLResponse:
+    audit("oauth_pin_rate_limited", client_id=params.get("client_id"), source_ip=source)
+    return _authorize_form(
+        params,
+        error="Too many failed PIN attempts. Try again later.",
+        status_code=429,
+        headers={"Retry-After": str(retry_after)},
+    )
 
 
 def _make_redirect(redirect_uri: str, query: dict[str, str]) -> RedirectResponse:
@@ -560,9 +624,18 @@ async def oauth_authorize_post(request: Request) -> Response:
     settings = get_settings()
     expected_pin = settings.oauth_admin_pin
     submitted_pin = str(form.get("pin") or "")
-    if expected_pin and not hmac.compare_digest(submitted_pin, expected_pin):
-        audit("oauth_pin_failed", client_id=params.get("client_id"))
-        return _authorize_form(params, error="Invalid admin PIN")
+    if expected_pin:
+        source = _pin_source(request)
+        retry_after = _pin_retry_after(source)
+        if retry_after:
+            return _pin_rate_limited_form(params, source, retry_after)
+        if not hmac.compare_digest(submitted_pin, expected_pin):
+            audit("oauth_pin_failed", client_id=params.get("client_id"), source_ip=source)
+            retry_after = _record_pin_failure(source)
+            if retry_after:
+                return _pin_rate_limited_form(params, source, retry_after)
+            return _authorize_form(params, error="Invalid admin PIN")
+        _clear_pin_failures(source)
 
     client = _approve_client(params["client_id"])
     if client is None:

--- a/src/local_shell_mcp/settings.py
+++ b/src/local_shell_mcp/settings.py
@@ -306,6 +306,7 @@ if _PYDANTIC_AVAILABLE:
 
         host: str = "0.0.0.0"
         port: int = 8765
+        forwarded_allow_ips: str = "127.0.0.1"
         mode: Literal["mcp", "http", "both", "stdio"] = "mcp"
 
         workspace_root: Path = DEFAULT_WORKSPACE_ROOT
@@ -513,6 +514,7 @@ else:
 
         host: str = "0.0.0.0"
         port: int = 8765
+        forwarded_allow_ips: str = "127.0.0.1"
         mode: Literal["mcp", "http", "both", "stdio"] = "mcp"
 
         workspace_root: Path = DEFAULT_WORKSPACE_ROOT

--- a/tests/test_main_complete.py
+++ b/tests/test_main_complete.py
@@ -36,6 +36,7 @@ def _settings(**updates):
         "mode": "mcp",
         "host": "127.0.0.1",
         "port": 9876,
+        "forwarded_allow_ips": "10.0.0.2",
         "auth_mode": "none",
         "remote_enabled": False,
         "mcp_session_idle_timeout_s": 9,
@@ -75,7 +76,10 @@ def test_run_mcp_streamable_and_sse(monkeypatch):
     monkeypatch.setattr(settings_module, "get_settings", lambda: _settings())
     monkeypatch.setattr(tools, "build_mcp", lambda: streamable)
     main_module.run_mcp()
-    assert runs.pop() == (("wrapped", streamable), {"host": "127.0.0.1", "port": 9876})
+    assert runs.pop() == (
+        ("wrapped", streamable),
+        {"host": "127.0.0.1", "port": 9876, "forwarded_allow_ips": "10.0.0.2"},
+    )
 
     class FakeApp:
         def __init__(self):
@@ -91,7 +95,11 @@ def test_run_mcp_streamable_and_sse(monkeypatch):
         monkeypatch.setattr(tools, "build_mcp", lambda item=sse: item)
         main_module.run_mcp()
         app, kwargs = runs.pop()
-        assert kwargs == {"host": "127.0.0.1", "port": 9876}
+        assert kwargs == {
+            "host": "127.0.0.1",
+            "port": 9876,
+            "forwarded_allow_ips": "10.0.0.2",
+        }
         assert len(app.middleware) == expected_middleware_count
 
 
@@ -142,7 +150,13 @@ def test_run_http(monkeypatch):
 
     main_module.run_http()
 
-    assert calls == [("validate", settings), ("http-app", {"host": "127.0.0.1", "port": 9876})]
+    assert calls == [
+        ("validate", settings),
+        (
+            "http-app",
+            {"host": "127.0.0.1", "port": 9876, "forwarded_allow_ips": "10.0.0.2"},
+        ),
+    ]
 
 
 def test_main_subcommands_and_version(monkeypatch, capsys):

--- a/tests/test_oauth_complete.py
+++ b/tests/test_oauth_complete.py
@@ -29,6 +29,7 @@ def _configure(tmp_path, monkeypatch, **env):
     get_settings.cache_clear()
     oauth._CLIENTS.clear()
     oauth._CODES.clear()
+    oauth._PIN_FAILURES.clear()
 
 
 def _app() -> Starlette:
@@ -315,6 +316,70 @@ def test_authorize_validation_and_pin_failures(tmp_path, monkeypatch):
     assert wrong_pin.status_code == 200
     assert "Invalid admin PIN" in wrong_pin.text
     assert not oauth._CODES
+
+
+def test_pin_failures_are_rate_limited_by_source(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    now = [1_000.0]
+    monkeypatch.setattr(oauth.time, "monotonic", lambda: now[0])
+
+    app = _app()
+    blocked = TestClient(app, client=("198.51.100.10", 50_000))
+    other = TestClient(app, client=("198.51.100.11", 50_000))
+    recovering = TestClient(app, client=("198.51.100.12", 50_000))
+    client_id = _register(blocked)
+    params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": "https://client.test/callback",
+        "code_challenge": "challenge",
+        "code_challenge_method": "S256",
+    }
+
+    for _ in range(oauth.OAUTH_PIN_FAILURE_LIMIT - 1):
+        response = blocked.post("/oauth/authorize", data={**params, "pin": "wrong"})
+        assert response.status_code == 200
+        assert "Invalid admin PIN" in response.text
+
+    limited = blocked.post("/oauth/authorize", data={**params, "pin": "wrong"})
+    assert limited.status_code == 429
+    assert limited.headers["retry-after"] == str(oauth.OAUTH_PIN_FAILURE_WINDOW_S)
+    assert "Too many failed PIN attempts" in limited.text
+    assert not oauth._CODES
+
+    still_limited = blocked.post(
+        "/oauth/authorize",
+        data={**params, "pin": "correct-admin-pin"},
+        follow_redirects=False,
+    )
+    assert still_limited.status_code == 429
+
+    other_source = other.post(
+        "/oauth/authorize",
+        data={**params, "pin": "correct-admin-pin"},
+        follow_redirects=False,
+    )
+    assert other_source.status_code == 302
+
+    one_failure = recovering.post("/oauth/authorize", data={**params, "pin": "wrong"})
+    assert one_failure.status_code == 200
+    assert "198.51.100.12" in oauth._PIN_FAILURES
+    recovered_early = recovering.post(
+        "/oauth/authorize",
+        data={**params, "pin": "correct-admin-pin"},
+        follow_redirects=False,
+    )
+    assert recovered_early.status_code == 302
+    assert "198.51.100.12" not in oauth._PIN_FAILURES
+
+    now[0] += oauth.OAUTH_PIN_FAILURE_WINDOW_S + 1
+    recovered_after_window = blocked.post(
+        "/oauth/authorize",
+        data={**params, "pin": "correct-admin-pin"},
+        follow_redirects=False,
+    )
+    assert recovered_after_window.status_code == 302
+    assert "198.51.100.10" not in oauth._PIN_FAILURES
 
 
 def test_complete_authorization_code_flow_and_token_failures(tmp_path, monkeypatch):

--- a/tests/test_oauth_complete.py
+++ b/tests/test_oauth_complete.py
@@ -382,6 +382,19 @@ def test_pin_failures_are_rate_limited_by_source(tmp_path, monkeypatch):
     assert "198.51.100.10" not in oauth._PIN_FAILURES
 
 
+def test_pin_failure_sources_are_bounded(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setattr(oauth, "MAX_OAUTH_PIN_SOURCES", 2)
+    monkeypatch.setattr(oauth.time, "monotonic", lambda: 1_000.0)
+
+    oauth._record_pin_failure("source-a")
+    oauth._record_pin_failure("source-b")
+    oauth._record_pin_failure("source-a")
+    oauth._record_pin_failure("source-c")
+
+    assert list(oauth._PIN_FAILURES) == ["source-a", "source-c"]
+
+
 def test_complete_authorization_code_flow_and_token_failures(tmp_path, monkeypatch):
     _configure(
         tmp_path,


### PR DESCRIPTION
## Summary
- limit OAuth admin PIN failures per source to 5 attempts in 5 minutes
- return HTTP 429 with `Retry-After` while a source is blocked
- trust explicitly configured reverse proxies so Compose/cloudflared requests retain the public caller address
- bound tracked PIN sources to a 4096-entry LRU cache
- clear prior failures after a successful PIN check and audit rate-limited requests

## Tests
- `ruff check .`
- `PYTHONPATH=src pytest -q` (599 passed)
- `mkdocs build --strict`
- Docker Compose validation is covered by CI; Docker CLI is unavailable in the local runner