### PR TITLE
feat: add dynamic MCP gateway and browser sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,8 @@ The public MCP surface includes:
 - Shell and jobs: `run_shell_tool`, `run_python_tool`, persistent `shell_*`, and tracked `job_*` tools. Use `run_shell_tool` for Git CLI operations.
 - Filesystem: `list_files`, `tree_view`, `glob_search`, `grep_search`, unified `read_file`, native-vision `view_image`, `write_file`, unified `edit_file`, `delete_file_or_dir`, and `apply_patch`.
 - Transfer: `transfer_path` for files or directories across controller and worker endpoints.
-- Browser: `browser_get_text_tool`, unified `browser_capture_tool`, and `playwright_run_script_tool`.
+- Dynamic MCP: `mcp_manage`, `mcp_tool_search`, `mcp_tool_inspect`, and `mcp_tool_call`. External tools are discovered progressively and never expand LSM's own `tools/list` surface.
+- Browser: persistent high-level `browser_session`, `browser_snapshot`, and `browser_act`; one-shot `browser_get_text_tool` / `browser_capture_tool`; `playwright_run_script_tool` remains the low-level escape hatch.
 - File links: `create_file_link`, `list_file_links`, `revoke_file_link`.
 - Remote workers: `remote_invite`, `remote_list_machines`, `remote_rename_machine`, and `remote_revoke_machine`; normal execution tools accept optional `machine`.
 - Agent Skills: `skills_list`, `skill_load`, `skill_read_file`.
@@ -183,6 +184,7 @@ Default protections include:
 - Command timeouts, output limits, and concurrency limits.
 - Default command/path denylists for host-control fragments.
 - Shell subprocess environment filtering for service-side secrets.
+- Dynamic stdio MCP servers inherit only a minimal OS environment plus explicitly configured per-server variables; configured environment/header values are stored in a mode-`0600` state file and redacted from tool results and Audit arguments.
 - Audit logs at `/workspace/.local-shell-mcp/audit.jsonl`.
 - Secret scanning helpers before commits and pushes.
 - Tokenized file links with TTL/download limits and revocation.

--- a/docs/guides/browser-automation.md
+++ b/docs/guides/browser-automation.md
@@ -6,16 +6,19 @@ Browser tools use Playwright to inspect pages, capture evidence, and run reprodu
 
 | Tool | Purpose |
 |---|---|
+| `browser_session` | Start, list, close, or clean up persistent browser sessions; optionally reuse a profile or storage state. |
+| `browser_snapshot` | Read bounded page text, page/network errors, and interactive elements with short refs such as `e1`; optionally capture a screenshot. |
+| `browser_act` | Run structured navigation, click, fill, select, key, wait, and multi-page actions using snapshot refs or CSS selectors. |
 | `browser_get_text_tool` | Extract visible text from a selector. |
 | `browser_capture_tool` | Save either a PNG screenshot or Chromium PDF. |
-| `playwright_run_script_tool` | Run a complete Python Playwright script for clicks, forms, console inspection, or multi-page flows. |
+| `playwright_run_script_tool` | Run a complete Python Playwright script when the high-level action set is insufficient. |
 
-All three accept optional `machine`. Browser dependencies must already be installed on the selected controller or worker; installation is performed with ordinary shell commands such as `python -m playwright install chromium`.
+All browser tools accept optional `machine`. Browser dependencies must already be installed on the selected controller or worker; installation is performed with ordinary shell commands such as `python -m playwright install chromium`.
 
 ## Common flows
 
-For visual verification, start the site with `shell_start` or `job_start`, wait for readiness, call `browser_capture_tool(capture_format="png")`, then stop the process. Use `capture_format="pdf"` with Chromium for printable output.
+For interactive work, call `browser_session(action="start", url=...)`, then `browser_snapshot`. The snapshot returns short references such as `e1` and `e2`; pass those refs directly to `browser_act`, for example `{"action": "click", "target": "e1"}` or `{"action": "fill", "target": "e2", "value": "..."}`. Re-snapshot after navigation because element refs are page-state references, not permanent selectors.
 
-Use `browser_get_text_tool` when only rendered content matters. Use `playwright_run_script_tool` when the workflow requires interaction or JavaScript evaluation.
+For one-shot visual verification, start the site with `shell_start` or `job_start`, wait for readiness, call `browser_capture_tool(capture_format="png")`, then stop the process. Use `capture_format="pdf"` with Chromium for printable output. Use `browser_get_text_tool` when only rendered content matters, and keep `playwright_run_script_tool` for JavaScript evaluation or interactions not represented by `browser_act`.
 
 Keep scripts bounded, set explicit timeouts, save artifacts under the workspace, and avoid entering credentials unless the environment is dedicated to the task.

--- a/docs/guides/browser-automation.zh-Hant.md
+++ b/docs/guides/browser-automation.zh-Hant.md
@@ -6,16 +6,19 @@
 
 | 工具 | 用途 |
 |---|---|
+| `browser_session` | 啟動、列出、關閉或清理持久瀏覽器會話；可重用 profile 或 storage state。 |
+| `browser_snapshot` | 讀取有界頁面文字、頁面/網路錯誤，以及帶 `e1` 等短引用的可互動元素；可選截圖。 |
+| `browser_act` | 使用 snapshot 引用或 CSS selector 執行導覽、點擊、填寫、選擇、按鍵、等待和多頁面操作。 |
 | `browser_get_text_tool` | 從指定 selector 提取可見文字。 |
 | `browser_capture_tool` | 保存 PNG 截圖或 Chromium PDF。 |
-| `playwright_run_script_tool` | 執行完整 Python Playwright 腳本，處理點擊、表單、主控台檢查或多頁面流程。 |
+| `playwright_run_script_tool` | 當高層 action 集合不足時，執行完整 Python Playwright 腳本。 |
 
-三個工具都接受可選的 `machine` 參數。控制端或目標 worker 必須已經安裝瀏覽器相依套件；安裝工作透過一般 shell 命令完成，例如 `python -m playwright install chromium`。
+所有瀏覽器工具都接受可選的 `machine` 參數。控制端或目標 worker 必須已經安裝瀏覽器相依套件；安裝工作透過一般 shell 命令完成，例如 `python -m playwright install chromium`。
 
 ## 常見流程
 
-進行視覺驗證時，先用 `shell_start` 或 `job_start` 啟動站點，等服務就緒後呼叫 `browser_capture_tool(capture_format="png")`，最後停止程序。需要可列印輸出時使用 `capture_format="pdf"`，並選擇 Chromium。
+需要互動時，先呼叫 `browser_session(action="start", url=...)`，再呼叫 `browser_snapshot`。snapshot 會回傳 `e1`、`e2` 這類短引用，可直接作為 `browser_act` 的 `target`，例如 `{"action": "click", "target": "e1"}` 或 `{"action": "fill", "target": "e2", "value": "..."}`。頁面導覽後應重新 snapshot，因為這些引用表示目前頁面狀態，並不是永久 selector。
 
-只關心渲染文字時使用 `browser_get_text_tool`。需要互動、JavaScript 求值或複雜導覽時使用 `playwright_run_script_tool`。
+一次性視覺驗證仍可先用 `shell_start` 或 `job_start` 啟動站點，等服務就緒後呼叫 `browser_capture_tool(capture_format="png")`，最後停止程序。需要可列印輸出時使用 `capture_format="pdf"`，並選擇 Chromium。只關心渲染文字時使用 `browser_get_text_tool`；只有需要 JavaScript 求值或 `browser_act` 尚未涵蓋的互動時才使用 `playwright_run_script_tool`。
 
 腳本應設定明確逾時，把產物保存到工作區，並避免在非專用環境中輸入憑據。

--- a/docs/guides/browser-automation.zh.md
+++ b/docs/guides/browser-automation.zh.md
@@ -6,16 +6,19 @@
 
 | 工具 | 用途 |
 |---|---|
+| `browser_session` | 启动、列出、关闭或清理持久浏览器会话；可复用 profile 或 storage state。 |
+| `browser_snapshot` | 读取有界页面文本、页面/网络错误，以及带 `e1` 等短引用的可交互元素；可选截图。 |
+| `browser_act` | 使用 snapshot 引用或 CSS selector 执行导航、点击、填写、选择、按键、等待和多页面操作。 |
 | `browser_get_text_tool` | 从指定 selector 提取可见文本。 |
 | `browser_capture_tool` | 保存 PNG 截图或 Chromium PDF。 |
-| `playwright_run_script_tool` | 运行完整 Python Playwright 脚本，处理点击、表单、控制台检查或多页面流程。 |
+| `playwright_run_script_tool` | 当高层 action 集合不足时，运行完整 Python Playwright 脚本。 |
 
-三个工具都接受可选的 `machine` 参数。控制端或目标 worker 必须已经安装浏览器依赖；安装工作通过普通 shell 命令完成，例如 `python -m playwright install chromium`。
+所有浏览器工具都接受可选的 `machine` 参数。控制端或目标 worker 必须已经安装浏览器依赖；安装工作通过普通 shell 命令完成，例如 `python -m playwright install chromium`。
 
 ## 常见流程
 
-进行视觉验证时，先用 `shell_start` 或 `job_start` 启动站点，等服务就绪后调用 `browser_capture_tool(capture_format="png")`，最后停止进程。需要可打印输出时使用 `capture_format="pdf"`，并选择 Chromium。
+需要交互时，先调用 `browser_session(action="start", url=...)`，再调用 `browser_snapshot`。snapshot 会返回 `e1`、`e2` 这样的短引用，可直接作为 `browser_act` 的 `target`，例如 `{"action": "click", "target": "e1"}` 或 `{"action": "fill", "target": "e2", "value": "..."}`。页面导航后应重新 snapshot，因为这些引用表示当前页面状态，并不是永久 selector。
 
-只关心渲染文本时使用 `browser_get_text_tool`。需要交互、JavaScript 求值或复杂导航时使用 `playwright_run_script_tool`。
+一次性视觉验证仍可先用 `shell_start` 或 `job_start` 启动站点，等服务就绪后调用 `browser_capture_tool(capture_format="png")`，最后停止进程。需要可打印输出时使用 `capture_format="pdf"`，并选择 Chromium。只关心渲染文本时使用 `browser_get_text_tool`；只有需要 JavaScript 求值或 `browser_act` 尚未覆盖的交互时才使用 `playwright_run_script_tool`。
 
 脚本应设置明确超时，把产物保存到工作区，并避免在非专用环境中输入凭据。

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,7 +68,7 @@ The intended isolation boundary is the container or VM running the service.
 | Shell and Python | `run_shell_tool`, `run_python_tool`, `shell_start` | Builds, tests, scripts, long-running processes |
 | Files and search | `tree_view`, `grep_search`, `read_file`, `apply_patch` | Repository inspection and precise edits |
 | Git | `run_shell_tool`, `run_shell_tool`, `run_shell_tool`, `run_shell_tool` | Reviewable source-control workflows |
-| Browser | `browser_capture_tool`, `browser_get_text_tool`, `playwright_run_script_tool` | UI checks, screenshots, rendered docs, page text |
+| Browser | `browser_session`, `browser_snapshot`, `browser_act`, one-shot capture/text tools, `playwright_run_script_tool` | Persistent interaction, UI checks, screenshots, rendered docs, page text |
 | File links | `create_file_link`, `revoke_file_link` | Downloading generated artifacts from chat |
 | Remote workers | `remote_invite`, `run_shell_tool`, `transfer_path` | Machines behind NAT, firewalls, or cluster login flows |
 

--- a/docs/index.zh-Hant.md
+++ b/docs/index.zh-Hant.md
@@ -68,7 +68,7 @@ Docker、VS Code 擴展、二進制、Python 和 stdio 是運行時；ChatGPT �
 | Shell 和 Python | `run_shell_tool`, `run_python_tool`, `shell_start` | 構建、測試、腳本、長時間進程 |
 | 文件和搜索 | `tree_view`, `grep_search`, `read_file`, `apply_patch` | 倉庫檢查和精確修改 |
 | Git | `run_shell_tool`, `run_shell_tool`, `run_shell_tool`, `run_shell_tool` | 可審查的源碼管理流程 |
-| 瀏覽器 | `browser_capture_tool`, `browser_get_text_tool`, `playwright_run_script_tool` | UI 檢查、截圖、渲染文檔、頁面文本 |
+| 瀏覽器 | `browser_session`, `browser_snapshot`, `browser_act`、一次性截圖/文字工具、`playwright_run_script_tool` | 持久互動、UI 檢查、截圖、渲染文檔、頁面文字 |
 | 文件鏈接 | `create_file_link`, `revoke_file_link` | 從聊天中下載生成產物 |
 | 遠程節點 | `remote_invite`, `run_shell_tool`, `transfer_path` | NAT、防火牆或集羣登錄流程後的機器 |
 

--- a/docs/index.zh.md
+++ b/docs/index.zh.md
@@ -68,7 +68,7 @@ Docker、VS Code 扩展、二进制、Python 和 stdio 是运行时；ChatGPT �
 | Shell 和 Python | `run_shell_tool`, `run_python_tool`, `shell_start` | 构建、测试、脚本、长时间进程 |
 | 文件和搜索 | `tree_view`, `grep_search`, `read_file`, `apply_patch` | 仓库检查和精确修改 |
 | Git | `run_shell_tool`, `run_shell_tool`, `run_shell_tool`, `run_shell_tool` | 可审查的源码管理流程 |
-| 浏览器 | `browser_capture_tool`, `browser_get_text_tool`, `playwright_run_script_tool` | UI 检查、截图、渲染文档、页面文本 |
+| 浏览器 | `browser_session`, `browser_snapshot`, `browser_act`、一次性截图/文本工具、`playwright_run_script_tool` | 持久交互、UI 检查、截图、渲染文档、页面文本 |
 | 文件链接 | `create_file_link`, `revoke_file_link` | 从聊天中下载生成产物 |
 | 远程节点 | `remote_invite`, `run_shell_tool`, `transfer_path` | NAT、防火墙或集群登录流程后的机器 |
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -13,7 +13,9 @@ All tools except connector-style `search` and `fetch` return a structured `ToolR
 | Run an interactive or long task | `shell_start` or `job_start` |
 | Make exact file changes | `edit_file` or `apply_patch` |
 | Transfer a file or directory | `transfer_path` |
-| Capture a page | `browser_get_text_tool` or `browser_capture_tool` |
+| Discover an external MCP capability | `mcp_tool_search`, then `mcp_tool_inspect` |
+| Interact with a page | `browser_session`, `browser_snapshot`, then `browser_act` |
+| Capture a one-shot page | `browser_get_text_tool` or `browser_capture_tool` |
 | Work on a remote machine | use the same tool with `machine`; use `remote_*` only for worker administration |
 
 ## Connector and discovery
@@ -26,7 +28,7 @@ Search workspace files and return ChatGPT connector-compatible results.
 |---|---|---|---|
 | `query` | `string` | required |  |
 
-OAuth scopes: `shell:read`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 ### `fetch`
 
@@ -36,7 +38,7 @@ Fetch a workspace file by id returned from search.
 |---|---|---|---|
 | `id` | `string` | required |  |
 
-OAuth scopes: `shell:read`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 ## Environment, skills, and task state
 
@@ -48,7 +50,7 @@ Return version, workspace, auth, policy, and environment information locally or 
 |---|---|---|---|
 | `machine` | `string \| null` | `null` |  |
 
-OAuth scopes: `shell:read`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
 
@@ -56,7 +58,7 @@ When `machine` is supplied, the call additionally requires `remote:use` and runs
 
 List installed agent skills without loading their instructions. The MCP tool surface stays fixed; adding or removing skill directories is reflected on the next call.
 
-OAuth scopes: `shell:read`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 ### `skill_load`
 
@@ -66,7 +68,7 @@ Load one installed agent skill by the exact name returned from skills_list. Retu
 |---|---|---|---|
 | `name` | `string` | required |  |
 
-OAuth scopes: `shell:read`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 ### `skill_read_file`
 
@@ -77,7 +79,7 @@ Read one related text file from an installed Skill.
 | `name` | `string` | required |  |
 | `path` | `string` | required |  |
 
-OAuth scopes: `shell:read`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 ### `secret_scan`
 
@@ -89,13 +91,13 @@ Scan local workspace text files for common secrets before commit or push.
 | `glob` | `string \| null` | `null` |  |
 | `max_results` | `integer` | `200` |  |
 
-OAuth scopes: `shell:read`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 ### `todo_read_tool`
 
 Read the local agent todo list.
 
-OAuth scopes: `shell:read`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 ### `todo_write_tool`
 
@@ -105,7 +107,7 @@ Write the local agent todo list.
 |---|---|---|---|
 | `todos` | `array[object]` | required |  |
 
-OAuth scopes: `shell:read, shell:write`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 ### `audit_tail`
 
@@ -115,7 +117,7 @@ Read recent local audit log entries.
 |---|---|---|---|
 | `lines` | `integer` | `100` |  |
 
-OAuth scopes: `shell:read`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 ## Shells and jobs
 
@@ -133,7 +135,7 @@ Run one non-interactive shell command locally or on a remote machine. Use for bu
 | `explanation` | `string \| null` | `null` |  |
 | `machine` | `string \| null` | `null` |  |
 
-OAuth scopes: `shell:read, shell:execute`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
 
@@ -150,7 +152,7 @@ Write and run a short Python script locally or on a remote machine.
 | `explanation` | `string \| null` | `null` |  |
 | `machine` | `string \| null` | `null` |  |
 
-OAuth scopes: `shell:read, shell:execute`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
 
@@ -167,7 +169,7 @@ Start a persistent interactive shell locally or on a remote machine.
 | `explanation` | `string \| null` | `null` |  |
 | `machine` | `string \| null` | `null` |  |
 
-OAuth scopes: `shell:read, shell:execute`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
 
@@ -182,7 +184,7 @@ Send input to a persistent local or remote shell session.
 | `enter` | `boolean` | `true` |  |
 | `machine` | `string \| null` | `null` |  |
 
-OAuth scopes: `shell:read, shell:execute`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
 
@@ -196,7 +198,7 @@ Read recent output from a persistent local or remote shell session.
 | `lines` | `integer` | `200` |  |
 | `machine` | `string \| null` | `null` |  |
 
-OAuth scopes: `shell:read`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
 
@@ -209,7 +211,7 @@ Terminate a persistent local or remote shell session.
 | `session_id` | `string` | required |  |
 | `machine` | `string \| null` | `null` |  |
 
-OAuth scopes: `shell:read, shell:execute`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
 
@@ -221,7 +223,7 @@ List persistent shell sessions locally or on a remote machine.
 |---|---|---|---|
 | `machine` | `string \| null` | `null` |  |
 
-OAuth scopes: `shell:read`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
 
@@ -238,7 +240,7 @@ Start a tracked long-running job locally or on a remote machine.
 | `explanation` | `string \| null` | `null` |  |
 | `machine` | `string \| null` | `null` |  |
 
-OAuth scopes: `shell:read, shell:execute`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
 
@@ -251,7 +253,7 @@ List tracked jobs locally or on a remote machine.
 | `include_finished` | `boolean` | `true` |  |
 | `machine` | `string \| null` | `null` |  |
 
-OAuth scopes: `shell:read`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
 
@@ -265,7 +267,7 @@ Read recent output for a tracked local or remote job.
 | `lines` | `integer` | `200` |  |
 | `machine` | `string \| null` | `null` |  |
 
-OAuth scopes: `shell:read`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
 
@@ -278,7 +280,7 @@ Stop a tracked local or remote job.
 | `job_id` | `string` | required |  |
 | `machine` | `string \| null` | `null` |  |
 
-OAuth scopes: `shell:read, shell:execute`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
 
@@ -293,7 +295,7 @@ Restart a stopped or exited tracked local or remote job.
 | `explanation` | `string \| null` | `null` |  |
 | `machine` | `string \| null` | `null` |  |
 
-OAuth scopes: `shell:read, shell:execute`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
 
@@ -310,7 +312,7 @@ List files and directories locally or on a remote machine.
 | `max_entries` | `integer` | `500` |  |
 | `machine` | `string \| null` | `null` |  |
 
-OAuth scopes: `shell:read`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
 
@@ -325,7 +327,7 @@ Return a compact directory tree locally or on a remote machine.
 | `max_entries` | `integer` | `500` |  |
 | `machine` | `string \| null` | `null` |  |
 
-OAuth scopes: `shell:read`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
 
@@ -340,7 +342,7 @@ Find paths by glob locally or on a remote machine.
 | `max_results` | `integer` | `500` |  |
 | `machine` | `string \| null` | `null` |  |
 
-OAuth scopes: `shell:read`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
 
@@ -358,7 +360,7 @@ Search file contents locally or on a remote machine.
 | `max_results` | `integer \| null` | `null` |  |
 | `machine` | `string \| null` | `null` |  |
 
-OAuth scopes: `shell:read`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
 
@@ -375,7 +377,7 @@ Read one file or a list of files locally or on a remote machine.
 | `binary_preview_bytes` | `integer` | `256` |  |
 | `machine` | `string \| null` | `null` |  |
 
-OAuth scopes: `shell:read`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
 
@@ -388,7 +390,7 @@ View a PNG, JPEG, GIF, or WebP file as native MCP image content locally or on a 
 | `path` | `string` | required |  |
 | `machine` | `string \| null` | `null` |  |
 
-OAuth scopes: `shell:read`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
 
@@ -405,7 +407,7 @@ Write a UTF-8 text file locally or on a remote machine.
 | `explanation` | `string \| null` | `null` |  |
 | `machine` | `string \| null` | `null` |  |
 
-OAuth scopes: `shell:read, shell:write`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
 
@@ -421,7 +423,7 @@ Apply one or more exact-text edits to one local or remote file. Each edits entry
 | `explanation` | `string \| null` | `null` |  |
 | `machine` | `string \| null` | `null` |  |
 
-OAuth scopes: `shell:read, shell:write`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
 
@@ -437,13 +439,13 @@ Delete a local or remote file or directory. recursive=false deletes files or emp
 | `explanation` | `string \| null` | `null` |  |
 | `machine` | `string \| null` | `null` |  |
 
-OAuth scopes: `shell:read, shell:write`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
 
 ### `apply_patch`
 
-Check and apply a standard unified diff or a `*** Begin Patch` envelope locally or on a remote machine.
+Check and apply a unified diff or an apply_patch envelope locally or remotely.
 
 | Parameter | Type | Required/default | Description |
 |---|---|---|---|
@@ -453,13 +455,13 @@ Check and apply a standard unified diff or a `*** Begin Patch` envelope locally 
 | `explanation` | `string \| null` | `null` |  |
 | `machine` | `string \| null` | `null` |  |
 
-OAuth scopes: `shell:read, shell:write`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
 
 ### `transfer_path`
 
-Start a tracked job that copies a file or directory between the controller and remote machines. A missing machine denotes the controller; at least one endpoint must be remote. The call returns immediately with a job record; use `job_list`, `job_tail`, `job_stop`, and `job_retry` to follow or control it.
+Start a tracked job that copies a file or directory between the controller and remote machines. Remote uploads use resumable raw-binary chunks; use job_list, job_tail, job_stop, and job_retry to manage the transfer.
 
 | Parameter | Type | Required/default | Description |
 |---|---|---|---|
@@ -468,13 +470,13 @@ Start a tracked job that copies a file or directory between the controller and r
 | `source_machine` | `string \| null` | `null` |  |
 | `destination_machine` | `string \| null` | `null` |  |
 | `overwrite` | `boolean` | `false` |  |
-| `chunk_size` | `integer \| null` | `null` | Raw-binary chunk size for worker-to-controller upload legs. Defaults to 1 MiB and is capped at 4 MiB. |
+| `chunk_size` | `integer \| null` | `null` |  |
 | `purpose` | `string \| null` | `null` |  |
 | `explanation` | `string \| null` | `null` |  |
 
-OAuth scopes: `remote:use, shell:read, shell:write`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
-At least one of `source_machine` and `destination_machine` must be supplied. Omitted endpoints refer to the controller workspace; the source may be either a file or a directory. Worker-to-controller upload legs use transactional, resumable raw-binary chunks with per-chunk and final SHA-256 validation.
+At least one of `source_machine` and `destination_machine` must be supplied. Omitted endpoints refer to the controller workspace; the source may be either a file or a directory.
 
 ### `create_file_link`
 
@@ -488,7 +490,7 @@ Create a temporary browser-accessible URL for a local file. By default the respo
 | `max_downloads` | `integer \| null` | `null` |  |
 | `inline` | `boolean` | `false` |  |
 
-OAuth scopes: `shell:read, file:share`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 ### `list_file_links`
 
@@ -498,7 +500,7 @@ List generated local file download URLs.
 |---|---|---|---|
 | `include_expired` | `boolean` | `false` |  |
 
-OAuth scopes: `shell:read, file:share`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 ### `revoke_file_link`
 
@@ -508,9 +510,126 @@ Revoke a generated local file download URL.
 |---|---|---|---|
 | `token` | `string` | required |  |
 
-OAuth scopes: `shell:read, file:share`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
+
+## Dynamic MCP gateway
+
+### `mcp_manage`
+
+Register, list, get, enable, disable, refresh, remove, or update the isolated environment/headers of dynamic MCP servers. Use transport=stdio with command/args/cwd, or transport=streamable_http with url. Secret env/header values are persisted privately and are never returned.
+
+| Parameter | Type | Required/default | Description |
+|---|---|---|---|
+| `action` | `string` | required |  |
+| `name` | `string \| null` | `null` |  |
+| `transport` | `string \| null` | `null` |  |
+| `command` | `string \| null` | `null` |  |
+| `args` | `array[string] \| null` | `null` |  |
+| `cwd` | `string \| null` | `null` |  |
+| `url` | `string \| null` | `null` |  |
+| `env` | `object \| null` | `null` |  |
+| `headers` | `object \| null` | `null` |  |
+| `enabled` | `boolean` | `true` |  |
+| `overwrite` | `boolean` | `false` |  |
+| `refresh` | `boolean` | `true` |  |
+| `key` | `string \| null` | `null` |  |
+| `value` | `string \| null` | `null` |  |
+
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
+
+### `mcp_tool_search`
+
+Search cached lightweight tool summaries from enabled dynamic MCP servers. Dynamic tools stay out of this server's tools/list; use the returned <server>:<tool> name with mcp_tool_inspect before calling it.
+
+| Parameter | Type | Required/default | Description |
+|---|---|---|---|
+| `query` | `string` | `""` |  |
+| `server` | `string \| null` | `null` |  |
+| `limit` | `integer` | `20` |  |
+
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
+
+### `mcp_tool_inspect`
+
+Return the full cached schema for one dynamic MCP tool named <server>:<tool>. Refresh the server with mcp_manage if its cached schema is stale.
+
+| Parameter | Type | Required/default | Description |
+|---|---|---|---|
+| `name` | `string` | required |  |
+
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
+
+### `mcp_tool_call`
+
+Call one cached dynamic MCP tool named <server>:<tool>. Discover it with mcp_tool_search and inspect its schema with mcp_tool_inspect first. External MCP connections are opened only for the duration of this call.
+
+| Parameter | Type | Required/default | Description |
+|---|---|---|---|
+| `name` | `string` | required |  |
+| `arguments` | `object \| null` | `null` |  |
+| `timeout_s` | `integer \| null` | `null` |  |
+
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 ## Browser automation
+
+### `browser_session`
+
+Start, list, close, or clean up persistent high-level browser sessions locally or remotely. start can open a URL, reuse a persistent profile_id, or load storage_state_path; close can save storage state.
+
+| Parameter | Type | Required/default | Description |
+|---|---|---|---|
+| `action` | `string` | required |  |
+| `session_id` | `string \| null` | `null` |  |
+| `browser` | `string` | `"chromium"` |  |
+| `headless` | `boolean` | `true` |  |
+| `width` | `integer` | `1440` |  |
+| `height` | `integer` | `1000` |  |
+| `url` | `string \| null` | `null` |  |
+| `wait_until` | `string` | `"domcontentloaded"` |  |
+| `profile_id` | `string \| null` | `null` |  |
+| `storage_state_path` | `string \| null` | `null` |  |
+| `save_storage_state_path` | `string \| null` | `null` |  |
+| `machine` | `string \| null` | `null` |  |
+
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
+
+When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
+
+### `browser_snapshot`
+
+Capture a persistent browser page: title, URL, bounded visible text, interactive elements with stable short refs such as e1, recent page/network errors, and an optional screenshot path. Use refs directly as browser_act targets until the page navigates or a new snapshot is taken.
+
+| Parameter | Type | Required/default | Description |
+|---|---|---|---|
+| `session_id` | `string` | required |  |
+| `page_id` | `string \| null` | `null` |  |
+| `include_text` | `boolean` | `true` |  |
+| `screenshot` | `boolean` | `true` |  |
+| `full_page` | `boolean` | `false` |  |
+| `max_text_chars` | `integer` | `100000` |  |
+| `max_elements` | `integer` | `100` |  |
+| `machine` | `string \| null` | `null` |  |
+
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
+
+When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
+
+### `browser_act`
+
+Run structured actions in a persistent browser session. Supports navigate, new_page, close_page, click, fill, type, select, press, check, uncheck, hover, wait, wait_for_text, and wait_for_url. target may be a browser_snapshot ref such as e1 or a CSS selector. Use playwright_run_script_tool only when these high-level actions are insufficient.
+
+| Parameter | Type | Required/default | Description |
+|---|---|---|---|
+| `session_id` | `string` | required |  |
+| `actions` | `array[object]` | required |  |
+| `page_id` | `string \| null` | `null` |  |
+| `timeout_ms` | `integer` | `30000` |  |
+| `machine` | `string \| null` | `null` |  |
+
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
+
+When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
 
 ### `browser_capture_tool`
 
@@ -528,7 +647,7 @@ Open a URL and save a PNG screenshot or PDF locally or on a remote machine.
 | `wait_until` | `string` | `"networkidle"` |  |
 | `machine` | `string \| null` | `null` |  |
 
-OAuth scopes: `browser:use, shell:write`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
 
@@ -544,7 +663,7 @@ Open a URL and return visible text locally or on a remote machine.
 | `selector` | `string` | `"body"` |  |
 | `machine` | `string \| null` | `null` |  |
 
-OAuth scopes: `browser:use`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
 
@@ -559,7 +678,7 @@ Run a full Python Playwright script locally or on a remote machine.
 | `timeout_s` | `integer` | `60` |  |
 | `machine` | `string \| null` | `null` |  |
 
-OAuth scopes: `browser:use, shell:execute`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
 
@@ -575,13 +694,13 @@ Create a one-time command for a remote machine to join this server.
 | `workdir` | `string \| null` | `null` |  |
 | `ttl_s` | `integer \| null` | `null` |  |
 
-OAuth scopes: `remote:use`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 ### `remote_list_machines`
 
 List registered remote worker machines.
 
-OAuth scopes: `remote:use`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 ### `remote_revoke_machine`
 
@@ -591,7 +710,7 @@ Revoke and remove a remote worker machine.
 |---|---|---|---|
 | `machine` | `string` | required |  |
 
-OAuth scopes: `remote:use`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.
 
@@ -604,6 +723,6 @@ Rename a remote worker machine.
 | `machine` | `string` | required |  |
 | `new_name` | `string` | required |  |
 
-OAuth scopes: `remote:use`.
+OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, remote:use`.
 
 When `machine` is supplied, the call additionally requires `remote:use` and runs through the remote worker protocol.

--- a/scripts/generate-tools-reference.py
+++ b/scripts/generate-tools-reference.py
@@ -66,8 +66,20 @@ GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
         ),
     ),
     (
+        "Dynamic MCP gateway",
+        (
+            "mcp_manage",
+            "mcp_tool_search",
+            "mcp_tool_inspect",
+            "mcp_tool_call",
+        ),
+    ),
+    (
         "Browser automation",
         (
+            "browser_session",
+            "browser_snapshot",
+            "browser_act",
             "browser_capture_tool",
             "browser_get_text_tool",
             "playwright_run_script_tool",
@@ -139,7 +151,9 @@ async def generate() -> str:
         "| Run an interactive or long task | `shell_start` or `job_start` |",
         "| Make exact file changes | `edit_file` or `apply_patch` |",
         "| Transfer a file or directory | `transfer_path` |",
-        "| Capture a page | `browser_get_text_tool` or `browser_capture_tool` |",
+        "| Discover an external MCP capability | `mcp_tool_search`, then `mcp_tool_inspect` |",
+        "| Interact with a page | `browser_session`, `browser_snapshot`, then `browser_act` |",
+        "| Capture a one-shot page | `browser_get_text_tool` or `browser_capture_tool` |",
         "| Work on a remote machine | use the same tool with `machine`; use `remote_*` only for worker administration |",
         "",
     ]

--- a/src/local_shell_mcp/audit.py
+++ b/src/local_shell_mcp/audit.py
@@ -483,7 +483,14 @@ _TOOL_OPERATION_GROUPS: dict[str, frozenset[str]] = {
     ),
     "jobs": frozenset({"job_start", "job_list", "job_tail", "job_stop", "job_retry"}),
     "browser": frozenset(
-        {"browser_capture_tool", "browser_get_text_tool", "playwright_run_script_tool"}
+        {
+            "browser_session",
+            "browser_snapshot",
+            "browser_act",
+            "browser_capture_tool",
+            "browser_get_text_tool",
+            "playwright_run_script_tool",
+        }
     ),
     "remote": frozenset(
         {
@@ -500,6 +507,10 @@ _TOOL_OPERATION_GROUPS: dict[str, frozenset[str]] = {
             "skills_list",
             "skill_load",
             "skill_read_file",
+            "mcp_manage",
+            "mcp_tool_search",
+            "mcp_tool_inspect",
+            "mcp_tool_call",
             "todo_read_tool",
             "todo_write_tool",
             "audit_tail",

--- a/src/local_shell_mcp/browser_sessions.py
+++ b/src/local_shell_mcp/browser_sessions.py
@@ -17,6 +17,8 @@ _IDLE_TIMEOUT_S = 3600
 _MAX_ACTIONS = 50
 _MAX_SNAPSHOT_ELEMENTS = 200
 _MAX_SNAPSHOT_TEXT_CHARS = 100_000
+_MAX_BROWSER_ARTIFACT_FILES = 100
+_MAX_BROWSER_ARTIFACT_BYTES = 512 * 1024 * 1024
 _PROFILE_RE = re.compile(r"^[A-Za-z0-9._-]{1,80}$")
 _REF_ATTRIBUTE = "data-local-shell-mcp-ref"
 
@@ -54,7 +56,9 @@ class BrowserSessionManager:
     def __init__(self, state_dir: Path) -> None:
         self._state_dir = Path(state_dir)
         self._sessions: dict[str, BrowserSessionState] = {}
+        self._starting_sessions = 0
         self._lock = asyncio.Lock()
+        self._artifact_lock = asyncio.Lock()
 
     async def manage(
         self,
@@ -114,28 +118,35 @@ class BrowserSessionManager:
             raise ValueError("invalid wait_until")
         width = max(320, min(int(width), 7680))
         height = max(240, min(int(height), 4320))
-        if profile_id and not _PROFILE_RE.fullmatch(profile_id):
+        if profile_id and (
+            profile_id in {".", ".."} or not _PROFILE_RE.fullmatch(profile_id)
+        ):
             raise ValueError("profile_id must match [A-Za-z0-9._-] and be at most 80 characters")
         if profile_id and storage_state_path:
             raise ValueError("profile_id and storage_state_path cannot be combined")
 
         await self._cleanup_idle()
         async with self._lock:
-            if len(self._sessions) >= _MAX_SESSIONS:
+            if len(self._sessions) + self._starting_sessions >= _MAX_SESSIONS:
                 raise ValueError(f"at most {_MAX_SESSIONS} browser sessions may be active")
+            self._starting_sessions += 1
+        slot_reserved = True
 
-        try:
-            from playwright.async_api import async_playwright
-        except ImportError as exc:  # pragma: no cover - depends on worker environment.
-            raise RuntimeError(
-                "Playwright is not installed in this environment; install the local-shell-mcp browser dependency first"
-            ) from exc
-
-        playwright = await async_playwright().start()
-        browser_type = getattr(playwright, browser)
+        playwright = None
         browser_handle = None
         context = None
+        session = None
+        inserted = False
         try:
+            try:
+                from playwright.async_api import async_playwright
+            except ImportError as exc:  # pragma: no cover - depends on worker environment.
+                raise RuntimeError(
+                    "Playwright is not installed in this environment; install the local-shell-mcp browser dependency first"
+                ) from exc
+
+            playwright = await async_playwright().start()
+            browser_type = getattr(playwright, browser)
             viewport = {"width": width, "height": height}
             if profile_id:
                 profile_dir = self._state_dir / "browser-profiles" / profile_id
@@ -166,16 +177,32 @@ class BrowserSessionManager:
                 await page_state.page.goto(url, wait_until=wait_until, timeout=60_000)
             async with self._lock:
                 self._sessions[session.session_id] = session
+                self._starting_sessions -= 1
+                slot_reserved = False
+                inserted = True
             return await self._session_summary(session, current_page_id=page_state.page_id)
-        except Exception:
-            if context is not None:
+        except (Exception, asyncio.CancelledError):
+            if inserted and session is not None:
+                async with self._lock:
+                    self._sessions.pop(session.session_id, None)
+            if session is not None:
                 with contextlib.suppress(Exception):
-                    await context.close()
-            if browser_handle is not None:
-                with contextlib.suppress(Exception):
-                    await browser_handle.close()
-            await playwright.stop()
+                    await self._close_state(session)
+            else:
+                if context is not None:
+                    with contextlib.suppress(Exception):
+                        await context.close()
+                if browser_handle is not None:
+                    with contextlib.suppress(Exception):
+                        await browser_handle.close()
+                if playwright is not None:
+                    with contextlib.suppress(Exception):
+                        await playwright.stop()
             raise
+        finally:
+            if slot_reserved:
+                async with self._lock:
+                    self._starting_sessions -= 1
 
     async def close(
         self, session_id: str, *, save_storage_state_path: str | None = None
@@ -184,11 +211,13 @@ class BrowserSessionManager:
             session = self._sessions.pop(session_id, None)
         if session is None:
             raise ValueError(f"unknown browser session: {session_id}")
-        if save_storage_state_path:
-            target = resolve_path(save_storage_state_path)
-            target.parent.mkdir(parents=True, exist_ok=True)
-            await session.context.storage_state(path=str(target))
-        await self._close_state(session)
+        try:
+            if save_storage_state_path:
+                target = resolve_path(save_storage_state_path)
+                target.parent.mkdir(parents=True, exist_ok=True)
+                await session.context.storage_state(path=str(target))
+        finally:
+            await self._close_state(session)
         result: dict[str, Any] = {"session_id": session_id, "closed": True}
         if save_storage_state_path:
             result["storage_state_path"] = relative_display(resolve_path(save_storage_state_path))
@@ -216,16 +245,25 @@ class BrowserSessionManager:
             text = ""
             truncated = False
             if include_text:
-                text = await page.locator("body").inner_text(timeout=10_000)
-                if len(text) > max_text_chars:
-                    text = text[:max_text_chars]
-                    truncated = True
+                bounded_text = await page.locator("body").evaluate(
+                    """
+(element, limit) => {
+  const text = element.innerText || '';
+  return {text: text.slice(0, limit), truncated: text.length > limit};
+}
+""",
+                    max_text_chars,
+                )
+                text = str(bounded_text["text"])
+                truncated = bool(bounded_text["truncated"])
             screenshot_path = None
             if screenshot:
                 artifacts = self._state_dir / "browser-artifacts"
                 artifacts.mkdir(parents=True, exist_ok=True)
                 target = artifacts / f"{session_id[:12]}-{page_state.page_id}-{uuid.uuid4().hex[:8]}.png"
                 await page.screenshot(path=str(target), full_page=bool(full_page))
+                async with self._artifact_lock:
+                    await asyncio.to_thread(self._prune_artifacts, artifacts, target)
                 screenshot_path = str(target)
             await self._sync_pages(session)
             return {
@@ -543,6 +581,34 @@ class BrowserSessionManager:
                     await session.browser.close()
             finally:
                 await session.playwright.stop()
+
+    @staticmethod
+    def _prune_artifacts(directory: Path, current: Path) -> None:
+        current_size = current.stat().st_size
+        if current_size > _MAX_BROWSER_ARTIFACT_BYTES:
+            current.unlink(missing_ok=True)
+            raise ValueError("browser screenshot exceeds the artifact retention byte limit")
+
+        others = sorted(
+            (path for path in directory.glob("*.png") if path != current),
+            key=lambda path: path.stat().st_mtime,
+            reverse=True,
+        )
+        kept_files = 1
+        kept_bytes = current_size
+        for path in others:
+            try:
+                size = path.stat().st_size
+            except FileNotFoundError:
+                continue
+            if (
+                kept_files < _MAX_BROWSER_ARTIFACT_FILES
+                and kept_bytes + size <= _MAX_BROWSER_ARTIFACT_BYTES
+            ):
+                kept_files += 1
+                kept_bytes += size
+                continue
+            path.unlink(missing_ok=True)
 
 
 _BROWSER_MANAGERS: dict[str, BrowserSessionManager] = {}

--- a/src/local_shell_mcp/browser_sessions.py
+++ b/src/local_shell_mcp/browser_sessions.py
@@ -1,0 +1,557 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import re
+import time
+import uuid
+from collections import deque
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .fs_ops import relative_display, resolve_path
+
+_MAX_SESSIONS = 8
+_IDLE_TIMEOUT_S = 3600
+_MAX_ACTIONS = 50
+_MAX_SNAPSHOT_ELEMENTS = 200
+_MAX_SNAPSHOT_TEXT_CHARS = 100_000
+_PROFILE_RE = re.compile(r"^[A-Za-z0-9._-]{1,80}$")
+_REF_ATTRIBUTE = "data-local-shell-mcp-ref"
+
+
+@dataclass(slots=True)
+class BrowserPageState:
+    page_id: str
+    page: Any
+    refs: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class BrowserSessionState:
+    session_id: str
+    playwright: Any
+    context: Any
+    browser: Any | None
+    browser_name: str
+    profile_id: str | None
+    created_at: float
+    last_used_at: float
+    pages: dict[str, BrowserPageState] = field(default_factory=dict)
+    errors: deque[dict[str, Any]] = field(default_factory=lambda: deque(maxlen=100))
+    network: deque[dict[str, Any]] = field(default_factory=lambda: deque(maxlen=100))
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+
+class BrowserSessionManager:
+    """Persistent Playwright sessions for high-level browser tools.
+
+    Playwright is imported lazily so remote workers can still bootstrap on machines where the
+    browser dependency is not installed until a browser tool is actually invoked.
+    """
+
+    def __init__(self, state_dir: Path) -> None:
+        self._state_dir = Path(state_dir)
+        self._sessions: dict[str, BrowserSessionState] = {}
+        self._lock = asyncio.Lock()
+
+    async def manage(
+        self,
+        *,
+        action: str,
+        session_id: str | None = None,
+        browser: str = "chromium",
+        headless: bool = True,
+        width: int = 1440,
+        height: int = 1000,
+        url: str | None = None,
+        wait_until: str = "domcontentloaded",
+        profile_id: str | None = None,
+        storage_state_path: str | None = None,
+        save_storage_state_path: str | None = None,
+    ) -> dict[str, Any]:
+        action = action.strip().lower()
+        if action == "start":
+            return await self.start(
+                browser=browser,
+                headless=headless,
+                width=width,
+                height=height,
+                url=url,
+                wait_until=wait_until,
+                profile_id=profile_id,
+                storage_state_path=storage_state_path,
+            )
+        if action == "list":
+            await self._cleanup_idle()
+            async with self._lock:
+                sessions = list(self._sessions.values())
+            return {"sessions": [await self._session_summary(item) for item in sessions]}
+        if action == "close":
+            if not session_id:
+                raise ValueError("session_id is required for action=close")
+            return await self.close(session_id, save_storage_state_path=save_storage_state_path)
+        if action == "cleanup":
+            return {"closed": await self._cleanup_idle(force=True)}
+        raise ValueError("action must be start, list, close, or cleanup")
+
+    async def start(
+        self,
+        *,
+        browser: str = "chromium",
+        headless: bool = True,
+        width: int = 1440,
+        height: int = 1000,
+        url: str | None = None,
+        wait_until: str = "domcontentloaded",
+        profile_id: str | None = None,
+        storage_state_path: str | None = None,
+    ) -> dict[str, Any]:
+        if browser not in {"chromium", "firefox", "webkit"}:
+            raise ValueError("browser must be chromium, firefox, or webkit")
+        if wait_until not in {"load", "domcontentloaded", "networkidle", "commit"}:
+            raise ValueError("invalid wait_until")
+        width = max(320, min(int(width), 7680))
+        height = max(240, min(int(height), 4320))
+        if profile_id and not _PROFILE_RE.fullmatch(profile_id):
+            raise ValueError("profile_id must match [A-Za-z0-9._-] and be at most 80 characters")
+        if profile_id and storage_state_path:
+            raise ValueError("profile_id and storage_state_path cannot be combined")
+
+        await self._cleanup_idle()
+        async with self._lock:
+            if len(self._sessions) >= _MAX_SESSIONS:
+                raise ValueError(f"at most {_MAX_SESSIONS} browser sessions may be active")
+
+        try:
+            from playwright.async_api import async_playwright
+        except ImportError as exc:  # pragma: no cover - depends on worker environment.
+            raise RuntimeError(
+                "Playwright is not installed in this environment; install the local-shell-mcp browser dependency first"
+            ) from exc
+
+        playwright = await async_playwright().start()
+        browser_type = getattr(playwright, browser)
+        browser_handle = None
+        context = None
+        try:
+            viewport = {"width": width, "height": height}
+            if profile_id:
+                profile_dir = self._state_dir / "browser-profiles" / profile_id
+                profile_dir.mkdir(parents=True, exist_ok=True)
+                context = await browser_type.launch_persistent_context(
+                    user_data_dir=str(profile_dir), headless=headless, viewport=viewport
+                )
+            else:
+                browser_handle = await browser_type.launch(headless=headless)
+                context_options: dict[str, Any] = {"viewport": viewport}
+                if storage_state_path:
+                    state_path = resolve_path(storage_state_path, must_exist=True)
+                    context_options["storage_state"] = str(state_path)
+                context = await browser_handle.new_context(**context_options)
+
+            session = BrowserSessionState(
+                session_id=uuid.uuid4().hex,
+                playwright=playwright,
+                context=context,
+                browser=browser_handle,
+                browser_name=browser,
+                profile_id=profile_id,
+                created_at=time.time(),
+                last_used_at=time.time(),
+            )
+            page_state = await self._ensure_page(session)
+            if url:
+                await page_state.page.goto(url, wait_until=wait_until, timeout=60_000)
+            async with self._lock:
+                self._sessions[session.session_id] = session
+            return await self._session_summary(session, current_page_id=page_state.page_id)
+        except Exception:
+            if context is not None:
+                with contextlib.suppress(Exception):
+                    await context.close()
+            if browser_handle is not None:
+                with contextlib.suppress(Exception):
+                    await browser_handle.close()
+            await playwright.stop()
+            raise
+
+    async def close(
+        self, session_id: str, *, save_storage_state_path: str | None = None
+    ) -> dict[str, Any]:
+        async with self._lock:
+            session = self._sessions.pop(session_id, None)
+        if session is None:
+            raise ValueError(f"unknown browser session: {session_id}")
+        if save_storage_state_path:
+            target = resolve_path(save_storage_state_path)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            await session.context.storage_state(path=str(target))
+        await self._close_state(session)
+        result: dict[str, Any] = {"session_id": session_id, "closed": True}
+        if save_storage_state_path:
+            result["storage_state_path"] = relative_display(resolve_path(save_storage_state_path))
+        return result
+
+    async def snapshot(
+        self,
+        session_id: str,
+        *,
+        page_id: str | None = None,
+        include_text: bool = True,
+        screenshot: bool = True,
+        full_page: bool = False,
+        max_text_chars: int = _MAX_SNAPSHOT_TEXT_CHARS,
+        max_elements: int = 100,
+    ) -> dict[str, Any]:
+        session = await self._get_session(session_id)
+        async with session.lock:
+            page_state = await self._select_page(session, page_id)
+            page = page_state.page
+            session.last_used_at = time.time()
+            max_text_chars = max(0, min(int(max_text_chars), _MAX_SNAPSHOT_TEXT_CHARS))
+            max_elements = max(1, min(int(max_elements), _MAX_SNAPSHOT_ELEMENTS))
+            elements = await self._capture_interactive_elements(page_state, max_elements)
+            text = ""
+            truncated = False
+            if include_text:
+                text = await page.locator("body").inner_text(timeout=10_000)
+                if len(text) > max_text_chars:
+                    text = text[:max_text_chars]
+                    truncated = True
+            screenshot_path = None
+            if screenshot:
+                artifacts = self._state_dir / "browser-artifacts"
+                artifacts.mkdir(parents=True, exist_ok=True)
+                target = artifacts / f"{session_id[:12]}-{page_state.page_id}-{uuid.uuid4().hex[:8]}.png"
+                await page.screenshot(path=str(target), full_page=bool(full_page))
+                screenshot_path = str(target)
+            await self._sync_pages(session)
+            return {
+                "session_id": session_id,
+                "page_id": page_state.page_id,
+                "title": await page.title(),
+                "url": page.url,
+                "pages": await self._page_summaries(session),
+                "text": text if include_text else None,
+                "text_truncated": truncated,
+                "interactive_elements": elements,
+                "errors": list(session.errors)[-20:],
+                "network": list(session.network)[-30:],
+                "screenshot_path": screenshot_path,
+            }
+
+    async def act(
+        self,
+        session_id: str,
+        actions: list[dict[str, Any]],
+        *,
+        page_id: str | None = None,
+        timeout_ms: int = 30_000,
+    ) -> dict[str, Any]:
+        if not actions:
+            raise ValueError("actions must contain at least one browser action")
+        if len(actions) > _MAX_ACTIONS:
+            raise ValueError(f"actions may contain at most {_MAX_ACTIONS} entries")
+        timeout_ms = max(1, min(int(timeout_ms), 120_000))
+        session = await self._get_session(session_id)
+        results: list[dict[str, Any]] = []
+        async with session.lock:
+            current = await self._select_page(session, page_id)
+            session.last_used_at = time.time()
+            for index, raw_action in enumerate(actions):
+                if not isinstance(raw_action, dict):
+                    raise ValueError(f"actions[{index}] must be an object")
+                action = str(raw_action.get("action") or "").strip().lower()
+                if not action:
+                    raise ValueError(f"actions[{index}].action is required")
+                result, current = await self._run_action(
+                    session, current, action, raw_action, timeout_ms
+                )
+                results.append({"index": index, "action": action, **result})
+            await self._sync_pages(session)
+            return {
+                "session_id": session_id,
+                "page_id": current.page_id,
+                "title": await current.page.title(),
+                "url": current.page.url,
+                "pages": await self._page_summaries(session),
+                "results": results,
+            }
+
+    async def _run_action(
+        self,
+        session: BrowserSessionState,
+        current: BrowserPageState,
+        action: str,
+        data: dict[str, Any],
+        timeout_ms: int,
+    ) -> tuple[dict[str, Any], BrowserPageState]:
+        page = current.page
+        if action == "navigate":
+            url = str(data.get("url") or "").strip()
+            if not url:
+                raise ValueError("navigate requires url")
+            wait_until = str(data.get("wait_until") or "domcontentloaded")
+            if wait_until not in {"load", "domcontentloaded", "networkidle", "commit"}:
+                raise ValueError("invalid wait_until")
+            response = await page.goto(url, wait_until=wait_until, timeout=timeout_ms)
+            return {"status": response.status if response else None, "url": page.url}, current
+        if action == "new_page":
+            page = await session.context.new_page()
+            current = self._register_page(session, page)
+            url = str(data.get("url") or "").strip()
+            if url:
+                await page.goto(url, wait_until="domcontentloaded", timeout=timeout_ms)
+            return {"page_id": current.page_id, "url": page.url}, current
+        if action == "close_page":
+            await page.close()
+            await self._sync_pages(session)
+            current = await self._select_page(session, None)
+            return {"closed": True, "page_id": current.page_id}, current
+        if action == "wait":
+            milliseconds = max(0, min(int(data.get("ms", 1000)), 30_000))
+            await page.wait_for_timeout(milliseconds)
+            return {"waited_ms": milliseconds}, current
+        if action == "wait_for_text":
+            text = str(data.get("text") or "")
+            if not text:
+                raise ValueError("wait_for_text requires text")
+            await page.get_by_text(text).first.wait_for(timeout=timeout_ms)
+            return {"matched": text}, current
+        if action == "wait_for_url":
+            url = str(data.get("url") or "")
+            if not url:
+                raise ValueError("wait_for_url requires url")
+            await page.wait_for_url(url, timeout=timeout_ms)
+            return {"url": page.url}, current
+
+        target = str(data.get("target") or "").strip()
+        if not target:
+            raise ValueError(f"{action} requires target")
+        locator = self._locator(current, target)
+        if action == "click":
+            await locator.click(timeout=timeout_ms)
+        elif action == "fill":
+            await locator.fill(str(data.get("value") or ""), timeout=timeout_ms)
+        elif action == "type":
+            await locator.press_sequentially(str(data.get("value") or ""), timeout=timeout_ms)
+        elif action == "select":
+            value = data.get("value")
+            if isinstance(value, list):
+                await locator.select_option([str(item) for item in value], timeout=timeout_ms)
+            else:
+                await locator.select_option(str(value or ""), timeout=timeout_ms)
+        elif action == "press":
+            key = str(data.get("key") or "").strip()
+            if not key:
+                raise ValueError("press requires key")
+            await locator.press(key, timeout=timeout_ms)
+        elif action == "check":
+            await locator.check(timeout=timeout_ms)
+        elif action == "uncheck":
+            await locator.uncheck(timeout=timeout_ms)
+        elif action == "hover":
+            await locator.hover(timeout=timeout_ms)
+        else:
+            raise ValueError(
+                "unsupported browser action; use navigate, new_page, close_page, click, fill, type, "
+                "select, press, check, uncheck, hover, wait, wait_for_text, or wait_for_url"
+            )
+        return {"target": target}, current
+
+    async def _capture_interactive_elements(
+        self, page_state: BrowserPageState, max_elements: int
+    ) -> list[dict[str, Any]]:
+        token = uuid.uuid4().hex[:12]
+        raw = await page_state.page.locator(
+            "a,button,input,textarea,select,[role='button'],[role='link'],[contenteditable='true']"
+        ).evaluate_all(
+            """
+(elements, payload) => {
+  const [attribute, token, maxElements] = payload;
+  const visible = elements.filter((element) => {
+    const style = window.getComputedStyle(element);
+    const rect = element.getBoundingClientRect();
+    return style.visibility !== 'hidden' && style.display !== 'none' && rect.width > 0 && rect.height > 0;
+  }).slice(0, maxElements);
+  return visible.map((element, index) => {
+    const ref = `e${index + 1}`;
+    const marker = `${token}-${ref}`;
+    element.setAttribute(attribute, marker);
+    const text = (element.innerText || element.value || element.getAttribute('aria-label') || element.getAttribute('title') || '').trim().slice(0, 500);
+    return {
+      ref,
+      marker,
+      tag: element.tagName.toLowerCase(),
+      role: element.getAttribute('role'),
+      type: element.getAttribute('type'),
+      text,
+      name: element.getAttribute('name'),
+      placeholder: element.getAttribute('placeholder'),
+      href: element.href || null,
+      disabled: Boolean(element.disabled),
+    };
+  });
+}
+""",
+            [_REF_ATTRIBUTE, token, max_elements],
+        )
+        page_state.refs = {
+            str(item["ref"]): f'[{_REF_ATTRIBUTE}="{item.pop("marker")}"]' for item in raw
+        }
+        return raw
+
+    def _locator(self, page_state: BrowserPageState, target: str) -> Any:
+        selector = page_state.refs.get(target, target)
+        return page_state.page.locator(selector).first
+
+    async def _get_session(self, session_id: str) -> BrowserSessionState:
+        await self._cleanup_idle()
+        async with self._lock:
+            session = self._sessions.get(session_id)
+        if session is None:
+            raise ValueError(f"unknown browser session: {session_id}")
+        return session
+
+    async def _ensure_page(self, session: BrowserSessionState) -> BrowserPageState:
+        await self._sync_pages(session)
+        if session.pages:
+            return next(iter(session.pages.values()))
+        return self._register_page(session, await session.context.new_page())
+
+    async def _select_page(
+        self, session: BrowserSessionState, page_id: str | None
+    ) -> BrowserPageState:
+        await self._sync_pages(session)
+        if page_id:
+            page = session.pages.get(page_id)
+            if page is None:
+                raise ValueError(f"unknown browser page: {page_id}")
+            return page
+        if session.pages:
+            return next(reversed(session.pages.values()))
+        return self._register_page(session, await session.context.new_page())
+
+    async def _sync_pages(self, session: BrowserSessionState) -> None:
+        live_pages = [page for page in session.context.pages if not page.is_closed()]
+        live_ids = {id(page) for page in live_pages}
+        for page_id, state in list(session.pages.items()):
+            if id(state.page) not in live_ids:
+                session.pages.pop(page_id, None)
+        known = {id(state.page) for state in session.pages.values()}
+        for page in live_pages:
+            if id(page) not in known:
+                self._register_page(session, page)
+
+    def _register_page(self, session: BrowserSessionState, page: Any) -> BrowserPageState:
+        for state in session.pages.values():
+            if state.page is page:
+                return state
+        state = BrowserPageState(page_id=uuid.uuid4().hex[:12], page=page)
+        session.pages[state.page_id] = state
+        page.on(
+            "pageerror",
+            lambda error, page_id=state.page_id: session.errors.append(
+                {"page_id": page_id, "kind": "pageerror", "message": str(error)}
+            ),
+        )
+        page.on(
+            "console",
+            lambda message, page_id=state.page_id: self._record_console_error(
+                session, page_id, message
+            ),
+        )
+        page.on(
+            "requestfailed",
+            lambda request, page_id=state.page_id: session.errors.append(
+                {
+                    "page_id": page_id,
+                    "kind": "requestfailed",
+                    "method": request.method,
+                    "url": request.url,
+                    "failure": request.failure,
+                }
+            ),
+        )
+        page.on(
+            "response",
+            lambda response, page_id=state.page_id: session.network.append(
+                {
+                    "page_id": page_id,
+                    "method": response.request.method,
+                    "status": response.status,
+                    "url": response.url,
+                }
+            ),
+        )
+        return state
+
+    @staticmethod
+    def _record_console_error(session: BrowserSessionState, page_id: str, message: Any) -> None:
+        if message.type == "error":
+            session.errors.append(
+                {"page_id": page_id, "kind": "console", "message": message.text}
+            )
+
+    async def _session_summary(
+        self, session: BrowserSessionState, *, current_page_id: str | None = None
+    ) -> dict[str, Any]:
+        await self._sync_pages(session)
+        return {
+            "session_id": session.session_id,
+            "browser": session.browser_name,
+            "profile_id": session.profile_id,
+            "current_page_id": current_page_id,
+            "pages": await self._page_summaries(session),
+            "created_at": session.created_at,
+            "last_used_at": session.last_used_at,
+        }
+
+    @staticmethod
+    async def _page_summaries(session: BrowserSessionState) -> list[dict[str, Any]]:
+        rows = []
+        for state in session.pages.values():
+            if state.page.is_closed():
+                continue
+            rows.append(
+                {"page_id": state.page_id, "title": await state.page.title(), "url": state.page.url}
+            )
+        return rows
+
+    async def _cleanup_idle(self, *, force: bool = False) -> int:
+        cutoff = time.time() - _IDLE_TIMEOUT_S
+        async with self._lock:
+            stale_ids = [
+                session_id
+                for session_id, state in self._sessions.items()
+                if force or state.last_used_at < cutoff
+            ]
+            stale = [self._sessions.pop(session_id) for session_id in stale_ids]
+        for session in stale:
+            await self._close_state(session)
+        return len(stale)
+
+    @staticmethod
+    async def _close_state(session: BrowserSessionState) -> None:
+        try:
+            await session.context.close()
+        finally:
+            try:
+                if session.browser is not None:
+                    await session.browser.close()
+            finally:
+                await session.playwright.stop()
+
+
+_BROWSER_MANAGERS: dict[str, BrowserSessionManager] = {}
+
+
+def get_browser_session_manager(state_dir: Path) -> BrowserSessionManager:
+    key = str(Path(state_dir).resolve())
+    manager = _BROWSER_MANAGERS.get(key)
+    if manager is None:
+        manager = BrowserSessionManager(Path(state_dir))
+        _BROWSER_MANAGERS[key] = manager
+    return manager

--- a/src/local_shell_mcp/dynamic_mcp.py
+++ b/src/local_shell_mcp/dynamic_mcp.py
@@ -65,6 +65,30 @@ def _tool_json(tool: Any) -> dict[str, Any]:
     raise TypeError(f"unsupported MCP tool descriptor: {type(tool).__name__}")
 
 
+def _config_key(server: DynamicMCPServer) -> tuple[Any, ...]:
+    return (
+        server.transport,
+        server.command,
+        tuple(server.args),
+        server.cwd,
+        server.url,
+        tuple(sorted(server.env.items())),
+        tuple(sorted(server.headers.items())),
+    )
+
+
+def _redact_config_secrets(message: str, server: DynamicMCPServer) -> str:
+    redacted = message
+    secrets = sorted(
+        {value for value in (*server.env.values(), *server.headers.values()) if value},
+        key=len,
+        reverse=True,
+    )
+    for secret in secrets:
+        redacted = redacted.replace(secret, "<redacted>")
+    return redacted
+
+
 @dataclass(slots=True)
 class DynamicMCPServer:
     name: str
@@ -311,7 +335,9 @@ class DynamicMCPManager:
                     "action": action,
                     "server": server.public(),
                     "refreshed": False,
-                    "refresh_error": str(exc) or type(exc).__name__,
+                    "refresh_error": _redact_config_secrets(
+                        str(exc) or type(exc).__name__, server
+                    ),
                 }
             return {"action": action, **refreshed}
 
@@ -343,6 +369,8 @@ class DynamicMCPManager:
                     target[clean_key] = value
                 else:
                     target.pop(clean_key, None)
+                server.tools = []
+                server.refreshed_at = None
             else:
                 raise ValueError(
                     "action must be register, list, get, enable, disable, remove, refresh, "
@@ -359,12 +387,17 @@ class DynamicMCPManager:
             if server is None:
                 raise ValueError(f"unknown dynamic MCP server: {name}")
             config = DynamicMCPServer.from_json(server.to_json())
+            config_key = _config_key(config)
         tools = await self._fetch_tools(config)
         async with self._lock:
             servers = self._load()
             current = servers.get(name)
             if current is None:
                 raise ValueError(f"dynamic MCP server was removed while refreshing: {name}")
+            if _config_key(current) != config_key:
+                raise RuntimeError(
+                    f"dynamic MCP server configuration changed while refreshing: {name}"
+                )
             current.tools = tools
             current.refreshed_at = _now_iso()
             current.updated_at = current.refreshed_at

--- a/src/local_shell_mcp/dynamic_mcp.py
+++ b/src/local_shell_mcp/dynamic_mcp.py
@@ -1,0 +1,479 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+import re
+import shlex
+import tempfile
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+from mcp.client.streamable_http import streamablehttp_client
+
+from .fs_ops import resolve_path
+from .shell_ops import check_command_policy
+
+_REGISTRY_VERSION = 1
+_MAX_TOOLS_PER_SERVER = 512
+_SERVER_NAME_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
+_INHERITED_ENV_KEYS = {
+    "COMSPEC",
+    "HOME",
+    "LANG",
+    "LC_ALL",
+    "PATH",
+    "PATHEXT",
+    "SHELL",
+    "SYSTEMROOT",
+    "TEMP",
+    "TERM",
+    "TMP",
+    "TMPDIR",
+    "USER",
+    "USERNAME",
+    "WINDIR",
+}
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _string_dict(value: dict[str, Any] | None, *, label: str) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for key, item in (value or {}).items():
+        name = str(key).strip()
+        if not name:
+            raise ValueError(f"{label} keys must not be empty")
+        if not isinstance(item, str):
+            raise ValueError(f"{label} values must be strings")
+        result[name] = item
+    return result
+
+
+def _tool_json(tool: Any) -> dict[str, Any]:
+    if hasattr(tool, "model_dump"):
+        return tool.model_dump(mode="json", by_alias=True, exclude_none=True)
+    raise TypeError(f"unsupported MCP tool descriptor: {type(tool).__name__}")
+
+
+@dataclass(slots=True)
+class DynamicMCPServer:
+    name: str
+    transport: str
+    enabled: bool = True
+    command: str | None = None
+    args: list[str] = field(default_factory=list)
+    cwd: str | None = None
+    url: str | None = None
+    env: dict[str, str] = field(default_factory=dict)
+    headers: dict[str, str] = field(default_factory=dict)
+    tools: list[dict[str, Any]] = field(default_factory=list)
+    refreshed_at: str | None = None
+    updated_at: str = field(default_factory=_now_iso)
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> DynamicMCPServer:
+        return cls(
+            name=str(data["name"]),
+            transport=str(data["transport"]),
+            enabled=bool(data.get("enabled", True)),
+            command=data.get("command"),
+            args=[str(item) for item in data.get("args", [])],
+            cwd=data.get("cwd"),
+            url=data.get("url"),
+            env=_string_dict(data.get("env"), label="env"),
+            headers=_string_dict(data.get("headers"), label="headers"),
+            tools=[dict(item) for item in data.get("tools", []) if isinstance(item, dict)],
+            refreshed_at=data.get("refreshed_at"),
+            updated_at=str(data.get("updated_at") or _now_iso()),
+        )
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "transport": self.transport,
+            "enabled": self.enabled,
+            "command": self.command,
+            "args": self.args,
+            "cwd": self.cwd,
+            "url": self.url,
+            "env": self.env,
+            "headers": self.headers,
+            "tools": self.tools,
+            "refreshed_at": self.refreshed_at,
+            "updated_at": self.updated_at,
+        }
+
+    def public(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "transport": self.transport,
+            "enabled": self.enabled,
+            "command": self.command if self.transport == "stdio" else None,
+            "args": list(self.args) if self.transport == "stdio" else [],
+            "cwd": self.cwd if self.transport == "stdio" else None,
+            "url": self.url if self.transport == "streamable_http" else None,
+            "env_keys": sorted(self.env),
+            "header_keys": sorted(self.headers),
+            "tool_count": len(self.tools),
+            "refreshed_at": self.refreshed_at,
+            "updated_at": self.updated_at,
+        }
+
+
+class DynamicMCPManager:
+    """Persistent registry and progressive-disclosure gateway for external MCP servers.
+
+    Configurations and cached tool schemas are persisted. External stdio/HTTP connections are
+    opened only for refresh and tool calls, so dynamic servers never expand this MCP server's
+    own tools/list surface and do not require long-lived child processes.
+    """
+
+    def __init__(self, state_dir: Path, *, max_timeout_s: int = 3600) -> None:
+        self._path = Path(state_dir) / "dynamic-mcp.json"
+        self._max_timeout_s = max(1, int(max_timeout_s))
+        self._lock = asyncio.Lock()
+
+    def _load(self) -> dict[str, DynamicMCPServer]:
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return {}
+        except (OSError, json.JSONDecodeError) as exc:
+            raise RuntimeError(f"unable to read dynamic MCP registry: {exc}") from exc
+        if raw.get("version") != _REGISTRY_VERSION:
+            raise RuntimeError("unsupported dynamic MCP registry version")
+        servers: dict[str, DynamicMCPServer] = {}
+        for item in raw.get("servers", []):
+            if not isinstance(item, dict):
+                continue
+            server = DynamicMCPServer.from_json(item)
+            servers[server.name] = server
+        return servers
+
+    def _save(self, servers: dict[str, DynamicMCPServer]) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps(
+            {
+                "version": _REGISTRY_VERSION,
+                "servers": [servers[name].to_json() for name in sorted(servers)],
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        fd, temporary_name = tempfile.mkstemp(
+            prefix=f".{self._path.name}.", suffix=".tmp", dir=self._path.parent
+        )
+        temporary = Path(temporary_name)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(payload)
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            with contextlib.suppress(OSError):
+                temporary.chmod(0o600)
+            os.replace(temporary, self._path)
+            with contextlib.suppress(OSError):
+                self._path.chmod(0o600)
+        except Exception:
+            with contextlib.suppress(OSError):
+                temporary.unlink(missing_ok=True)
+            raise
+
+    @staticmethod
+    def _validate_config(server: DynamicMCPServer) -> None:
+        if not _SERVER_NAME_RE.fullmatch(server.name):
+            raise ValueError("name must match [A-Za-z0-9._-] and be at most 64 characters")
+        if server.transport not in {"stdio", "streamable_http"}:
+            raise ValueError("transport must be stdio or streamable_http")
+        if server.transport == "stdio":
+            if not server.command or not server.command.strip():
+                raise ValueError("command is required for stdio MCP servers")
+            if server.url:
+                raise ValueError("url is only valid for streamable_http MCP servers")
+        else:
+            if not server.url or not server.url.startswith(("http://", "https://")):
+                raise ValueError("an absolute HTTP(S) url is required for streamable_http MCP servers")
+            if server.command:
+                raise ValueError("command is only valid for stdio MCP servers")
+
+    @asynccontextmanager
+    async def _session(self, server: DynamicMCPServer) -> AsyncIterator[ClientSession]:
+        if server.transport == "stdio":
+            env = {key: value for key, value in os.environ.items() if key.upper() in _INHERITED_ENV_KEYS}
+            env.update(server.env)
+            params = StdioServerParameters(
+                command=server.command or "",
+                args=list(server.args),
+                cwd=server.cwd,
+                env=env,
+            )
+            async with (
+                stdio_client(params) as (read_stream, write_stream),
+                ClientSession(read_stream, write_stream) as session,
+            ):
+                await session.initialize()
+                yield session
+            return
+
+        async with streamablehttp_client(server.url or "", headers=dict(server.headers)) as streams:
+            read_stream, write_stream, _ = streams
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                yield session
+
+    async def _fetch_tools(self, server: DynamicMCPServer) -> list[dict[str, Any]]:
+        tools: list[dict[str, Any]] = []
+        cursor: str | None = None
+        async with asyncio.timeout(min(30, self._max_timeout_s)):
+            async with self._session(server) as session:
+                while True:
+                    response = await session.list_tools(cursor=cursor)
+                    tools.extend(_tool_json(tool) for tool in response.tools)
+                    if len(tools) > _MAX_TOOLS_PER_SERVER:
+                        raise ValueError(
+                            f"dynamic MCP server exposes more than {_MAX_TOOLS_PER_SERVER} tools"
+                        )
+                    cursor = response.nextCursor
+                    if not cursor:
+                        break
+        return tools
+
+    async def manage(
+        self,
+        *,
+        action: str,
+        name: str | None = None,
+        transport: str | None = None,
+        command: str | None = None,
+        args: list[str] | None = None,
+        cwd: str | None = None,
+        url: str | None = None,
+        env: dict[str, Any] | None = None,
+        headers: dict[str, Any] | None = None,
+        enabled: bool = True,
+        overwrite: bool = False,
+        refresh: bool = True,
+        key: str | None = None,
+        value: str | None = None,
+    ) -> dict[str, Any]:
+        action = action.strip().lower()
+        if action == "list":
+            async with self._lock:
+                servers = self._load()
+            return {"servers": [servers[item].public() for item in sorted(servers)]}
+
+        clean_name = (name or "").strip()
+        if not clean_name:
+            raise ValueError("name is required")
+
+        if action == "register":
+            normalized_transport = (transport or "stdio").strip().lower()
+            normalized_args = [str(item) for item in (args or [])]
+            normalized_command = command.strip() if command else None
+            if normalized_transport == "stdio" and normalized_command:
+                check_command_policy(shlex.join([normalized_command, *normalized_args]))
+            server = DynamicMCPServer(
+                name=clean_name,
+                transport=normalized_transport,
+                enabled=enabled,
+                command=normalized_command,
+                args=normalized_args,
+                cwd=str(resolve_path(cwd.strip())) if cwd else None,
+                url=url.strip() if url else None,
+                env=_string_dict(env, label="env"),
+                headers=_string_dict(headers, label="headers"),
+            )
+            self._validate_config(server)
+            async with self._lock:
+                servers = self._load()
+                if server.name in servers and not overwrite:
+                    raise ValueError(f"dynamic MCP server already exists: {server.name}")
+                servers[server.name] = server
+                self._save(servers)
+            if not refresh:
+                return {"action": action, "server": server.public(), "refreshed": False}
+            try:
+                refreshed = await self.refresh(clean_name)
+            except Exception as exc:
+                return {
+                    "action": action,
+                    "server": server.public(),
+                    "refreshed": False,
+                    "refresh_error": str(exc) or type(exc).__name__,
+                }
+            return {"action": action, **refreshed}
+
+        if action == "refresh":
+            return {"action": action, **(await self.refresh(clean_name))}
+
+        async with self._lock:
+            servers = self._load()
+            server = servers.get(clean_name)
+            if server is None:
+                raise ValueError(f"unknown dynamic MCP server: {clean_name}")
+
+            if action == "get":
+                return {"action": action, "server": server.public()}
+            if action in {"enable", "disable"}:
+                server.enabled = action == "enable"
+            elif action == "remove":
+                del servers[clean_name]
+                self._save(servers)
+                return {"action": action, "name": clean_name, "removed": True}
+            elif action in {"env_set", "env_unset", "header_set", "header_unset"}:
+                clean_key = (key or "").strip()
+                if not clean_key:
+                    raise ValueError("key is required")
+                target = server.env if action.startswith("env_") else server.headers
+                if action.endswith("_set"):
+                    if value is None:
+                        raise ValueError("value is required")
+                    target[clean_key] = value
+                else:
+                    target.pop(clean_key, None)
+            else:
+                raise ValueError(
+                    "action must be register, list, get, enable, disable, remove, refresh, "
+                    "env_set, env_unset, header_set, or header_unset"
+                )
+            server.updated_at = _now_iso()
+            self._save(servers)
+            return {"action": action, "server": server.public()}
+
+    async def refresh(self, name: str) -> dict[str, Any]:
+        async with self._lock:
+            servers = self._load()
+            server = servers.get(name)
+            if server is None:
+                raise ValueError(f"unknown dynamic MCP server: {name}")
+            config = DynamicMCPServer.from_json(server.to_json())
+        tools = await self._fetch_tools(config)
+        async with self._lock:
+            servers = self._load()
+            current = servers.get(name)
+            if current is None:
+                raise ValueError(f"dynamic MCP server was removed while refreshing: {name}")
+            current.tools = tools
+            current.refreshed_at = _now_iso()
+            current.updated_at = current.refreshed_at
+            self._save(servers)
+            return {"server": current.public(), "refreshed": True}
+
+    async def search(
+        self, query: str = "", *, server: str | None = None, limit: int = 20
+    ) -> dict[str, Any]:
+        limit = max(1, min(int(limit), 100))
+        tokens = [token for token in query.lower().split() if token]
+        async with self._lock:
+            servers = self._load()
+        selected = [servers[server]] if server and server in servers else []
+        if server and not selected:
+            raise ValueError(f"unknown dynamic MCP server: {server}")
+        if not server:
+            selected = [item for item in servers.values() if item.enabled]
+
+        matches: list[tuple[int, dict[str, Any]]] = []
+        unrefreshed: list[str] = []
+        for item in selected:
+            if not item.enabled:
+                continue
+            if not item.tools:
+                unrefreshed.append(item.name)
+            for tool in item.tools:
+                name = str(tool.get("name") or "")
+                title = str(tool.get("title") or "")
+                description = str(tool.get("description") or "")
+                haystack = f"{item.name}:{name} {title} {description}".lower()
+                if tokens and not all(token in haystack for token in tokens):
+                    continue
+                score = 0
+                qualified = f"{item.name}:{name}".lower()
+                for token in tokens:
+                    if token in qualified:
+                        score += 4
+                    elif token in title.lower():
+                        score += 2
+                    else:
+                        score += 1
+                matches.append(
+                    (
+                        score,
+                        {
+                            "name": f"{item.name}:{name}",
+                            "server": item.name,
+                            "tool": name,
+                            "title": title or None,
+                            "description": description or None,
+                        },
+                    )
+                )
+        matches.sort(key=lambda pair: (-pair[0], pair[1]["name"]))
+        return {
+            "tools": [item for _, item in matches[:limit]],
+            "count": min(len(matches), limit),
+            "total_matches": len(matches),
+            "unrefreshed_servers": sorted(unrefreshed),
+        }
+
+    async def inspect(self, qualified_name: str) -> dict[str, Any]:
+        server_name, tool_name = self._split_qualified_name(qualified_name)
+        async with self._lock:
+            servers = self._load()
+            server = servers.get(server_name)
+        if server is None:
+            raise ValueError(f"unknown dynamic MCP server: {server_name}")
+        for tool in server.tools:
+            if tool.get("name") == tool_name:
+                return {"name": qualified_name, "server": server.public(), "tool": tool}
+        raise ValueError(
+            f"unknown cached tool {qualified_name}; refresh the server before inspecting it"
+        )
+
+    async def call(
+        self,
+        qualified_name: str,
+        arguments: dict[str, Any] | None = None,
+        *,
+        timeout_s: int | None = None,
+    ) -> dict[str, Any]:
+        server_name, tool_name = self._split_qualified_name(qualified_name)
+        async with self._lock:
+            servers = self._load()
+            server = servers.get(server_name)
+            if server is None:
+                raise ValueError(f"unknown dynamic MCP server: {server_name}")
+            config = DynamicMCPServer.from_json(server.to_json())
+        if not config.enabled:
+            raise ValueError(f"dynamic MCP server is disabled: {server_name}")
+        if not any(tool.get("name") == tool_name for tool in config.tools):
+            raise ValueError(
+                f"unknown cached tool {qualified_name}; refresh the server before calling it"
+            )
+        requested_timeout = 60 if timeout_s is None else int(timeout_s)
+        bounded_timeout = max(1, min(requested_timeout, self._max_timeout_s))
+        async with asyncio.timeout(bounded_timeout):
+            async with self._session(config) as session:
+                result = await session.call_tool(tool_name, arguments or {})
+        return {
+            "name": qualified_name,
+            "result": result.model_dump(mode="json", by_alias=True, exclude_none=True),
+        }
+
+    @staticmethod
+    def _split_qualified_name(value: str) -> tuple[str, str]:
+        server_name, separator, tool_name = value.strip().partition(":")
+        if not separator or not server_name or not tool_name:
+            raise ValueError("dynamic MCP tool names must use <server>:<tool>")
+        return server_name, tool_name

--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -29,6 +29,7 @@ from typing import Any
 
 from . import __version__
 from .audit import audit, suppress_audit
+from .browser_sessions import get_browser_session_manager
 from .errors import (
     PathNotFoundError,
     ShellExecutableNotFoundError,
@@ -1127,6 +1128,9 @@ WORKER_TRANSFER_TOOLS = frozenset(
 )
 WORKER_BROWSER_TOOLS = frozenset(
     {
+        "browser_session",
+        "browser_snapshot",
+        "browser_act",
         "browser_capture_tool",
         "browser_get_text_tool",
         "playwright_run_script_tool",
@@ -1557,6 +1561,41 @@ async def _execute_transfer_worker_tool(tool: str, args: dict[str, Any]) -> Any:
 
 
 async def _execute_browser_worker_tool(tool: str, args: dict[str, Any]) -> Any:
+    session_manager = get_browser_session_manager(get_settings().state_dir)
+    if tool == "browser_session":
+        return await session_manager.manage(
+            action=args["action"],
+            session_id=args.get("session_id"),
+            browser=args.get("browser", "chromium"),
+            headless=args.get("headless", True),
+            width=args.get("width", 1440),
+            height=args.get("height", 1000),
+            url=args.get("url"),
+            wait_until=args.get("wait_until", "domcontentloaded"),
+            profile_id=args.get("profile_id"),
+            storage_state_path=args.get("storage_state_path"),
+            save_storage_state_path=args.get("save_storage_state_path"),
+        )
+
+    if tool == "browser_snapshot":
+        return await session_manager.snapshot(
+            args["session_id"],
+            page_id=args.get("page_id"),
+            include_text=args.get("include_text", True),
+            screenshot=args.get("screenshot", True),
+            full_page=args.get("full_page", False),
+            max_text_chars=args.get("max_text_chars", 100_000),
+            max_elements=args.get("max_elements", 100),
+        )
+
+    if tool == "browser_act":
+        return await session_manager.act(
+            args["session_id"],
+            args["actions"],
+            page_id=args.get("page_id"),
+            timeout_ms=args.get("timeout_ms", 30_000),
+        )
+
     if tool == "browser_capture_tool":
         return await browser_capture(
             args["url"],
@@ -1612,6 +1651,7 @@ def worker_capabilities() -> list[str]:
         "search",
         "python",
         "playwright",
+        "browser_sessions",
     ]
 
 

--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -21,7 +21,9 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from .audit import audit, audit_call_context, audit_result_ok
 from .auth import require_current_scopes
+from .browser_sessions import get_browser_session_manager
 from .downloads import create_share_link, list_share_links, revoke_share_link
+from .dynamic_mcp import DynamicMCPManager
 from .errors import (
     PathNotFoundError,
     ShellExecutableNotFoundError,
@@ -267,7 +269,9 @@ MCP_INSTRUCTIONS = (
     "to discover the exact Skill name and description. Before following a Skill's "
     "workflow, call skill_load with that exact name. Call skill_read_file only when "
     "a related file returned by skill_load is needed. Skills use this fixed tool "
-    "surface; do not expect per-Skill MCP tools."
+    "surface; do not expect per-Skill MCP tools. When a registered external MCP may "
+    "provide a capability, use mcp_tool_search, then mcp_tool_inspect, then mcp_tool_call; "
+    "dynamic MCP tools never appear directly in tools/list."
 )
 
 
@@ -286,6 +290,7 @@ NON_CANCELLABLE_TOOL_NAMES = frozenset(
         "apply_patch",
         "transfer_path",
         "todo_write_tool",
+        "mcp_tool_call",
     }
 )
 
@@ -357,6 +362,40 @@ def _audit_tool_arguments(args: tuple[Any, ...], kwargs: dict[str, Any]) -> dict
     }
 
 
+def _safe_audit_call_arguments(tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    if tool_name == "mcp_tool_call":
+        dynamic_arguments = arguments.get("arguments")
+        return {
+            "name": arguments.get("name"),
+            "argument_keys": sorted(dynamic_arguments) if isinstance(dynamic_arguments, dict) else [],
+            "timeout_s": arguments.get("timeout_s"),
+        }
+    if tool_name == "mcp_manage":
+        safe = dict(arguments)
+        for field_name in ("env", "headers"):
+            value = safe.get(field_name)
+            if isinstance(value, dict):
+                safe[field_name] = {str(key): "<redacted>" for key in value}
+        if str(safe.get("action") or "").lower() in {"env_set", "header_set"}:
+            safe["value"] = "<redacted>"
+        return safe
+    if tool_name == "browser_act":
+        safe = dict(arguments)
+        actions = safe.get("actions")
+        if isinstance(actions, list):
+            safe["actions"] = [
+                {
+                    str(key): "<redacted>" if key == "value" else value
+                    for key, value in action.items()
+                }
+                if isinstance(action, dict)
+                else action
+                for action in actions
+            ]
+        return safe
+    return arguments
+
+
 def _audit_tool_purpose(
     tool_name: str, purpose: str | None = None, explanation: str | None = None
 ) -> dict[str, str]:
@@ -423,9 +462,10 @@ def _install_mcp_tool_watchdogs(mcp: FastMCP) -> None:
                 call_arguments = dict(kwargs)
             if any(call_arguments.get(name) for name in REMOTE_MACHINE_ARGUMENTS):
                 require_current_scopes(("remote:use",))
+            safe_call_arguments = _safe_audit_call_arguments(__tool_name, call_arguments)
             arguments = {
                 "positional_count": len(args),
-                "keyword_args": _serialize_audit_value(call_arguments),
+                "keyword_args": _serialize_audit_value(safe_call_arguments),
             }
             audit_context = {
                 name: call_arguments[name]
@@ -542,6 +582,9 @@ MACHINE_CAPABLE_TOOL_NAMES = {
     "edit_file",
     "delete_file_or_dir",
     "apply_patch",
+    "browser_session",
+    "browser_snapshot",
+    "browser_act",
     "browser_capture_tool",
     "browser_get_text_tool",
     "playwright_run_script_tool",
@@ -552,9 +595,12 @@ OPEN_WORLD_TOOL_NAMES = {
     "create_file_link",
     "revoke_file_link",
     "transfer_path",
+    "mcp_manage",
+    "mcp_tool_call",
 }
 
 READ_ONLY_OPEN_WORLD_TOOL_NAMES = {
+    "browser_snapshot",
     "browser_get_text_tool",
 }
 
@@ -2039,10 +2085,153 @@ def _register_maintenance_tools(mcp: FastMCP, read_only_tool: ToolAnnotations) -
         return await _tool_call(asyncio.to_thread, _read_audit_tail_entries, lines)
 
 
+def _register_dynamic_mcp_tools(
+    mcp: FastMCP, settings: Any, read_only_tool: ToolAnnotations
+) -> None:
+    manager = DynamicMCPManager(settings.state_dir, max_timeout_s=settings.max_timeout_s)
+    shell_read_meta = _oauth_meta(["shell:read"])
+    shell_execute_meta = _oauth_meta(["shell:read", "shell:execute"])
+
+    @mcp.tool(structured_output=True, meta=shell_execute_meta)
+    async def mcp_manage(
+        action: str,
+        name: str | None = None,
+        transport: str | None = None,
+        command: str | None = None,
+        args: list[str] | None = None,
+        cwd: str | None = None,
+        url: str | None = None,
+        env: dict[str, Any] | None = None,
+        headers: dict[str, Any] | None = None,
+        enabled: bool = True,
+        overwrite: bool = False,
+        refresh: bool = True,
+        key: str | None = None,
+        value: str | None = None,
+    ) -> ToolResult:
+        """Register, list, get, enable, disable, refresh, remove, or update the isolated environment/headers of dynamic MCP servers. Use transport=stdio with command/args/cwd, or transport=streamable_http with url. Secret env/header values are persisted privately and are never returned."""
+        return await _tool_call(
+            manager.manage,
+            action=action,
+            name=name,
+            transport=transport,
+            command=command,
+            args=args,
+            cwd=cwd,
+            url=url,
+            env=env,
+            headers=headers,
+            enabled=enabled,
+            overwrite=overwrite,
+            refresh=refresh,
+            key=key,
+            value=value,
+        )
+
+    @mcp.tool(structured_output=True, annotations=read_only_tool, meta=shell_read_meta)
+    async def mcp_tool_search(
+        query: str = "", server: str | None = None, limit: int = 20
+    ) -> ToolResult:
+        """Search cached lightweight tool summaries from enabled dynamic MCP servers. Dynamic tools stay out of this server's tools/list; use the returned <server>:<tool> name with mcp_tool_inspect before calling it."""
+        return await _tool_call(manager.search, query, server=server, limit=limit)
+
+    @mcp.tool(structured_output=True, annotations=read_only_tool, meta=shell_read_meta)
+    async def mcp_tool_inspect(name: str) -> ToolResult:
+        """Return the full cached schema for one dynamic MCP tool named <server>:<tool>. Refresh the server with mcp_manage if its cached schema is stale."""
+        return await _tool_call(manager.inspect, name)
+
+    @mcp.tool(structured_output=True, meta=shell_execute_meta)
+    async def mcp_tool_call(
+        name: str,
+        arguments: dict[str, Any] | None = None,
+        timeout_s: int | None = None,
+    ) -> ToolResult:
+        """Call one cached dynamic MCP tool named <server>:<tool>. Discover it with mcp_tool_search and inspect its schema with mcp_tool_inspect first. External MCP connections are opened only for the duration of this call."""
+        return await _tool_call(manager.call, name, arguments, timeout_s=timeout_s)
+
+
 def _register_browser_tools(mcp: FastMCP, settings: Any, read_only_tool: ToolAnnotations) -> None:
     browser_meta = _oauth_meta(["browser:use"])
     browser_write_meta = _oauth_meta(["browser:use", "shell:write"])
     browser_execute_meta = _oauth_meta(["browser:use", "shell:execute"])
+    session_manager = get_browser_session_manager(settings.state_dir)
+
+    @mcp.tool(structured_output=True, meta=browser_meta)
+    async def browser_session(
+        action: str,
+        session_id: str | None = None,
+        browser: str = "chromium",
+        headless: bool = True,
+        width: int = 1440,
+        height: int = 1000,
+        url: str | None = None,
+        wait_until: str = "domcontentloaded",
+        profile_id: str | None = None,
+        storage_state_path: str | None = None,
+        save_storage_state_path: str | None = None,
+        machine: str | None = None,
+    ) -> ToolResult:
+        """Start, list, close, or clean up persistent high-level browser sessions locally or remotely. start can open a URL, reuse a persistent profile_id, or load storage_state_path; close can save storage state."""
+        args = {
+            "action": action,
+            "session_id": session_id,
+            "browser": browser,
+            "headless": headless,
+            "width": width,
+            "height": height,
+            "url": url,
+            "wait_until": wait_until,
+            "profile_id": profile_id,
+            "storage_state_path": storage_state_path,
+            "save_storage_state_path": save_storage_state_path,
+        }
+        if machine:
+            return await _remote_call(settings, machine, "browser_session", args)
+        return await _tool_call(session_manager.manage, **args)
+
+    @mcp.tool(structured_output=True, annotations=read_only_tool, meta=browser_meta)
+    async def browser_snapshot(
+        session_id: str,
+        page_id: str | None = None,
+        include_text: bool = True,
+        screenshot: bool = True,
+        full_page: bool = False,
+        max_text_chars: int = 100_000,
+        max_elements: int = 100,
+        machine: str | None = None,
+    ) -> ToolResult:
+        """Capture a persistent browser page: title, URL, bounded visible text, interactive elements with stable short refs such as e1, recent page/network errors, and an optional screenshot path. Use refs directly as browser_act targets until the page navigates or a new snapshot is taken."""
+        args = {
+            "session_id": session_id,
+            "page_id": page_id,
+            "include_text": include_text,
+            "screenshot": screenshot,
+            "full_page": full_page,
+            "max_text_chars": max_text_chars,
+            "max_elements": max_elements,
+        }
+        if machine:
+            return await _remote_call(settings, machine, "browser_snapshot", args)
+        return await _tool_call(session_manager.snapshot, **args)
+
+    @mcp.tool(structured_output=True, meta=browser_meta)
+    async def browser_act(
+        session_id: str,
+        actions: list[dict[str, Any]],
+        page_id: str | None = None,
+        timeout_ms: int = 30_000,
+        machine: str | None = None,
+    ) -> ToolResult:
+        """Run structured actions in a persistent browser session. Supports navigate, new_page, close_page, click, fill, type, select, press, check, uncheck, hover, wait, wait_for_text, and wait_for_url. target may be a browser_snapshot ref such as e1 or a CSS selector. Use playwright_run_script_tool only when these high-level actions are insufficient."""
+        args = {
+            "session_id": session_id,
+            "actions": actions,
+            "page_id": page_id,
+            "timeout_ms": timeout_ms,
+        }
+        if machine:
+            return await _remote_call(settings, machine, "browser_act", args)
+        return await _tool_call(session_manager.act, **args)
 
     @mcp.tool(structured_output=True, meta=browser_write_meta)
     async def browser_capture_tool(
@@ -2160,6 +2349,7 @@ def build_mcp() -> FastMCP:
     _register_download_tools(mcp, read_only_tool)
     _register_workspace_write_tools(mcp, settings)
     _register_maintenance_tools(mcp, read_only_tool)
+    _register_dynamic_mcp_tools(mcp, settings, read_only_tool)
     _register_browser_tools(mcp, settings, read_only_tool)
     _register_remote_admin_tools(mcp, read_only_tool)
 

--- a/tests/test_audit_ui_complete.py
+++ b/tests/test_audit_ui_complete.py
@@ -46,6 +46,8 @@ def test_audit_call_helpers_cover_legacy_unpaired_and_optional_fields():
     assert audit_module._operation_type({"event": "run_shell_start"}) == "shell"
     assert audit_module._operation_type({"event": "job_started"}) == "jobs"
     assert audit_module._operation_type({"event": "browser_capture"}) == "browser"
+    assert audit_module._operation_type({"tool": "browser_snapshot"}) == "browser"
+    assert audit_module._operation_type({"tool": "mcp_tool_call"}) == "agent"
     assert audit_module._operation_type({"event": "download_created"}) == "files"
     assert audit_module._operation_type({"event": "transfer_completed"}) == "remote"
     assert audit_module._operation_type({"tool": "transfer_path"}) == "remote"

--- a/tests/test_browser_sessions.py
+++ b/tests/test_browser_sessions.py
@@ -1,13 +1,33 @@
 from __future__ import annotations
 
+import asyncio
 import time
 from pathlib import Path
 
 import pytest
 
 from local_shell_mcp import browser_sessions
-from local_shell_mcp.browser_sessions import BrowserSessionManager, get_browser_session_manager
+from local_shell_mcp.browser_sessions import (
+    BrowserSessionManager,
+    BrowserSessionState,
+    get_browser_session_manager,
+)
 from local_shell_mcp.settings import get_settings
+
+
+def _chromium_installed() -> bool:
+    try:
+        from playwright.sync_api import sync_playwright
+
+        with sync_playwright() as playwright:
+            return Path(playwright.chromium.executable_path).is_file()
+    except Exception:
+        return False
+
+
+requires_chromium = pytest.mark.skipif(
+    not _chromium_installed(), reason="Playwright Chromium is not installed in this test environment"
+)
 
 
 @pytest.fixture(autouse=True)
@@ -51,8 +71,9 @@ def _pages(tmp_path: Path) -> tuple[str, str]:
     return first.as_uri(), second.as_uri()
 
 
+@requires_chromium
 @pytest.mark.asyncio
-async def test_browser_session_snapshot_refs_actions_and_storage_state(tmp_path):
+async def test_browser_session_snapshot_refs_actions_and_storage_state(tmp_path, monkeypatch):
     first_url, second_url = _pages(tmp_path)
     manager = BrowserSessionManager(tmp_path / ".state")
 
@@ -77,6 +98,11 @@ async def test_browser_session_snapshot_refs_actions_and_storage_state(tmp_path)
     ]
     assert any(item["kind"] == "console" for item in snapshot["errors"])
     assert any(item["kind"] in {"pageerror", "requestfailed"} for item in snapshot["errors"])
+
+    monkeypatch.setattr(browser_sessions, "_MAX_BROWSER_ARTIFACT_FILES", 2)
+    for _ in range(3):
+        await manager.snapshot(session_id, page_id=page_id, screenshot=True, include_text=False)
+    assert len(list((tmp_path / ".state" / "browser-artifacts").glob("*.png"))) == 2
 
     acted = await manager.act(
         session_id,
@@ -153,6 +179,7 @@ async def test_browser_session_snapshot_refs_actions_and_storage_state(tmp_path)
     await manager.close(restored["session_id"])
 
 
+@requires_chromium
 @pytest.mark.asyncio
 async def test_profiles_lists_cleanup_limits_and_singleton(tmp_path, monkeypatch):
     first_url, _ = _pages(tmp_path)
@@ -182,6 +209,7 @@ async def test_profiles_lists_cleanup_limits_and_singleton(tmp_path, monkeypatch
         await manager.close(one["session_id"])
 
 
+@requires_chromium
 @pytest.mark.asyncio
 async def test_browser_validation_and_action_errors(tmp_path, monkeypatch):
     first_url, _ = _pages(tmp_path)
@@ -238,6 +266,166 @@ async def test_browser_validation_and_action_errors(tmp_path, monkeypatch):
         timeout_ms=999999,
     )
     await manager.close(session_id)
+
+
+@pytest.mark.asyncio
+async def test_profile_dot_segments_are_rejected_without_starting_browser(tmp_path):
+    manager = BrowserSessionManager(tmp_path / ".state")
+    for profile_id in (".", ".."):
+        with pytest.raises(ValueError, match="profile_id"):
+            await manager.start(profile_id=profile_id)
+
+
+@pytest.mark.asyncio
+async def test_start_reserves_slot_during_launch_and_releases_it_on_cancel(tmp_path, monkeypatch):
+    manager = BrowserSessionManager(tmp_path / ".state")
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    stopped = {"value": False}
+
+    class BlockingBrowserType:
+        async def launch(self, **_kwargs):
+            entered.set()
+            await release.wait()
+            raise AssertionError("cancelled launch should not resume")
+
+    class FakePlaywright:
+        chromium = BlockingBrowserType()
+        firefox = BlockingBrowserType()
+        webkit = BlockingBrowserType()
+
+        async def stop(self):
+            stopped["value"] = True
+
+    class Starter:
+        async def start(self):
+            return FakePlaywright()
+
+    monkeypatch.setattr(browser_sessions, "_MAX_SESSIONS", 1)
+    monkeypatch.setattr("playwright.async_api.async_playwright", lambda: Starter())
+    task = asyncio.create_task(manager.start())
+    await entered.wait()
+    with pytest.raises(ValueError, match="at most 1 browser sessions"):
+        await manager.start()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert manager._starting_sessions == 0
+    assert stopped["value"] is True
+
+
+@pytest.mark.asyncio
+async def test_start_cancellation_after_registration_removes_and_closes_session(
+    tmp_path, monkeypatch
+):
+    manager = BrowserSessionManager(tmp_path / ".state")
+    summary_entered = asyncio.Event()
+    context_closed = {"value": False}
+    browser_closed = {"value": False}
+    playwright_stopped = {"value": False}
+
+    class FakePage:
+        url = "about:blank"
+
+        def is_closed(self):
+            return False
+
+        def on(self, *_args):
+            return None
+
+        async def title(self):
+            return ""
+
+    class FakeContext:
+        def __init__(self):
+            self.pages = []
+
+        async def new_page(self):
+            page = FakePage()
+            self.pages.append(page)
+            return page
+
+        async def close(self):
+            context_closed["value"] = True
+
+    context = FakeContext()
+
+    class FakeBrowser:
+        async def new_context(self, **_kwargs):
+            return context
+
+        async def close(self):
+            browser_closed["value"] = True
+
+    class FakeBrowserType:
+        async def launch(self, **_kwargs):
+            return FakeBrowser()
+
+    class FakePlaywright:
+        chromium = FakeBrowserType()
+        firefox = FakeBrowserType()
+        webkit = FakeBrowserType()
+
+        async def stop(self):
+            playwright_stopped["value"] = True
+
+    class Starter:
+        async def start(self):
+            return FakePlaywright()
+
+    async def blocked_summary(_session, **_kwargs):
+        summary_entered.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr("playwright.async_api.async_playwright", lambda: Starter())
+    monkeypatch.setattr(manager, "_session_summary", blocked_summary)
+    task = asyncio.create_task(manager.start())
+    await summary_entered.wait()
+    assert len(manager._sessions) == 1
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert manager._sessions == {}
+    assert context_closed["value"] is True
+    assert browser_closed["value"] is True
+    assert playwright_stopped["value"] is True
+
+
+@pytest.mark.asyncio
+async def test_close_releases_browser_when_storage_state_save_fails(tmp_path):
+    manager = BrowserSessionManager(tmp_path / ".state")
+    closed = {"context": False, "browser": False, "playwright": False}
+
+    class Context:
+        async def storage_state(self, **_kwargs):
+            raise RuntimeError("save failed")
+
+        async def close(self):
+            closed["context"] = True
+
+    class Browser:
+        async def close(self):
+            closed["browser"] = True
+
+    class Playwright:
+        async def stop(self):
+            closed["playwright"] = True
+
+    session = BrowserSessionState(
+        session_id="session",
+        playwright=Playwright(),
+        context=Context(),
+        browser=Browser(),
+        browser_name="chromium",
+        profile_id=None,
+        created_at=time.time(),
+        last_used_at=time.time(),
+    )
+    manager._sessions[session.session_id] = session
+    with pytest.raises(RuntimeError, match="save failed"):
+        await manager.close("session", save_storage_state_path="state.json")
+    assert manager._sessions == {}
+    assert closed == {"context": True, "browser": True, "playwright": True}
 
 
 @pytest.mark.asyncio

--- a/tests/test_browser_sessions.py
+++ b/tests/test_browser_sessions.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from local_shell_mcp import browser_sessions
+from local_shell_mcp.browser_sessions import BrowserSessionManager, get_browser_session_manager
+from local_shell_mcp.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _settings(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(tmp_path / ".state"))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_AUTH_MODE", "none")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _pages(tmp_path: Path) -> tuple[str, str]:
+    second = tmp_path / "second.html"
+    second.write_text(
+        "<html><head><title>Second</title></head><body><p>second page</p></body></html>",
+        encoding="utf-8",
+    )
+    first = tmp_path / "index.html"
+    first.write_text(
+        f"""
+<html>
+<head><title>Browser Test</title></head>
+<body>
+  <button id="button" onclick="document.querySelector('#status').textContent='clicked'">Click me</button>
+  <input id="input" placeholder="type here">
+  <select id="select"><option value="a">A</option><option value="b">B</option></select>
+  <input id="check" type="checkbox">
+  <a id="link" href="{second.as_uri()}">Second page</a>
+  <div id="status">ready</div>
+  <img src="missing.png">
+  <script>
+    console.error('console-boom');
+    setTimeout(() => {{ throw new Error('page-boom'); }}, 0);
+  </script>
+</body>
+</html>
+""".strip(),
+        encoding="utf-8",
+    )
+    return first.as_uri(), second.as_uri()
+
+
+@pytest.mark.asyncio
+async def test_browser_session_snapshot_refs_actions_and_storage_state(tmp_path):
+    first_url, second_url = _pages(tmp_path)
+    manager = BrowserSessionManager(tmp_path / ".state")
+
+    started = await manager.manage(action="start", url=first_url, width=900, height=700)
+    session_id = started["session_id"]
+    page_id = started["current_page_id"]
+    assert started["browser"] == "chromium"
+    assert started["pages"][0]["title"] == "Browser Test"
+
+    await manager.act(session_id, [{"action": "wait", "ms": 30}], page_id=page_id)
+    snapshot = await manager.snapshot(
+        session_id, page_id=page_id, screenshot=True, max_text_chars=12, max_elements=50
+    )
+    assert snapshot["text_truncated"] is True
+    assert Path(snapshot["screenshot_path"]).is_file()
+    assert [row["ref"] for row in snapshot["interactive_elements"][:5]] == [
+        "e1",
+        "e2",
+        "e3",
+        "e4",
+        "e5",
+    ]
+    assert any(item["kind"] == "console" for item in snapshot["errors"])
+    assert any(item["kind"] in {"pageerror", "requestfailed"} for item in snapshot["errors"])
+
+    acted = await manager.act(
+        session_id,
+        [
+            {"action": "fill", "target": "e2", "value": "hello"},
+            {"action": "press", "target": "#input", "key": "End"},
+            {"action": "type", "target": "#input", "value": "!"},
+            {"action": "select", "target": "#select", "value": "b"},
+            {"action": "check", "target": "#check"},
+            {"action": "uncheck", "target": "#check"},
+            {"action": "hover", "target": "#button"},
+            {"action": "click", "target": "e1"},
+            {"action": "wait_for_text", "text": "clicked"},
+            {"action": "wait", "ms": 1},
+        ],
+        page_id=page_id,
+    )
+    assert acted["page_id"] == page_id
+    assert acted["results"][0]["target"] == "e2"
+
+    state = await manager._get_session(session_id)
+    original_page = state.pages[page_id].page
+    assert await original_page.locator("#input").input_value() == "hello!"
+    assert await original_page.locator("#select").input_value() == "b"
+    assert await original_page.locator("#check").is_checked() is False
+    assert await original_page.locator("#status").inner_text() == "clicked"
+
+    new_page = await manager.act(
+        session_id,
+        [
+            {"action": "new_page", "url": second_url},
+            {"action": "wait_for_url", "url": second_url},
+        ],
+    )
+    second_page_id = new_page["page_id"]
+    assert second_page_id != page_id
+    assert new_page["title"] == "Second"
+    closed_page = await manager.act(
+        session_id, [{"action": "close_page"}], page_id=second_page_id
+    )
+    assert closed_page["page_id"] == page_id
+
+    navigated = await manager.act(
+        session_id,
+        [
+            {"action": "navigate", "url": second_url, "wait_until": "load"},
+            {"action": "wait_for_url", "url": second_url},
+        ],
+        page_id=page_id,
+    )
+    assert navigated["title"] == "Second"
+    no_text = await manager.snapshot(
+        session_id,
+        page_id=page_id,
+        include_text=False,
+        screenshot=False,
+        full_page=True,
+        max_elements=1,
+    )
+    assert no_text["text"] is None
+    assert no_text["screenshot_path"] is None
+
+    storage_path = "browser-state.json"
+    closed = await manager.manage(
+        action="close", session_id=session_id, save_storage_state_path=storage_path
+    )
+    assert closed["closed"] is True
+    assert (tmp_path / storage_path).is_file()
+
+    restored = await manager.manage(
+        action="start", url=first_url, storage_state_path=storage_path
+    )
+    assert restored["pages"][0]["title"] == "Browser Test"
+    await manager.close(restored["session_id"])
+
+
+@pytest.mark.asyncio
+async def test_profiles_lists_cleanup_limits_and_singleton(tmp_path, monkeypatch):
+    first_url, _ = _pages(tmp_path)
+    manager = BrowserSessionManager(tmp_path / ".state")
+
+    profile = await manager.start(url=first_url, profile_id="profile-1")
+    assert profile["profile_id"] == "profile-1"
+    assert (tmp_path / ".state" / "browser-profiles" / "profile-1").is_dir()
+    listed = await manager.manage(action="list")
+    assert [item["session_id"] for item in listed["sessions"]] == [profile["session_id"]]
+
+    same_a = get_browser_session_manager(tmp_path / ".singleton")
+    same_b = get_browser_session_manager(tmp_path / ".singleton")
+    assert same_a is same_b
+
+    state = await manager._get_session(profile["session_id"])
+    state.last_used_at = time.time() - browser_sessions._IDLE_TIMEOUT_S - 1
+    assert (await manager.manage(action="list"))["sessions"] == []
+
+    monkeypatch.setattr(browser_sessions, "_MAX_SESSIONS", 1)
+    one = await manager.start(url=first_url)
+    with pytest.raises(ValueError, match="at most 1 browser sessions"):
+        await manager.start(url=first_url)
+    cleanup = await manager.manage(action="cleanup")
+    assert cleanup["closed"] == 1
+    with pytest.raises(ValueError, match="unknown browser session"):
+        await manager.close(one["session_id"])
+
+
+@pytest.mark.asyncio
+async def test_browser_validation_and_action_errors(tmp_path, monkeypatch):
+    first_url, _ = _pages(tmp_path)
+    manager = BrowserSessionManager(tmp_path / ".state")
+
+    with pytest.raises(ValueError, match="browser must be"):
+        await manager.start(browser="netscape")
+    with pytest.raises(ValueError, match="invalid wait_until"):
+        await manager.start(wait_until="later")
+    with pytest.raises(ValueError, match="profile_id"):
+        await manager.start(profile_id="bad profile")
+    with pytest.raises(ValueError, match="cannot be combined"):
+        await manager.start(profile_id="p", storage_state_path="state.json")
+    with pytest.raises(ValueError, match="action must be"):
+        await manager.manage(action="wat")
+    with pytest.raises(ValueError, match="session_id is required"):
+        await manager.manage(action="close")
+    with pytest.raises(ValueError, match="unknown browser session"):
+        await manager.snapshot("missing")
+
+    started = await manager.start(url=first_url)
+    session_id = started["session_id"]
+    with pytest.raises(ValueError, match="unknown browser page"):
+        await manager.snapshot(session_id, page_id="missing")
+    with pytest.raises(ValueError, match="at least one"):
+        await manager.act(session_id, [])
+    with pytest.raises(ValueError, match="at most"):
+        await manager.act(session_id, [{"action": "wait"}] * (browser_sessions._MAX_ACTIONS + 1))
+    with pytest.raises(ValueError, match=r"actions\[0\] must be an object"):
+        await manager.act(session_id, ["bad"])
+    with pytest.raises(ValueError, match=r"actions\[0\]\.action is required"):
+        await manager.act(session_id, [{}])
+    with pytest.raises(ValueError, match="requires url"):
+        await manager.act(session_id, [{"action": "navigate"}])
+    with pytest.raises(ValueError, match="invalid wait_until"):
+        await manager.act(
+            session_id,
+            [{"action": "navigate", "url": first_url, "wait_until": "later"}],
+        )
+    with pytest.raises(ValueError, match="requires text"):
+        await manager.act(session_id, [{"action": "wait_for_text"}])
+    with pytest.raises(ValueError, match="requires url"):
+        await manager.act(session_id, [{"action": "wait_for_url"}])
+    with pytest.raises(ValueError, match="requires target"):
+        await manager.act(session_id, [{"action": "click"}])
+    with pytest.raises(ValueError, match="press requires key"):
+        await manager.act(session_id, [{"action": "press", "target": "#input"}])
+    with pytest.raises(ValueError, match="unsupported browser action"):
+        await manager.act(session_id, [{"action": "dance", "target": "#input"}])
+
+    await manager.act(
+        session_id,
+        [{"action": "select", "target": "#select", "value": ["a"]}],
+        timeout_ms=999999,
+    )
+    await manager.close(session_id)
+
+
+@pytest.mark.asyncio
+async def test_start_failure_stops_playwright(tmp_path, monkeypatch):
+    manager = BrowserSessionManager(tmp_path / ".state")
+    stopped = {"value": False}
+
+    class BrokenBrowserType:
+        async def launch(self, **_kwargs):
+            raise RuntimeError("launch failed")
+
+    class FakePlaywright:
+        chromium = BrokenBrowserType()
+        firefox = BrokenBrowserType()
+        webkit = BrokenBrowserType()
+
+        async def stop(self):
+            stopped["value"] = True
+
+    class Starter:
+        async def start(self):
+            return FakePlaywright()
+
+    monkeypatch.setattr("playwright.async_api.async_playwright", lambda: Starter())
+    with pytest.raises(RuntimeError, match="launch failed"):
+        await manager.start()
+    assert stopped["value"] is True

--- a/tests/test_dynamic_mcp.py
+++ b/tests/test_dynamic_mcp.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+import os
+import sys
+from contextlib import asynccontextmanager
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from mcp.types import CallToolResult, TextContent, Tool
+
+from local_shell_mcp import dynamic_mcp
+from local_shell_mcp.dynamic_mcp import DynamicMCPManager
+from local_shell_mcp.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _settings(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(tmp_path / ".state"))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_AUTH_MODE", "none")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_ALLOW_FULL_CONTAINER", "false")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _server_script(path: Path) -> Path:
+    script = path / "demo_mcp.py"
+    script.write_text(
+        """
+from mcp.server.fastmcp import FastMCP
+mcp = FastMCP("demo")
+
+@mcp.tool()
+def echo(text: str) -> str:
+    return "echo:" + text
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    return script
+
+
+@pytest.mark.asyncio
+async def test_stdio_gateway_round_trip_persists_cache_and_redacts_config(tmp_path):
+    state_dir = tmp_path / ".state"
+    manager = DynamicMCPManager(state_dir)
+    script = _server_script(tmp_path)
+
+    registered = await manager.manage(
+        action="register",
+        name="demo",
+        transport="stdio",
+        command=sys.executable,
+        args=[str(script)],
+        cwd=str(tmp_path),
+        env={"DEMO_TOKEN": "very-secret"},
+        headers={"Authorization": "Bearer also-secret"},
+    )
+    public = registered["server"]
+    assert registered["refreshed"] is True
+    assert public["tool_count"] == 1
+    assert public["env_keys"] == ["DEMO_TOKEN"]
+    assert public["header_keys"] == ["Authorization"]
+    assert "very-secret" not in repr(public)
+    assert "also-secret" not in repr(public)
+    if os.name != "nt":
+        assert (state_dir / "dynamic-mcp.json").stat().st_mode & 0o777 == 0o600
+
+    found = await manager.search("echo")
+    assert found["tools"][0]["name"] == "demo:echo"
+    inspected = await manager.inspect("demo:echo")
+    assert inspected["tool"]["inputSchema"]["required"] == ["text"]
+    called = await manager.call("demo:echo", {"text": "hello"})
+    assert called["result"]["content"][0]["text"] == "echo:hello"
+
+    reloaded = DynamicMCPManager(state_dir)
+    assert (await reloaded.search("echo"))["tools"][0]["name"] == "demo:echo"
+    listed = await reloaded.manage(action="list")
+    assert listed["servers"][0]["name"] == "demo"
+    assert (await reloaded.manage(action="get", name="demo"))["server"]["tool_count"] == 1
+
+    await reloaded.manage(action="env_set", name="demo", key="EXTRA", value="secret")
+    await reloaded.manage(action="header_set", name="demo", key="X-Test", value="secret")
+    changed = await reloaded.manage(action="get", name="demo")
+    assert changed["server"]["env_keys"] == ["DEMO_TOKEN", "EXTRA"]
+    assert changed["server"]["header_keys"] == ["Authorization", "X-Test"]
+    await reloaded.manage(action="env_unset", name="demo", key="EXTRA")
+    await reloaded.manage(action="header_unset", name="demo", key="X-Test")
+
+    await reloaded.manage(action="disable", name="demo")
+    assert (await reloaded.search("echo"))["tools"] == []
+    with pytest.raises(ValueError, match="disabled"):
+        await reloaded.call("demo:echo", {"text": "x"})
+    await reloaded.manage(action="enable", name="demo")
+    assert (await reloaded.search("echo"))["total_matches"] == 1
+
+    removed = await reloaded.manage(action="remove", name="demo")
+    assert removed["removed"] is True
+    assert (await reloaded.manage(action="list"))["servers"] == []
+
+
+@pytest.mark.asyncio
+async def test_register_without_refresh_and_refresh_failure_are_recoverable(tmp_path, monkeypatch):
+    manager = DynamicMCPManager(tmp_path / ".state")
+    script = _server_script(tmp_path)
+
+    saved = await manager.manage(
+        action="register",
+        name="cold",
+        command=sys.executable,
+        args=[str(script)],
+        refresh=False,
+    )
+    assert saved["refreshed"] is False
+    search = await manager.search(server="cold")
+    assert search["tools"] == []
+    assert search["unrefreshed_servers"] == ["cold"]
+
+    async def fail_refresh(_server):
+        raise RuntimeError("offline")
+
+    monkeypatch.setattr(manager, "_fetch_tools", fail_refresh)
+    failed = await manager.manage(
+        action="register",
+        name="broken",
+        command=sys.executable,
+        args=[str(script)],
+    )
+    assert failed["refreshed"] is False
+    assert failed["refresh_error"] == "offline"
+    assert {row["name"] for row in (await manager.manage(action="list"))["servers"]} == {
+        "broken",
+        "cold",
+    }
+
+
+@pytest.mark.asyncio
+async def test_http_transport_pagination_call_and_tool_limit(tmp_path, monkeypatch):
+    manager = DynamicMCPManager(tmp_path / ".state")
+    await manager.manage(
+        action="register",
+        name="web",
+        transport="streamable_http",
+        url="https://mcp.example.test/mcp",
+        headers={"Authorization": "Bearer hidden"},
+        refresh=False,
+    )
+
+    seen: dict[str, object] = {}
+
+    @asynccontextmanager
+    async def fake_http(url, headers):
+        seen["url"] = url
+        seen["headers"] = headers
+        yield object(), object(), lambda: "session"
+
+    class FakeSession:
+        def __init__(self, _read, _write):
+            self.calls = 0
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def initialize(self):
+            seen["initialized"] = True
+
+        async def list_tools(self, cursor=None):
+            self.calls += 1
+            if cursor is None:
+                return SimpleNamespace(
+                    tools=[Tool(name="alpha", description="first tool", inputSchema={})],
+                    nextCursor="next",
+                )
+            return SimpleNamespace(
+                tools=[Tool(name="beta", description="second tool", inputSchema={})],
+                nextCursor=None,
+            )
+
+        async def call_tool(self, name, arguments):
+            seen["call"] = (name, arguments)
+            return CallToolResult(content=[TextContent(type="text", text="ok")], isError=False)
+
+    monkeypatch.setattr(dynamic_mcp, "streamablehttp_client", fake_http)
+    monkeypatch.setattr(dynamic_mcp, "ClientSession", FakeSession)
+
+    refreshed = await manager.manage(action="refresh", name="web")
+    assert refreshed["server"]["tool_count"] == 2
+    assert seen["url"] == "https://mcp.example.test/mcp"
+    assert seen["headers"] == {"Authorization": "Bearer hidden"}
+    assert seen["initialized"] is True
+    assert [item["name"] for item in (await manager.search("tool"))["tools"]] == [
+        "web:alpha",
+        "web:beta",
+    ]
+    called = await manager.call("web:alpha", {"x": 1}, timeout_s=5)
+    assert called["result"]["content"][0]["text"] == "ok"
+    assert seen["call"] == ("alpha", {"x": 1})
+
+    monkeypatch.setattr(dynamic_mcp, "_MAX_TOOLS_PER_SERVER", 1)
+    with pytest.raises(ValueError, match="more than 1 tools"):
+        await manager.refresh("web")
+
+
+@pytest.mark.asyncio
+async def test_validation_policy_and_registry_error_paths(tmp_path, monkeypatch):
+    manager = DynamicMCPManager(tmp_path / ".state", max_timeout_s=5)
+    script = _server_script(tmp_path)
+
+    with pytest.raises(ValueError, match="name must match"):
+        await manager.manage(action="register", name="bad name", command=sys.executable)
+    with pytest.raises(ValueError, match="transport"):
+        await manager.manage(action="register", name="bad", transport="sse", command="python")
+    with pytest.raises(ValueError, match="command is required"):
+        await manager.manage(action="register", name="missing", transport="stdio")
+    with pytest.raises(ValueError, match="absolute HTTP"):
+        await manager.manage(action="register", name="web", transport="streamable_http")
+    with pytest.raises(ValueError, match="command is only valid"):
+        await manager.manage(
+            action="register",
+            name="web",
+            transport="streamable_http",
+            url="https://example.test/mcp",
+            command="python",
+        )
+    with pytest.raises(PermissionError):
+        await manager.manage(
+            action="register", name="denied", command="mount", args=["/tmp/x"], refresh=False
+        )
+    with pytest.raises(ValueError, match="Path escapes workspace"):
+        await manager.manage(
+            action="register",
+            name="outside",
+            command=sys.executable,
+            cwd=str(tmp_path.parent),
+            refresh=False,
+        )
+    with pytest.raises(ValueError, match="env keys"):
+        await manager.manage(
+            action="register", name="bad-env", command=sys.executable, env={"": "x"}
+        )
+    with pytest.raises(ValueError, match="env values"):
+        await manager.manage(
+            action="register", name="bad-value", command=sys.executable, env={"X": 1}
+        )
+
+    await manager.manage(
+        action="register",
+        name="demo",
+        command=sys.executable,
+        args=[str(script)],
+        refresh=False,
+    )
+    with pytest.raises(ValueError, match="already exists"):
+        await manager.manage(
+            action="register",
+            name="demo",
+            command=sys.executable,
+            args=[str(script)],
+            refresh=False,
+        )
+    await manager.manage(
+        action="register",
+        name="demo",
+        command=sys.executable,
+        args=[str(script)],
+        refresh=False,
+        overwrite=True,
+    )
+    for action in ("get", "enable", "remove", "refresh"):
+        with pytest.raises(ValueError, match="unknown dynamic MCP server"):
+            await manager.manage(action=action, name="missing")
+    with pytest.raises(ValueError, match="name is required"):
+        await manager.manage(action="get")
+    with pytest.raises(ValueError, match="action must be"):
+        await manager.manage(action="wat", name="demo")
+    with pytest.raises(ValueError, match="key is required"):
+        await manager.manage(action="env_set", name="demo")
+    with pytest.raises(ValueError, match="value is required"):
+        await manager.manage(action="env_set", name="demo", key="X")
+    with pytest.raises(ValueError, match="unknown dynamic MCP server"):
+        await manager.search(server="missing")
+    with pytest.raises(ValueError, match="<server>:<tool>"):
+        await manager.inspect("invalid")
+    with pytest.raises(ValueError, match="unknown cached tool"):
+        await manager.inspect("demo:nope")
+    with pytest.raises(ValueError, match="unknown cached tool"):
+        await manager.call("demo:nope")
+
+    registry = tmp_path / ".state" / "dynamic-mcp.json"
+    registry.write_text("not json", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="unable to read"):
+        await manager.manage(action="list")
+    registry.write_text('{"version":999,"servers":[]}', encoding="utf-8")
+    with pytest.raises(RuntimeError, match="unsupported"):
+        await manager.manage(action="list")
+
+    class Unsupported:
+        pass
+
+    with pytest.raises(TypeError, match="unsupported MCP tool descriptor"):
+        dynamic_mcp._tool_json(Unsupported())
+
+
+@pytest.mark.asyncio
+async def test_refresh_detects_removal_race(tmp_path, monkeypatch):
+    manager = DynamicMCPManager(tmp_path / ".state")
+    await manager.manage(action="register", name="demo", command=sys.executable, refresh=False)
+
+    async def remove_during_fetch(_server):
+        await manager.manage(action="remove", name="demo")
+        return []
+
+    monkeypatch.setattr(manager, "_fetch_tools", remove_during_fetch)
+    with pytest.raises(ValueError, match="removed while refreshing"):
+        await manager.refresh("demo")

--- a/tests/test_dynamic_mcp.py
+++ b/tests/test_dynamic_mcp.py
@@ -91,6 +91,8 @@ async def test_stdio_gateway_round_trip_persists_cache_and_redacts_config(tmp_pa
     assert changed["server"]["header_keys"] == ["Authorization", "X-Test"]
     await reloaded.manage(action="env_unset", name="demo", key="EXTRA")
     await reloaded.manage(action="header_unset", name="demo", key="X-Test")
+    assert (await reloaded.search(server="demo"))["unrefreshed_servers"] == ["demo"]
+    await reloaded.manage(action="refresh", name="demo")
 
     await reloaded.manage(action="disable", name="demo")
     assert (await reloaded.search("echo"))["tools"] == []
@@ -122,7 +124,7 @@ async def test_register_without_refresh_and_refresh_failure_are_recoverable(tmp_
     assert search["unrefreshed_servers"] == ["cold"]
 
     async def fail_refresh(_server):
-        raise RuntimeError("offline")
+        raise RuntimeError("offline env-secret header-secret")
 
     monkeypatch.setattr(manager, "_fetch_tools", fail_refresh)
     failed = await manager.manage(
@@ -130,9 +132,13 @@ async def test_register_without_refresh_and_refresh_failure_are_recoverable(tmp_
         name="broken",
         command=sys.executable,
         args=[str(script)],
+        env={"TOKEN": "env-secret"},
+        headers={"Authorization": "header-secret"},
     )
     assert failed["refreshed"] is False
-    assert failed["refresh_error"] == "offline"
+    assert failed["refresh_error"] == "offline <redacted> <redacted>"
+    assert "env-secret" not in repr(failed)
+    assert "header-secret" not in repr(failed)
     assert {row["name"] for row in (await manager.manage(action="list"))["servers"]} == {
         "broken",
         "cold",
@@ -321,3 +327,20 @@ async def test_refresh_detects_removal_race(tmp_path, monkeypatch):
     monkeypatch.setattr(manager, "_fetch_tools", remove_during_fetch)
     with pytest.raises(ValueError, match="removed while refreshing"):
         await manager.refresh("demo")
+
+
+@pytest.mark.asyncio
+async def test_refresh_discards_tools_when_configuration_changes(tmp_path, monkeypatch):
+    manager = DynamicMCPManager(tmp_path / ".state")
+    await manager.manage(action="register", name="demo", command=sys.executable, refresh=False)
+
+    async def reconfigure_during_fetch(_server):
+        await manager.manage(action="env_set", name="demo", key="TOKEN", value="new-value")
+        return [Tool(name="stale", inputSchema={})]
+
+    monkeypatch.setattr(manager, "_fetch_tools", reconfigure_during_fetch)
+    with pytest.raises(RuntimeError, match="configuration changed while refreshing"):
+        await manager.refresh("demo")
+    searched = await manager.search(server="demo")
+    assert searched["tools"] == []
+    assert searched["unrefreshed_servers"] == ["demo"]

--- a/tests/test_mcp_chatgpt_compat.py
+++ b/tests/test_mcp_chatgpt_compat.py
@@ -196,6 +196,20 @@ async def test_tool_annotations_are_conservative_and_mode_independent(
     assert tools["create_file_link"].annotations.openWorldHint is True
     assert tools["browser_get_text_tool"].annotations.readOnlyHint is True
     assert tools["browser_get_text_tool"].annotations.openWorldHint is True
+    assert tools["browser_snapshot"].annotations.readOnlyHint is True
+    assert tools["browser_snapshot"].annotations.openWorldHint is True
+    assert tools["browser_session"].annotations.destructiveHint is True
+    assert tools["browser_session"].annotations.openWorldHint is True
+    assert tools["browser_act"].annotations.destructiveHint is True
+    assert tools["browser_act"].annotations.openWorldHint is True
+    assert tools["mcp_tool_search"].annotations.readOnlyHint is True
+    assert tools["mcp_tool_search"].annotations.openWorldHint is False
+    assert tools["mcp_tool_inspect"].annotations.readOnlyHint is True
+    assert tools["mcp_tool_inspect"].annotations.openWorldHint is False
+    assert tools["mcp_manage"].annotations.destructiveHint is True
+    assert tools["mcp_manage"].annotations.openWorldHint is True
+    assert tools["mcp_tool_call"].annotations.destructiveHint is True
+    assert tools["mcp_tool_call"].annotations.openWorldHint is True
     assert tools["read_file"].annotations.readOnlyHint is True
     assert tools["read_file"].annotations.openWorldHint is True
     assert tools["view_image"].annotations.readOnlyHint is True

--- a/tests/test_remote_complete.py
+++ b/tests/test_remote_complete.py
@@ -248,9 +248,17 @@ async def test_every_worker_tool_dispatch_branch(monkeypatch, tmp_path):
     def sync_value(*args, **kwargs):
         return {"args": list(args), "kwargs": kwargs}
 
+    class FakeBrowserSessions:
+        manage = staticmethod(async_value)
+        snapshot = staticmethod(async_value)
+        act = staticmethod(async_value)
+
     monkeypatch.setattr(remote, "run_shell", lambda *args, **kwargs: asyncio.sleep(0, result=command_result))
     monkeypatch.setattr(remote, "public_run_shell", lambda *args, **kwargs: asyncio.sleep(0, result=command_result))
     monkeypatch.setattr(remote, "_run_python", async_value)
+    monkeypatch.setattr(
+        remote, "get_browser_session_manager", lambda _state_dir: FakeBrowserSessions()
+    )
     for name in (
         "start_shell",
         "send_shell",
@@ -329,6 +337,9 @@ async def test_every_worker_tool_dispatch_branch(monkeypatch, tmp_path):
         "transfer_upload_url": {"path": "x", "url": "http://x", "expected_bytes": 0, "expected_sha256": "d"},
         "transfer_download_url": {"url": "http://x", "path": "x", "expected_bytes": 0, "expected_sha256": "d"},
         "apply_patch": {"patch": "diff"},
+        "browser_session": {"action": "list"},
+        "browser_snapshot": {"session_id": "s"},
+        "browser_act": {"session_id": "s", "actions": [{"action": "wait"}]},
         "browser_capture_tool": {"url": "https://x"},
         "browser_get_text_tool": {"url": "https://x"},
         "playwright_run_script_tool": {"script": "print(1)"},

--- a/tests/test_tool_surface.py
+++ b/tests/test_tool_surface.py
@@ -38,6 +38,13 @@ CORE_TOOL_NAMES = {
     "secret_scan",
     "todo_read_tool",
     "todo_write_tool",
+    "mcp_manage",
+    "mcp_tool_search",
+    "mcp_tool_inspect",
+    "mcp_tool_call",
+    "browser_session",
+    "browser_snapshot",
+    "browser_act",
     "browser_capture_tool",
     "browser_get_text_tool",
     "playwright_run_script_tool",
@@ -127,6 +134,9 @@ async def test_machine_capable_tools_use_optional_machine_arguments(tmp_path, mo
         "edit_file",
         "delete_file_or_dir",
         "apply_patch",
+        "browser_session",
+        "browser_snapshot",
+        "browser_act",
         "browser_capture_tool",
         "browser_get_text_tool",
         "playwright_run_script_tool",
@@ -164,6 +174,10 @@ async def test_key_tool_descriptions_guide_tool_choice(tmp_path, monkeypatch):
     assert "existing file-transfer protocol" in tools["view_image"].description
     assert "tool surface stays fixed" in tools["skills_list"].description
     assert "exact name returned from skills_list" in tools["skill_load"].description
+    assert "tools/list" in tools["mcp_tool_search"].description
+    assert "mcp_tool_inspect" in tools["mcp_tool_search"].description
+    assert "stable short refs" in tools["browser_snapshot"].description
+    assert "playwright_run_script_tool" in tools["browser_act"].description
 
 
 @pytest.mark.asyncio

--- a/tests/test_tools_complete.py
+++ b/tests/test_tools_complete.py
@@ -179,6 +179,13 @@ async def test_all_public_tool_wrappers_local_and_remote(tmp_path, monkeypatch):
         "secret_scan": {},
         "todo_read_tool": {},
         "todo_write_tool": {"todos": []},
+        "mcp_manage": {"action": "list"},
+        "mcp_tool_search": {},
+        "mcp_tool_inspect": {"name": "missing:tool"},
+        "mcp_tool_call": {"name": "missing:tool"},
+        "browser_session": {"action": "list"},
+        "browser_snapshot": {"session_id": "missing"},
+        "browser_act": {"session_id": "missing", "actions": [{"action": "wait"}]},
         "browser_capture_tool": {"url": "https://example.test"},
         "browser_get_text_tool": {"url": "https://example.test"},
         "playwright_run_script_tool": {"script": "print(1)"},
@@ -221,6 +228,9 @@ async def test_all_public_tool_wrappers_local_and_remote(tmp_path, monkeypatch):
         "edit_file": {"path": "x", "edits": []},
         "delete_file_or_dir": {"path": "x"},
         "apply_patch": {"patch": "diff"},
+        "browser_session": {"action": "list"},
+        "browser_snapshot": {"session_id": "s"},
+        "browser_act": {"session_id": "s", "actions": [{"action": "wait"}]},
         "browser_capture_tool": {"url": "https://x"},
         "browser_get_text_tool": {"url": "https://x"},
         "playwright_run_script_tool": {"script": "x"},
@@ -347,6 +357,32 @@ def test_tool_helpers_audit_serialization_timeout_and_tail(tmp_path, monkeypatch
     assert len(serialized["items"]) == 30
     assert "object at" in serialized["object"]
     assert tools._audit_tool_arguments((1, 2), {"password": "x"})["positional_count"] == 2
+
+    managed = tools._safe_audit_call_arguments(
+        "mcp_manage",
+        {
+            "action": "env_set",
+            "name": "demo",
+            "env": {"TOKEN": "secret"},
+            "headers": {"Authorization": "Bearer secret"},
+            "value": "secret",
+        },
+    )
+    assert managed["env"] == {"TOKEN": "<redacted>"}
+    assert managed["headers"] == {"Authorization": "<redacted>"}
+    assert managed["value"] == "<redacted>"
+    dynamic_call = tools._safe_audit_call_arguments(
+        "mcp_tool_call", {"name": "demo:tool", "arguments": {"token": "secret"}, "timeout_s": 5}
+    )
+    assert dynamic_call == {"name": "demo:tool", "argument_keys": ["token"], "timeout_s": 5}
+    browser_call = tools._safe_audit_call_arguments(
+        "browser_act",
+        {
+            "session_id": "s",
+            "actions": [{"action": "fill", "target": "e1", "value": "secret"}],
+        },
+    )
+    assert browser_call["actions"][0]["value"] == "<redacted>"
 
     assert tools._audit_tool_purpose("x", "  purpose ", " explanation ") == {
         "purpose": "purpose",


### PR DESCRIPTION
## Summary

- add a fixed-surface Dynamic MCP gateway with persistent server registration and progressive `search -> inspect -> call` discovery
- support stdio and Streamable HTTP MCP servers without exposing their tools in LSM `tools/list`
- isolate dynamic MCP environment/header secrets and redact them from tool results and Audit arguments
- add persistent high-level browser sessions with snapshot element refs and structured actions, while retaining `playwright_run_script_tool` as the escape hatch
- expose the same browser session API on remote workers
- update generated tool reference and browser documentation

## Verification

- `ruff check .`
- `PYTHONPATH=src pytest -q` — 626 passed, 1 skipped
- `PYTHONPATH=src bash scripts/run-coverage.sh` — total 94.15%, every module >= 90%
- Dynamic MCP module coverage: 96.2%
- browser sessions module coverage: 96.5%
- real stdio MCP register/search/inspect/call integration test
- real Chromium session/snapshot/ref/action/profile/storage-state tests
- HTTP/MCP smoke, TUI PTY smoke, WebUI browser smoke
- `python scripts/check-doc-i18n.py`
- `mkdocs build --strict`
