### PR TITLE
test(shell): stabilize process timeout on macOS

### DIFF
--- a/tests/test_shell_tmux.py
+++ b/tests/test_shell_tmux.py
@@ -159,7 +159,7 @@ def test_run_exec_reports_timeout_before_process_creation(tmp_path, monkeypatch)
 
 def test_run_exec_terminates_process_after_timeout(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
-    monkeypatch.setattr(shell, "clamp_timeout", lambda timeout_s: 0.1)
+    monkeypatch.setattr(shell, "clamp_timeout", lambda timeout_s: 1.0)
 
     result = asyncio.run(
         shell._run_exec(


### PR DESCRIPTION
## Summary
- increase the timeout budget in the real subprocess termination test from 100 ms to 1 s
- keep startup-timeout behavior unchanged and covered by the separate mocked startup test

## Cause
The macOS x86_64 hosted runner needed about 156 ms to create the Python subprocess. The 100 ms test budget expired during process creation, so the result correctly reported `exit_code=None` and `Timed out while starting subprocess`, but the test expected the post-start termination path.

## Validation
- target test passed 20 consecutive runs
- `tests/test_shell_tmux.py` and `tests/test_shell_ops.py`: 33 passed
- full test suite: 599 passed
- Ruff and `git diff --check` passed

Fixes the failure in Actions run 30803676684, job 91653969796.