### PR TITLE
fix: declare Live Workspace widget domain

### DIFF
--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -353,6 +353,7 @@ def _live_workspace_resource_meta() -> dict[str, Any]:
     connect_domains = [value for value in (origin, websocket_origin) if value]
     return {
         "ui": {
+            "domain": origin,
             "csp": {"connectDomains": connect_domains},
             "permissions": {"clipboardWrite": {}},
             "prefersBorder": False,
@@ -361,6 +362,7 @@ def _live_workspace_resource_meta() -> dict[str, Any]:
             "A live local-shell-mcp execution workspace with activity, terminal, files, "
             "diffs, jobs, remotes, audit, and human/agent collaboration controls."
         ),
+        "openai/widgetDomain": origin,
         "openai/widgetPrefersBorder": False,
     }
 

--- a/tests/test_live_workspace.py
+++ b/tests/test_live_workspace.py
@@ -203,11 +203,13 @@ async def test_mcp_app_resource_and_render_result_hide_live_token(tmp_path, monk
     resources = {str(resource.uri): resource for resource in await mcp.list_resources()}
     resource = resources[LIVE_RESOURCE_URI]
     assert resource.mimeType == LIVE_RESOURCE_MIME
+    assert resource.meta["ui"]["domain"] == "https://lsm.example.test"
     assert resource.meta["ui"]["csp"]["connectDomains"] == [
         "https://lsm.example.test",
         "wss://lsm.example.test",
     ]
     assert resource.meta["ui"]["permissions"] == {"clipboardWrite": {}}
+    assert resource.meta["openai/widgetDomain"] == "https://lsm.example.test"
 
     result = await mcp.call_tool("open_live_workspace", {"machine": "local", "cwd": "."})
     assert isinstance(result, CallToolResult)


### PR DESCRIPTION
## Summary
- set `ui.domain` to the existing public base origin
- set the OpenAI compatibility field `openai/widgetDomain` to the same origin
- add regression coverage for both metadata fields

## Validation
- `PYTHONPATH=src pytest -q tests/test_live_workspace.py`
- `ruff check src/local_shell_mcp/tools.py tests/test_live_workspace.py`
- `git diff --check`