### PR TITLE
fix: allow Windows remote join bootstrap

### DIFF
--- a/src/local_shell_mcp/auth.py
+++ b/src/local_shell_mcp/auth.py
@@ -16,7 +16,20 @@ from .audit import audit
 from .settings import Settings, get_settings
 from .ui_security import has_valid_ui_local_token, is_loopback_connection
 
-PUBLIC_PATHS = {"/healthz", "/readyz", "/docs", "/openapi.json", "/join", "/remote/worker-bundle.tgz", "/remote/register", "/remote/resume", "/remote/poll", "/remote/heartbeat", "/remote/result"}
+PUBLIC_PATHS = {
+    "/healthz",
+    "/readyz",
+    "/docs",
+    "/openapi.json",
+    "/join",
+    "/join.ps1",
+    "/remote/worker-bundle.tgz",
+    "/remote/register",
+    "/remote/resume",
+    "/remote/poll",
+    "/remote/heartbeat",
+    "/remote/result",
+}
 HUMAN_UI_API_PREFIX = "/api/ui/"
 LIVE_UI_API_PREFIX = "/api/live/"
 _REQUEST_BODY_SCOPE_KEY = "local_shell_mcp.request_body"

--- a/tests/test_edge_modules_complete.py
+++ b/tests/test_edge_modules_complete.py
@@ -193,6 +193,7 @@ def test_auth_scopes_hosts_tokens_and_metadata(tmp_path, monkeypatch):
     get_settings.cache_clear()
     for path in (
         "/healthz",
+        "/join.ps1",
         "/remote/transfer/x",
         "/.well-known/x",
         "/oauth/x",


### PR DESCRIPTION
## Summary
- make `/join.ps1` public like `/join` so Windows remote workers can bootstrap before OAuth credentials exist
- add a regression assertion for the PowerShell join route

## Validation
- `PYTHONPATH="$PWD/src" python -m pytest -q` -> 697 passed, 1 skipped
- `python -m ruff check src/local_shell_mcp/auth.py tests/test_edge_modules_complete.py`
- `git diff --check`