### PR TITLE
Add Windows remote worker autostart

### DIFF
--- a/docs/guides/remote-workers.md
+++ b/docs/guides/remote-workers.md
@@ -17,6 +17,27 @@ MCP client -> control server -> outbound polling worker -> remote machine
 
 Only worker administration uses `remote_*` names. Execution, shell, job, filesystem, patch, and browser operations share the same schema locally and remotely. Supplying a machine additionally requires the `remote:use` OAuth scope.
 
+## Persistent workers
+
+The invite result contains platform-specific commands:
+
+- `persistent_command` installs and starts a user service on Linux or macOS.
+- `powershell_persistent_command` installs and starts a Windows user task from PowerShell.
+
+On Windows, `local-shell-mcp worker install-service` registers the `local-shell-mcp-worker` task for the current user. It starts immediately, starts again when that user logs on after a reboot, permits battery operation, ignores duplicate starts, and retries failed runs. It does not require administrator rights and does not run before the user signs in.
+
+Use the same lifecycle commands on every platform:
+
+```text
+local-shell-mcp worker status
+local-shell-mcp worker start
+local-shell-mcp worker stop
+local-shell-mcp worker restart
+local-shell-mcp worker uninstall-service
+```
+
+The worker log is stored under the worker state directory as `worker.log`.
+
 ## Capabilities
 
 Workers support shell and persistent shell sessions, tracked jobs, filesystem operations, transfer internals, Python execution, patches, and Playwright where dependencies are installed. Git uses standard commands through `run_shell_tool(machine=...)`.

--- a/docs/guides/remote-workers.zh-Hant.md
+++ b/docs/guides/remote-workers.zh-Hant.md
@@ -17,6 +17,27 @@ MCP 客戶端 -> 控制服務 -> 出站輪詢 worker -> 遠端機器
 
 只有 worker 管理繼續使用 `remote_*` 名稱。執行、shell、job、檔案、patch 和瀏覽器操作在本地與遠端使用同一 Schema。指定 `machine` 時會額外要求 `remote:use` OAuth scope。
 
+## 持久化 worker
+
+邀請結果會同時回傳適用於不同平台的命令：
+
+- `persistent_command` 在 Linux 或 macOS 上安裝並啟動使用者服務。
+- `powershell_persistent_command` 透過 PowerShell 在 Windows 上安裝並啟動使用者排程工作。
+
+在 Windows 上，`local-shell-mcp worker install-service` 會為目前使用者註冊 `local-shell-mcp-worker` 排程工作。工作會立即啟動，並在重新開機後該使用者登入時再次啟動；它允許使用電池時執行、忽略重複啟動，並在異常結束後重試。此方式不需要系統管理員權限，但不會在使用者登入前執行。
+
+所有平台使用相同的生命週期命令：
+
+```text
+local-shell-mcp worker status
+local-shell-mcp worker start
+local-shell-mcp worker stop
+local-shell-mcp worker restart
+local-shell-mcp worker uninstall-service
+```
+
+worker 日誌位於 worker 狀態目錄中的 `worker.log`。
+
 ## 能力與安全
 
 worker 支援 shell、持久終端、tracked job、檔案操作、傳輸、Python、patch，以及已安裝相依套件時的 Playwright。Git 透過 `run_shell_tool(machine=...)` 執行標準 CLI。

--- a/docs/guides/remote-workers.zh.md
+++ b/docs/guides/remote-workers.zh.md
@@ -17,6 +17,27 @@ MCP 客户端 -> 控制服务 -> 出站轮询 worker -> 远程机器
 
 只有 worker 管理继续使用 `remote_*` 名称。执行、shell、job、文件、patch 和浏览器操作在本地与远程使用同一 Schema。指定 `machine` 时会额外要求 `remote:use` OAuth scope。
 
+## 持久化 worker
+
+邀请结果会同时返回适用于不同平台的命令：
+
+- `persistent_command` 在 Linux 或 macOS 上安装并启动用户服务。
+- `powershell_persistent_command` 通过 PowerShell 在 Windows 上安装并启动用户计划任务。
+
+在 Windows 上，`local-shell-mcp worker install-service` 会为当前用户注册 `local-shell-mcp-worker` 计划任务。任务会立即启动，并在重启后该用户登录时再次启动；它允许电池供电运行、忽略重复启动，并在异常退出后重试。该方式不需要管理员权限，但不会在用户登录前运行。
+
+所有平台使用相同的生命周期命令：
+
+```text
+local-shell-mcp worker status
+local-shell-mcp worker start
+local-shell-mcp worker stop
+local-shell-mcp worker restart
+local-shell-mcp worker uninstall-service
+```
+
+worker 日志位于 worker 状态目录中的 `worker.log`。
+
 ## 能力与安全
 
 worker 支持 shell、持久终端、tracked job、文件操作、传输、Python、patch，以及已安装依赖时的 Playwright。Git 通过 `run_shell_tool(machine=...)` 执行标准 CLI。

--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -87,6 +87,7 @@ from .transfer_ops import (
 from .version import version_info as get_version_info
 
 REMOTE_JOIN_PATH = "/join"
+REMOTE_POWERSHELL_JOIN_PATH = REMOTE_JOIN_PATH + ".ps1"
 REMOTE_API_PREFIX = "/remote"
 REMOTE_WORKER_BUNDLE_PATH = "/remote/worker-bundle.tgz"
 REMOTE_WORKER_POLL_PROTOCOL_VERSION = 1
@@ -190,6 +191,10 @@ def _validate_machine_name(value: str) -> str:
     if any(ord(character) < 32 or character in {"/", "\\"} for character in name):
         raise ValueError("machine name contains unsupported characters")
     return name
+
+
+def _powershell_quote(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
 
 
 def _error(message: str, error: str = "remote_error", status_code: int = 400):  # noqa: ANN201
@@ -381,6 +386,16 @@ class RemoteManager:
             command += f" --name {shlex.quote(normalized_name)}"
         if workdir:
             command += f" --workdir {shlex.quote(workdir)}"
+        powershell_join_url = join_url.removesuffix(REMOTE_JOIN_PATH) + REMOTE_POWERSHELL_JOIN_PATH
+        powershell_command = (
+            "$script = (Invoke-WebRequest -UseBasicParsing "
+            f"{_powershell_quote(powershell_join_url)}).Content; "
+            f"& ([scriptblock]::Create($script)) -Invite {_powershell_quote(code)}"
+        )
+        if normalized_name:
+            powershell_command += f" -Name {_powershell_quote(normalized_name)}"
+        if workdir:
+            powershell_command += f" -Workdir {_powershell_quote(workdir)}"
         return {
             "code": code,
             "name": normalized_name,
@@ -389,6 +404,10 @@ class RemoteManager:
             "ttl_s": ttl,
             "join_url": join_url,
             "command": command,
+            "persistent_command": command + " --persist",
+            "powershell_join_url": powershell_join_url,
+            "powershell_command": powershell_command,
+            "powershell_persistent_command": powershell_command + " -Persist",
         }
 
     async def register_worker(self, payload: dict[str, Any]) -> dict[str, Any]:

--- a/src/local_shell_mcp/remote_worker_routes.py
+++ b/src/local_shell_mcp/remote_worker_routes.py
@@ -212,14 +212,27 @@ $Server = __SERVER__
 $ManifestUrl = "$Server__PUBLIC_MANIFEST_URL__"
 if (-not $Workdir) { $Workdir = (Get-Location).Path }
 
-$PythonCommand = Get-Command python.exe -ErrorAction SilentlyContinue
+$PythonExe = $null
 $PythonPrefix = @()
-if ($null -eq $PythonCommand) {
-  $PythonCommand = Get-Command py.exe -ErrorAction SilentlyContinue
-  $PythonPrefix = @("-3")
+$PythonCandidates = @(
+  [pscustomobject]@{ Name = "python.exe"; Prefix = @() }
+  [pscustomobject]@{ Name = "py.exe"; Prefix = @("-3") }
+)
+foreach ($Candidate in $PythonCandidates) {
+  $PythonCommand = Get-Command $Candidate.Name -ErrorAction SilentlyContinue
+  if ($null -eq $PythonCommand) { continue }
+  $ProbeArgs = @($Candidate.Prefix) + @(
+    "-c",
+    "import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)"
+  )
+  & $PythonCommand.Source @ProbeArgs
+  if ($LASTEXITCODE -eq 0) {
+    $PythonExe = $PythonCommand.Source
+    $PythonPrefix = @($Candidate.Prefix)
+    break
+  }
 }
-if ($null -eq $PythonCommand) { throw "Python 3 is required" }
-$PythonExe = $PythonCommand.Source
+if ($null -eq $PythonExe) { throw "Python 3.11 or newer is required" }
 
 $TempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("local-shell-mcp-worker-" + [guid]::NewGuid().ToString("N"))
 New-Item -ItemType Directory -Path $TempDir | Out-Null
@@ -344,7 +357,7 @@ try {
   Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $TempDir
 }
 '''
-    script = script.replace("__SERVER__", repr(server))
+    script = script.replace("__SERVER__", remote._powershell_quote(server))  # noqa: SLF001
     script = script.replace("__PUBLIC_MANIFEST_URL__", REMOTE_WORKER_PUBLIC_MANIFEST_URL)
     return PlainTextResponse(script, media_type="text/plain")
 

--- a/src/local_shell_mcp/remote_worker_routes.py
+++ b/src/local_shell_mcp/remote_worker_routes.py
@@ -195,11 +195,166 @@ exec python3 -m local_shell_mcp.remote_worker run
     return PlainTextResponse(script, media_type="text/x-shellscript")
 
 
+async def powershell_join_script(request: Any):  # noqa: ARG001, ANN201
+    from starlette.responses import PlainTextResponse
+
+    settings = get_settings()
+    server = (settings.public_base_url or f"http://{settings.host}:{settings.port}").rstrip("/")
+    script = r'''param(
+  [Parameter(Mandatory = $true)][string]$Invite,
+  [string]$Name = "",
+  [string]$Workdir = "",
+  [switch]$Background,
+  [switch]$Persist
+)
+$ErrorActionPreference = "Stop"
+$Server = __SERVER__
+$ManifestUrl = "$Server__PUBLIC_MANIFEST_URL__"
+if (-not $Workdir) { $Workdir = (Get-Location).Path }
+
+$PythonCommand = Get-Command python.exe -ErrorAction SilentlyContinue
+$PythonPrefix = @()
+if ($null -eq $PythonCommand) {
+  $PythonCommand = Get-Command py.exe -ErrorAction SilentlyContinue
+  $PythonPrefix = @("-3")
+}
+if ($null -eq $PythonCommand) { throw "Python 3 is required" }
+$PythonExe = $PythonCommand.Source
+
+$TempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("local-shell-mcp-worker-" + [guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $TempDir | Out-Null
+try {
+  $Manifest = (Invoke-WebRequest -UseBasicParsing -Uri $ManifestUrl).Content | ConvertFrom-Json
+  $BundleUrl = [string]$Manifest.url
+  $RemoteDigest = ([string]$Manifest.sha256).ToLowerInvariant()
+  $RemoteVersion = [string]$Manifest.bundle_version
+  if ($env:LOCAL_SHELL_MCP_WORKER_STATE_DIR) {
+    $StateHome = $env:LOCAL_SHELL_MCP_WORKER_STATE_DIR
+  } else {
+    $StateHome = Join-Path $HOME ".local\state\local-shell-mcp-worker"
+  }
+  $RuntimeRoot = Join-Path $TempDir "runtime"
+  $Persistent = $Background -or $Persist
+  if ($Persistent) {
+    $RuntimeRoot = Join-Path $StateHome "runtime"
+    $DigestPath = Join-Path $StateHome "bundle.sha256"
+    $LocalDigest = ""
+    if (Test-Path $DigestPath) { $LocalDigest = (Get-Content -Raw $DigestPath).Trim() }
+    $RuntimePackage = Join-Path $RuntimeRoot "local_shell_mcp"
+    if (-not (Test-Path $RuntimePackage) -or $LocalDigest -ne $RemoteDigest) {
+      Write-Host "Downloading worker bundle..."
+      $BundlePath = Join-Path $TempDir "worker.tgz"
+      Invoke-WebRequest -UseBasicParsing -Uri $BundleUrl -OutFile $BundlePath
+      $ActualDigest = (Get-FileHash -Algorithm SHA256 $BundlePath).Hash.ToLowerInvariant()
+      if ($ActualDigest -ne $RemoteDigest) { throw "worker bundle checksum mismatch" }
+      New-Item -ItemType Directory -Force -Path $StateHome | Out-Null
+      $RuntimeNext = "$RuntimeRoot.next.$PID"
+      $RuntimePrevious = "$RuntimeRoot.previous.$PID"
+      Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $RuntimeNext, $RuntimePrevious
+      New-Item -ItemType Directory -Path $RuntimeNext | Out-Null
+      $ExtractArgs = @($PythonPrefix) + @(
+        "-c",
+        "import sys,tarfile; tarfile.open(sys.argv[1], 'r:gz').extractall(sys.argv[2])",
+        $BundlePath,
+        $RuntimeNext
+      )
+      & $PythonExe @ExtractArgs
+      if ($LASTEXITCODE -ne 0) { throw "worker bundle extraction failed" }
+      if (Test-Path $RuntimeRoot) { Move-Item $RuntimeRoot $RuntimePrevious }
+      try {
+        Move-Item $RuntimeNext $RuntimeRoot
+      } catch {
+        if (Test-Path $RuntimePrevious) { Move-Item $RuntimePrevious $RuntimeRoot }
+        throw
+      }
+      Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $RuntimePrevious
+      Set-Content -Encoding Ascii -Path $DigestPath -Value $RemoteDigest
+    } else {
+      Write-Host "Worker bundle is already current ($RemoteVersion)."
+    }
+  } else {
+    Write-Host "Downloading worker bundle..."
+    $BundlePath = Join-Path $TempDir "worker.tgz"
+    Invoke-WebRequest -UseBasicParsing -Uri $BundleUrl -OutFile $BundlePath
+    $ActualDigest = (Get-FileHash -Algorithm SHA256 $BundlePath).Hash.ToLowerInvariant()
+    if ($ActualDigest -ne $RemoteDigest) { throw "worker bundle checksum mismatch" }
+    New-Item -ItemType Directory -Path $RuntimeRoot | Out-Null
+    $ExtractArgs = @($PythonPrefix) + @(
+      "-c",
+      "import sys,tarfile; tarfile.open(sys.argv[1], 'r:gz').extractall(sys.argv[2])",
+      $BundlePath,
+      $RuntimeRoot
+    )
+    & $PythonExe @ExtractArgs
+    if ($LASTEXITCODE -ne 0) { throw "worker bundle extraction failed" }
+  }
+
+  $env:LOCAL_SHELL_MCP_WORKER_STATE_DIR = $StateHome
+  $WorkerPythonPath = "$RuntimeRoot;$RuntimeRoot\vendor"
+  if ($env:PYTHONPATH) { $WorkerPythonPath += ";$env:PYTHONPATH" }
+  $env:PYTHONPATH = $WorkerPythonPath
+  $EnrollArgs = @($PythonPrefix) + @(
+    "-m", "local_shell_mcp.remote_worker", "enroll",
+    "--server", $Server,
+    "--invite-stdin",
+    "--workdir", $Workdir,
+    "--runtime-digest", $RemoteDigest,
+    "--runtime-version", $RemoteVersion
+  )
+  if ($Name) { $EnrollArgs += @("--name", $Name) }
+  $Invite | & $PythonExe @EnrollArgs
+  if ($LASTEXITCODE -ne 0) { throw "worker enrollment failed" }
+  $Invite = $null
+
+  if ($Persist) {
+    $InstallArgs = @($PythonPrefix) + @("-m", "local_shell_mcp.remote_worker", "install-service")
+    & $PythonExe @InstallArgs
+    if ($LASTEXITCODE -ne 0) { throw "worker service installation failed" }
+    if ($env:LOCAL_SHELL_MCP_WORKER_BIN_DIR) {
+      $WorkerBinDir = $env:LOCAL_SHELL_MCP_WORKER_BIN_DIR
+    } else {
+      $WorkerBinDir = Join-Path $HOME ".local\bin"
+    }
+    $env:PATH = "$WorkerBinDir;$env:PATH"
+    Write-Host "local-shell-mcp worker installed and started."
+    Write-Host "Management: local-shell-mcp worker status"
+    return
+  }
+  if ($Background) {
+    $LauncherArgs = @($PythonPrefix) + @("-m", "local_shell_mcp.remote_worker", "install-launcher")
+    & $PythonExe @LauncherArgs
+    if ($LASTEXITCODE -ne 0) { throw "worker launcher installation failed" }
+    $StartArgs = @($PythonPrefix) + @("-m", "local_shell_mcp.remote_worker", "start")
+    & $PythonExe @StartArgs
+    if ($LASTEXITCODE -ne 0) { throw "worker startup failed" }
+    if ($env:LOCAL_SHELL_MCP_WORKER_BIN_DIR) {
+      $WorkerBinDir = $env:LOCAL_SHELL_MCP_WORKER_BIN_DIR
+    } else {
+      $WorkerBinDir = Join-Path $HOME ".local\bin"
+    }
+    $env:PATH = "$WorkerBinDir;$env:PATH"
+    Write-Host "local-shell-mcp worker started in background."
+    Write-Host "Management: local-shell-mcp worker status"
+    return
+  }
+  $RunArgs = @($PythonPrefix) + @("-m", "local_shell_mcp.remote_worker", "run")
+  & $PythonExe @RunArgs
+  if ($LASTEXITCODE -ne 0) { throw "worker exited with status $LASTEXITCODE" }
+} finally {
+  Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $TempDir
+}
+'''
+    script = script.replace("__SERVER__", repr(server))
+    script = script.replace("__PUBLIC_MANIFEST_URL__", REMOTE_WORKER_PUBLIC_MANIFEST_URL)
+    return PlainTextResponse(script, media_type="text/plain")
+
+
 def remote_routes() -> list[Any]:
     from starlette.routing import Route
 
     return [
         Route(remote.REMOTE_JOIN_PATH, join_script, methods=["GET"]),
+        Route(remote.REMOTE_POWERSHELL_JOIN_PATH, powershell_join_script, methods=["GET"]),
         Route(REMOTE_WORKER_MANIFEST_PATH, worker_manifest, methods=["GET"]),
         Route(remote.REMOTE_WORKER_BUNDLE_PATH, worker_bundle, methods=["GET"]),
         Route(f"{remote.REMOTE_API_PREFIX}/register", remote.register_endpoint, methods=["POST"]),

--- a/src/local_shell_mcp/remote_worker_service.py
+++ b/src/local_shell_mcp/remote_worker_service.py
@@ -367,6 +367,18 @@ exit /b %ERRORLEVEL%
     return path
 
 
+def _installed_windows_launcher_path() -> Path | None:
+    try:
+        content = _windows_task_launcher_path().read_text(encoding="utf-8")
+    except OSError:
+        return None
+    match = re.search(r'^call "([^"\r\n]+)" worker run >> ', content, re.MULTILINE)
+    if not match:
+        return None
+    path = Path(match.group(1).replace("%%", "%"))
+    return path if path.is_absolute() else None
+
+
 def _register_windows_task(service_file: Path) -> None:
     action_arguments = f'/d /c ""{service_file.resolve()}""'
     script = "\n".join(
@@ -403,11 +415,14 @@ def _register_windows_task(service_file: Path) -> None:
 def _windows_task_status() -> dict[str, Any] | None:
     script = "\n".join(
         [
+            "$ErrorActionPreference = 'Stop'",
             (
-                f"$task = Get-ScheduledTask -TaskName {_powershell_literal(_WINDOWS_TASK_NAME)} "
-                "-ErrorAction SilentlyContinue"
+                "$tasks = @(Get-ScheduledTask -TaskPath '\\' -ErrorAction Stop | "
+                f"Where-Object {{ $_.TaskName -eq {_powershell_literal(_WINDOWS_TASK_NAME)} }})"
             ),
-            "if ($null -eq $task) { exit 3 }",
+            "if ($tasks.Count -eq 0) { exit 3 }",
+            "if ($tasks.Count -ne 1) { throw 'multiple matching scheduled tasks found' }",
+            "$task = $tasks[0]",
             (
                 "[Console]::Out.Write(([pscustomobject]@{state=[int]$task.State; "
                 "state_name=$task.State.ToString()} | ConvertTo-Json -Compress))"
@@ -415,16 +430,19 @@ def _windows_task_status() -> dict[str, Any] | None:
         ]
     )
     result = _run_powershell(script, check=False)
-    if result.returncode:
+    if result.returncode == 3:
         return None
+    if result.returncode:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit code {result.returncode}"
+        raise RuntimeError(f"failed to query Windows remote worker task: {detail}")
     try:
         payload = json.loads(result.stdout)
         return {
             "state": int(payload["state"]),
             "state_name": str(payload["state_name"]),
         }
-    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
-        return {"state": 0, "state_name": result.stdout.strip() or result.stderr.strip()}
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+        raise RuntimeError("Windows remote worker task returned invalid status data") from exc
 
 
 def _start_windows_task() -> None:
@@ -455,7 +473,8 @@ def refresh_installed_service_definition() -> Path | None:
         launcher = _installed_launchd_launcher_path() or worker_launcher_path()
         return _write_launchd_plist(launcher)
     if kind == "scheduled-task" and _windows_task_status() is not None:
-        return _write_windows_task_launcher()
+        launcher = _installed_windows_launcher_path() or worker_launcher_path()
+        return _write_windows_task_launcher(launcher)
     return None
 
 

--- a/src/local_shell_mcp/remote_worker_service.py
+++ b/src/local_shell_mcp/remote_worker_service.py
@@ -32,6 +32,8 @@ from .remote_worker_state import (
 
 _SERVICE_NAME = "local-shell-mcp-worker"
 _LAUNCHD_LABEL = "com.fwerkor.local-shell-mcp-worker"
+_WINDOWS_TASK_NAME = "local-shell-mcp-worker"
+_WINDOWS_TASK_STATE_RUNNING = 4
 _WORKER_MANAGED_ENV = "LOCAL_SHELL_MCP_WORKER_MANAGED"
 _LAUNCHD_PATH_SEPARATOR = ":"
 _LAUNCHD_HOMEBREW_DIRS = (
@@ -216,8 +218,27 @@ def _launchd_plist_path() -> Path:
     return user_home() / "Library" / "LaunchAgents" / f"{_LAUNCHD_LABEL}.plist"
 
 
+def _windows_task_launcher_path() -> Path:
+    return worker_state_dir() / "worker-service.cmd"
+
+
 def _run(command: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
     return subprocess.run(command, check=check, capture_output=True, text=True)  # noqa: S603
+
+
+def _powershell_executable() -> str | None:
+    return shutil.which("pwsh") or shutil.which("powershell")
+
+
+def _powershell_literal(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _run_powershell(script: str, *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    shell = _powershell_executable()
+    if not shell:
+        raise RuntimeError("PowerShell is required to manage the Windows remote worker task")
+    return _run([shell, "-NoProfile", "-NonInteractive", "-Command", script], check=check)
 
 
 def _user_id() -> int:
@@ -238,6 +259,8 @@ def service_kind() -> str:
         return "systemd"
     if system == "Darwin" and shutil.which("launchctl"):
         return "launchd"
+    if system == "Windows" and _powershell_executable():
+        return "scheduled-task"
     return "process"
 
 
@@ -324,11 +347,116 @@ def _write_launchd_plist(launcher: Path | None = None) -> Path:
     return path
 
 
-def refresh_installed_service_definition() -> Path | None:
-    if service_kind() != "launchd" or not _launchd_plist_path().exists():
+def _batch_path(path: Path) -> str:
+    return str(path).replace("%", "%%")
+
+
+def _write_windows_task_launcher(launcher: Path | None = None) -> Path:
+    launcher = launcher or worker_launcher_path()
+    path = _windows_task_launcher_path()
+    content = f'''@echo off
+setlocal
+set "PYTHONUNBUFFERED=1"
+set "{_WORKER_MANAGED_ENV}=1"
+set "LOCAL_SHELL_MCP_WORKER_STATE_DIR={_batch_path(worker_state_dir().resolve())}"
+call "{_batch_path(launcher.resolve())}" worker run >> "{_batch_path(worker_log_path().resolve())}" 2>&1
+exit /b %ERRORLEVEL%
+'''
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _register_windows_task(service_file: Path) -> None:
+    action_arguments = f'/d /c ""{service_file.resolve()}""'
+    script = "\n".join(
+        [
+            "$ErrorActionPreference = 'Stop'",
+            "$user = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name",
+            (
+                "$action = New-ScheduledTaskAction -Execute $env:ComSpec "
+                f"-Argument {_powershell_literal(action_arguments)} "
+                f"-WorkingDirectory {_powershell_literal(str(worker_state_dir().resolve()))}"
+            ),
+            "$trigger = New-ScheduledTaskTrigger -AtLogOn -User $user",
+            (
+                "$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries "
+                "-DontStopIfGoingOnBatteries -ExecutionTimeLimit ([TimeSpan]::Zero) "
+                "-MultipleInstances IgnoreNew -RestartCount 999 "
+                "-RestartInterval (New-TimeSpan -Minutes 1) -StartWhenAvailable"
+            ),
+            (
+                "$principal = New-ScheduledTaskPrincipal -UserId $user "
+                "-LogonType Interactive -RunLevel Limited"
+            ),
+            (
+                f"Register-ScheduledTask -TaskName {_powershell_literal(_WINDOWS_TASK_NAME)} "
+                "-Action $action -Trigger $trigger -Settings $settings -Principal $principal "
+                f"-Description {_powershell_literal('local-shell-mcp remote worker')} "
+                "-Force | Out-Null"
+            ),
+        ]
+    )
+    _run_powershell(script)
+
+
+def _windows_task_status() -> dict[str, Any] | None:
+    script = "\n".join(
+        [
+            (
+                f"$task = Get-ScheduledTask -TaskName {_powershell_literal(_WINDOWS_TASK_NAME)} "
+                "-ErrorAction SilentlyContinue"
+            ),
+            "if ($null -eq $task) { exit 3 }",
+            (
+                "[Console]::Out.Write(([pscustomobject]@{state=[int]$task.State; "
+                "state_name=$task.State.ToString()} | ConvertTo-Json -Compress))"
+            ),
+        ]
+    )
+    result = _run_powershell(script, check=False)
+    if result.returncode:
         return None
-    launcher = _installed_launchd_launcher_path() or worker_launcher_path()
-    return _write_launchd_plist(launcher)
+    try:
+        payload = json.loads(result.stdout)
+        return {
+            "state": int(payload["state"]),
+            "state_name": str(payload["state_name"]),
+        }
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+        return {"state": 0, "state_name": result.stdout.strip() or result.stderr.strip()}
+
+
+def _start_windows_task() -> None:
+    _run_powershell(
+        f"Start-ScheduledTask -TaskName {_powershell_literal(_WINDOWS_TASK_NAME)}"
+    )
+
+
+def _stop_windows_task() -> None:
+    _run_powershell(
+        f"Stop-ScheduledTask -TaskName {_powershell_literal(_WINDOWS_TASK_NAME)} "
+        "-ErrorAction SilentlyContinue",
+        check=False,
+    )
+
+
+def _unregister_windows_task() -> None:
+    _run_powershell(
+        f"Unregister-ScheduledTask -TaskName {_powershell_literal(_WINDOWS_TASK_NAME)} "
+        "-Confirm:$false -ErrorAction SilentlyContinue",
+        check=False,
+    )
+
+
+def refresh_installed_service_definition() -> Path | None:
+    kind = service_kind()
+    if kind == "launchd" and _launchd_plist_path().exists():
+        launcher = _installed_launchd_launcher_path() or worker_launcher_path()
+        return _write_launchd_plist(launcher)
+    if kind == "scheduled-task" and _windows_task_status() is not None:
+        return _write_windows_task_launcher()
+    return None
 
 
 def prepare_worker_service_environment() -> Path | None:
@@ -381,14 +509,14 @@ def _linux_process_identity(pid: int) -> str | None:
 
 
 def _windows_process_identity(pid: int) -> str | None:
-    shell = shutil.which("pwsh") or shutil.which("powershell")
+    shell = _powershell_executable()
     if not shell:
         return None
     script = (
         f'$p=Get-CimInstance Win32_Process -Filter "ProcessId = {pid}"; '
         'if ($p) { Write-Output ($p.CreationDate + "|" + $p.CommandLine) }'
     )
-    result = _run([shell, "-NoProfile", "-Command", script], check=False)
+    result = _run([shell, "-NoProfile", "-NonInteractive", "-Command", script], check=False)
     value = result.stdout.strip()
     if result.returncode or "|" not in value:
         return None
@@ -548,6 +676,14 @@ def install_service(*, start: bool = True) -> dict[str, Any]:
         _run(["launchctl", "bootout", domain, str(service_file)], check=False)
         if start:
             _run(["launchctl", "bootstrap", domain, str(service_file)])
+    elif kind == "scheduled-task":
+        _stop_process()
+        if _windows_task_status() is not None:
+            _stop_windows_task()
+        service_file = _write_windows_task_launcher(launcher)
+        _register_windows_task(service_file)
+        if start:
+            _start_windows_task()
     else:
         service_file = None
         if start:
@@ -570,6 +706,12 @@ def uninstall_service() -> dict[str, Any]:
         _run(["systemctl", "--user", "daemon-reload"], check=False)
     if _launchd_plist_path().exists():
         _launchd_plist_path().unlink(missing_ok=True)
+    if platform.system() == "Windows" and (
+        kind == "scheduled-task" or _windows_task_launcher_path().exists()
+    ):
+        if _powershell_executable():
+            _unregister_windows_task()
+        _windows_task_launcher_path().unlink(missing_ok=True)
     return {"kind": kind, "uninstalled": True}
 
 
@@ -582,6 +724,8 @@ def start_service() -> dict[str, Any]:
         result = _run(["launchctl", "kickstart", "-k", f"{domain}/{_LAUNCHD_LABEL}"], check=False)
         if result.returncode:
             _run(["launchctl", "bootstrap", domain, str(_launchd_plist_path())])
+    elif kind == "scheduled-task" and _windows_task_status() is not None:
+        _start_windows_task()
     else:
         _start_process()
     return service_status()
@@ -596,6 +740,8 @@ def stop_service() -> dict[str, Any]:
             ["launchctl", "bootout", f"gui/{_user_id()}", str(_launchd_plist_path())],
             check=False,
         )
+    elif kind == "scheduled-task" and _windows_task_status() is not None:
+        _stop_windows_task()
     else:
         _stop_process()
     return service_status()
@@ -624,6 +770,17 @@ def service_status() -> dict[str, Any]:
         )
         running = result.returncode == 0
         detail = result.stdout.strip() or result.stderr.strip()
+    elif native_kind == "scheduled-task":
+        task = _windows_task_status()
+        if task is not None:
+            installed = True
+            running = task["state"] == _WINDOWS_TASK_STATE_RUNNING
+            detail = task["state_name"]
+        else:
+            kind = "process"
+            installed = worker_launcher_path().exists()
+            pid = _read_pid()
+            running = pid is not None
     else:
         kind = "process"
         installed = worker_launcher_path().exists()

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -38,6 +38,10 @@ async def test_remote_invites_use_requested_origin_prune_expired_entries_and_val
 
     assert result["join_url"] == "https://control.example.test/join"
     assert "https://control.example.test/join" in result["command"]
+    assert result["persistent_command"].endswith(" --persist")
+    assert result["powershell_join_url"] == "https://control.example.test/join.ps1"
+    assert "https://control.example.test/join.ps1" in result["powershell_command"]
+    assert result["powershell_persistent_command"].endswith(" -Persist")
     assert "expired" not in manager.invites
     with pytest.raises(ValueError, match="unsupported characters"):
         await manager.create_invite("bad/name")

--- a/tests/test_remote_worker_routes.py
+++ b/tests/test_remote_worker_routes.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import shutil
+import subprocess
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -55,10 +58,57 @@ async def test_join_script_caches_bundle_and_removes_invite_from_worker_process(
     assert "remote_worker run --invite" not in script
 
 
+@pytest.mark.asyncio
+async def test_powershell_join_script_supports_persistent_windows_workers(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_PUBLIC_BASE_URL", "https://example.test")
+    get_settings.cache_clear()
+    response = await routes.powershell_join_script(None)  # type: ignore[arg-type]
+    script = response.body.decode("utf-8")
+    assert "/remote/worker-bundle.tgz?manifest=1" in script
+    assert "Get-FileHash -Algorithm SHA256" in script
+    assert "tarfile.open" in script
+    assert '"--invite-stdin"' in script
+    assert '"install-service"' in script
+    assert "[switch]$Persist" in script
+    assert "$Invite | & $PythonExe @EnrollArgs" in script
+    assert "-Invite $Invite" not in script
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires Windows PowerShell")
+@pytest.mark.asyncio
+async def test_powershell_join_script_parses_on_windows(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_PUBLIC_BASE_URL", "https://example.test")
+    get_settings.cache_clear()
+    response = await routes.powershell_join_script(None)  # type: ignore[arg-type]
+    script_path = tmp_path / "join.ps1"
+    script_path.write_bytes(response.body)
+    shell = shutil.which("pwsh") or shutil.which("powershell")
+    assert shell
+    parser = """
+$tokens = $null
+$errors = $null
+[System.Management.Automation.Language.Parser]::ParseFile($args[0], [ref]$tokens, [ref]$errors) | Out-Null
+if ($errors.Count -gt 0) {
+  $errors | ForEach-Object { [Console]::Error.WriteLine($_.Message) }
+  exit 1
+}
+"""
+    result = subprocess.run(  # noqa: S603
+        [shell, "-NoProfile", "-NonInteractive", "-Command", parser, str(script_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
 def test_remote_routes_replace_worker_bootstrap_endpoints():
     paths = [route.path for route in routes.remote_routes()]
-    assert paths[:3] == [
+    assert paths[:4] == [
         "/join",
+        "/join.ps1",
         "/remote/worker-manifest.json",
         "/remote/worker-bundle.tgz",
     ]

--- a/tests/test_remote_worker_routes.py
+++ b/tests/test_remote_worker_routes.py
@@ -73,6 +73,18 @@ async def test_powershell_join_script_supports_persistent_windows_workers(tmp_pa
     assert "[switch]$Persist" in script
     assert "$Invite | & $PythonExe @EnrollArgs" in script
     assert "-Invite $Invite" not in script
+    assert "sys.version_info >= (3, 11)" in script
+    assert script.index("sys.version_info >= (3, 11)") < script.index("Downloading worker bundle")
+
+
+@pytest.mark.asyncio
+async def test_powershell_join_script_escapes_server_url(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_PUBLIC_BASE_URL", "https://example.test/worker's")
+    get_settings.cache_clear()
+    response = await routes.powershell_join_script(None)  # type: ignore[arg-type]
+    script = response.body.decode("utf-8")
+    assert "$Server = 'https://example.test/worker''s'" in script
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="requires Windows PowerShell")
@@ -86,17 +98,18 @@ async def test_powershell_join_script_parses_on_windows(tmp_path, monkeypatch):
     script_path.write_bytes(response.body)
     shell = shutil.which("pwsh") or shutil.which("powershell")
     assert shell
+    script_literal = "'" + str(script_path).replace("'", "''") + "'"
     parser = """
 $tokens = $null
 $errors = $null
-[System.Management.Automation.Language.Parser]::ParseFile($args[0], [ref]$tokens, [ref]$errors) | Out-Null
+[System.Management.Automation.Language.Parser]::ParseFile(__SCRIPT_PATH__, [ref]$tokens, [ref]$errors) | Out-Null
 if ($errors.Count -gt 0) {
   $errors | ForEach-Object { [Console]::Error.WriteLine($_.Message) }
   exit 1
 }
-"""
+""".replace("__SCRIPT_PATH__", script_literal)
     result = subprocess.run(  # noqa: S603
-        [shell, "-NoProfile", "-NonInteractive", "-Command", parser, str(script_path)],
+        [shell, "-NoProfile", "-NonInteractive", "-Command", parser],
         check=False,
         capture_output=True,
         text=True,

--- a/tests/test_remote_worker_service.py
+++ b/tests/test_remote_worker_service.py
@@ -177,14 +177,24 @@ def test_windows_task_status_parses_state_and_handles_missing_task(monkeypatch):
             ["powershell"], 0, stdout="unexpected output", stderr=""
         ),
     )
-    assert service._windows_task_status() == {  # noqa: SLF001
-        "state": 0,
-        "state_name": "unexpected output",
-    }
+    with pytest.raises(RuntimeError, match="invalid status data"):
+        service._windows_task_status()  # noqa: SLF001
+
+    monkeypatch.setattr(
+        service,
+        "_run_powershell",
+        lambda script, check=False: subprocess.CompletedProcess(
+            ["powershell"], 1, stdout="", stderr="access denied"
+        ),
+    )
+    with pytest.raises(RuntimeError, match="access denied"):
+        service._windows_task_status()  # noqa: SLF001
 
 
 def test_windows_service_refresh_and_process_fallback(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
+    custom_launcher = tmp_path / "custom-bin" / "local-shell-mcp.cmd"
+    service._write_windows_task_launcher(custom_launcher)  # noqa: SLF001
     monkeypatch.setattr(service, "service_kind", lambda: "scheduled-task")
     monkeypatch.setattr(
         service,
@@ -194,6 +204,8 @@ def test_windows_service_refresh_and_process_fallback(tmp_path, monkeypatch):
     refreshed = service.refresh_installed_service_definition()
     assert refreshed == service._windows_task_launcher_path()  # noqa: SLF001
     assert refreshed.exists()
+    assert f'call "{custom_launcher.resolve()}" worker run' in refreshed.read_text(encoding="utf-8")
+    assert service._installed_windows_launcher_path() == custom_launcher.resolve()  # noqa: SLF001
 
     monkeypatch.setattr(service, "_windows_task_status", lambda: None)
     monkeypatch.setattr(service, "_read_pid", lambda: 42)

--- a/tests/test_remote_worker_service.py
+++ b/tests/test_remote_worker_service.py
@@ -67,6 +67,142 @@ def test_service_kind_detects_launchd_and_process(monkeypatch):
     assert service.service_kind() == "process"
 
 
+def test_service_kind_detects_windows_scheduled_task(monkeypatch):
+    monkeypatch.setattr(service.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(service, "_powershell_executable", lambda: "powershell.exe")
+    assert service.service_kind() == "scheduled-task"
+    monkeypatch.setattr(service, "_powershell_executable", lambda: None)
+    assert service.service_kind() == "process"
+
+
+def test_run_powershell_uses_available_shell_and_requires_one(monkeypatch):
+    calls = []
+    monkeypatch.setattr(service, "_powershell_executable", lambda: "powershell.exe")
+    monkeypatch.setattr(
+        service,
+        "_run",
+        lambda command, check=True: calls.append((command, check))
+        or subprocess.CompletedProcess(command, 0, stdout="ok", stderr=""),
+    )
+    result = service._run_powershell("Write-Output ok", check=False)  # noqa: SLF001
+    assert result.stdout == "ok"
+    assert calls == [
+        (["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", "Write-Output ok"], False)
+    ]
+
+    monkeypatch.setattr(service, "_powershell_executable", lambda: None)
+    with pytest.raises(RuntimeError, match="PowerShell is required"):
+        service._run_powershell("Write-Output ok")  # noqa: SLF001
+
+
+def test_install_and_manage_windows_scheduled_task(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    launcher = tmp_path / "bin" / "local-shell-mcp.cmd"
+    launcher.parent.mkdir(parents=True)
+    launcher.write_text("@echo off\n", encoding="utf-8")
+    monkeypatch.setattr(service, "install_launcher", lambda: launcher)
+    monkeypatch.setattr(service, "ensure_user_bin_on_path", lambda: [])
+    monkeypatch.setattr(service.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(service, "service_kind", lambda: "scheduled-task")
+    monkeypatch.setattr(service, "_powershell_executable", lambda: "powershell.exe")
+    state = {"installed": False, "value": 3}
+    scripts = []
+
+    def fake_status():
+        if not state["installed"]:
+            return None
+        name = "Running" if state["value"] == 4 else "Ready"
+        return {"state": state["value"], "state_name": name}
+
+    def fake_powershell(script, *, check=True):
+        scripts.append((script, check))
+        if "Unregister-ScheduledTask" in script:
+            state["installed"] = False
+        elif "Register-ScheduledTask" in script:
+            state["installed"] = True
+            state["value"] = 3
+        elif "Start-ScheduledTask" in script:
+            state["value"] = 4
+        elif "Stop-ScheduledTask" in script:
+            state["value"] = 3
+        return subprocess.CompletedProcess(["powershell"], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(service, "_windows_task_status", fake_status)
+    monkeypatch.setattr(service, "_run_powershell", fake_powershell)
+
+    result = service.install_service(start=True)
+    service_file = service._windows_task_launcher_path()  # noqa: SLF001
+    assert result["kind"] == "scheduled-task"
+    assert result["service_file"] == str(service_file)
+    assert service_file.exists()
+    launcher_text = service_file.read_text(encoding="utf-8")
+    assert "LOCAL_SHELL_MCP_WORKER_MANAGED=1" in launcher_text
+    assert "LOCAL_SHELL_MCP_WORKER_STATE_DIR=" in launcher_text
+    registration = next(script for script, _ in scripts if "Register-ScheduledTask" in script)
+    assert "New-ScheduledTaskTrigger -AtLogOn -User $user" in registration
+    assert "-LogonType Interactive -RunLevel Limited" in registration
+    assert "-RestartCount 999" in registration
+    assert service.service_status()["running"] is True
+
+    assert service.stop_service()["running"] is False
+    assert service.start_service()["running"] is True
+    assert service.uninstall_service()["uninstalled"] is True
+    assert state["installed"] is False
+    assert not service_file.exists()
+
+
+def test_windows_task_status_parses_state_and_handles_missing_task(monkeypatch):
+    monkeypatch.setattr(
+        service,
+        "_run_powershell",
+        lambda script, check=False: subprocess.CompletedProcess(
+            ["powershell"], 0, stdout='{"state":4,"state_name":"Running"}', stderr=""
+        ),
+    )
+    assert service._windows_task_status() == {"state": 4, "state_name": "Running"}  # noqa: SLF001
+
+    monkeypatch.setattr(
+        service,
+        "_run_powershell",
+        lambda script, check=False: subprocess.CompletedProcess(
+            ["powershell"], 3, stdout="", stderr="missing"
+        ),
+    )
+    assert service._windows_task_status() is None  # noqa: SLF001
+
+    monkeypatch.setattr(
+        service,
+        "_run_powershell",
+        lambda script, check=False: subprocess.CompletedProcess(
+            ["powershell"], 0, stdout="unexpected output", stderr=""
+        ),
+    )
+    assert service._windows_task_status() == {  # noqa: SLF001
+        "state": 0,
+        "state_name": "unexpected output",
+    }
+
+
+def test_windows_service_refresh_and_process_fallback(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setattr(service, "service_kind", lambda: "scheduled-task")
+    monkeypatch.setattr(
+        service,
+        "_windows_task_status",
+        lambda: {"state": 3, "state_name": "Ready"},
+    )
+    refreshed = service.refresh_installed_service_definition()
+    assert refreshed == service._windows_task_launcher_path()  # noqa: SLF001
+    assert refreshed.exists()
+
+    monkeypatch.setattr(service, "_windows_task_status", lambda: None)
+    monkeypatch.setattr(service, "_read_pid", lambda: 42)
+    status = service.service_status()
+    assert status["kind"] == "process"
+    assert status["pid"] == 42
+    assert status["running"] is True
+
+
 def test_launchd_install_start_and_status(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
     calls = []


### PR DESCRIPTION
## Summary

- add a per-user Windows Task Scheduler backend for remote worker install/start/stop/status/uninstall
- add a native PowerShell bootstrap endpoint and persistent Windows invite commands
- document Windows lifecycle behavior and add Windows-specific unit and syntax tests

## Validation

- `ruff check .`
- `PYTHONPATH=src pytest -q` — 605 passed, 1 skipped
- `PYTHONPATH=src bash scripts/run-coverage.sh` — 94.16%, all modules >= 90%
- `python scripts/check-doc-i18n.py`
- `mkdocs build --strict`