### PR TITLE
fix: report local-shell-mcp version over MCP

### DIFF
--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -19,6 +19,7 @@ from mcp.types import CallToolResult, ImageContent, TextContent, ToolAnnotations
 from pathspec.gitignore import GitIgnoreSpec
 from pydantic import BaseModel, ConfigDict, Field
 
+from . import __version__
 from .audit import audit, audit_call_context, audit_result_ok
 from .auth import current_principal, principal_scopes, require_current_scopes
 from .browser_sessions import get_browser_session_manager
@@ -2580,6 +2581,10 @@ def build_mcp() -> FastMCP:
         instructions=MCP_INSTRUCTIONS,
         transport_security=_transport_security_settings(),
     )
+    # FastMCP currently leaves the low-level server version unset, which makes
+    # the MCP SDK advertise its own package version during initialize. Report
+    # the local-shell-mcp version instead.
+    mcp._mcp_server.version = __version__
     read_only_tool = ToolAnnotations(
         readOnlyHint=True,
         destructiveHint=False,

--- a/tests/test_mcp_chatgpt_compat.py
+++ b/tests/test_mcp_chatgpt_compat.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 from starlette.applications import Starlette
 from starlette.routing import Route
 
+from local_shell_mcp import __version__
 from local_shell_mcp.auth import (
     _CURRENT_PRINCIPAL,
     Principal,
@@ -91,6 +92,7 @@ async def test_mcp_metadata_for_chatgpt_developer_mode(tmp_path, monkeypatch):
 
     mcp = build_mcp()
     assert "local-shell-mcp.example.com" in mcp.settings.transport_security.allowed_hosts
+    assert mcp._mcp_server.create_initialization_options().server_version == __version__
 
     tools = {tool.name: tool for tool in await mcp.list_tools()}
     assert tools["search"].meta["securitySchemes"][0]["type"] == "noauth"


### PR DESCRIPTION
## Summary
- advertise the local-shell-mcp package version in MCP `initialize` metadata
- prevent the MCP Python SDK version from being exposed as the server version
- add a ChatGPT compatibility regression assertion

## Validation
- `PYTHONPATH=src python -m pytest tests/test_mcp_chatgpt_compat.py -q`
- `PYTHONPATH=src python -m ruff check src/local_shell_mcp/tools.py tests/test_mcp_chatgpt_compat.py`
- verified initialization options report `server_version=3.2.0`