### PR TITLE
fix: hide Windows remote worker task

### DIFF
--- a/src/local_shell_mcp/jobs.py
+++ b/src/local_shell_mcp/jobs.py
@@ -21,6 +21,7 @@ from typing import Any, BinaryIO
 
 from .audit import audit
 from .fs_ops import resolve_path
+from .process_utils import managed_process_kwargs
 from .settings import get_settings
 from .shell_environment import filtered_subprocess_env
 from .shell_ops import (
@@ -1652,6 +1653,7 @@ def run_job_runner_cli(argv: list[str] | None = None) -> None:
             env=filtered_subprocess_env(blocked_names, blocked_prefixes),
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
+            **managed_process_kwargs(),
         )
         if process.stdout is None:
             raise RuntimeError("job process did not expose stdout")

--- a/src/local_shell_mcp/patch_ops.py
+++ b/src/local_shell_mcp/patch_ops.py
@@ -5,6 +5,8 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 
+from .process_utils import managed_process_kwargs
+
 _BEGIN_PATCH = "*** Begin Patch"
 _END_PATCH = "*** End Patch"
 _ACTION_PREFIXES = {
@@ -37,6 +39,7 @@ def git_apply_prefix(git_bin: str, cwd: str) -> str | None:
             capture_output=True,
             text=True,
             check=False,
+            **managed_process_kwargs(),
         )
     except OSError:
         return None

--- a/src/local_shell_mcp/process_utils.py
+++ b/src/local_shell_mcp/process_utils.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from typing import Any
+
+
+def managed_process_creationflags() -> int:
+    """Return Windows flags for LSM-managed subprocesses that never need a desktop console."""
+    if sys.platform != "win32":
+        return 0
+    return int(getattr(subprocess, "CREATE_NO_WINDOW", 0))
+
+
+def managed_process_kwargs() -> dict[str, Any]:
+    """Keyword arguments for subprocess APIs, preserving non-Windows call signatures."""
+    flags = managed_process_creationflags()
+    return {"creationflags": flags} if flags else {}

--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -1800,7 +1800,13 @@ def _worker_poll_payload(poll_request_timeout_s: float | None = None) -> dict[st
 
 def _reexec_updated_worker_runtime() -> None:
     from .remote_worker_cli import _worker_run_exec_argv
-    from .remote_worker_service import cancel_worker_lock_reexec, prepare_worker_lock_reexec
+    from .remote_worker_service import (
+        _current_worker_is_managed,
+        _windows_pythonw_executable,
+        _windows_task_launcher_path,
+        cancel_worker_lock_reexec,
+        prepare_worker_lock_reexec,
+    )
     from .remote_worker_state import worker_runtime_dir
 
     runtime = worker_runtime_dir()
@@ -1810,6 +1816,11 @@ def _reexec_updated_worker_runtime() -> None:
         preferred + [entry for entry in current if entry not in preferred]
     )
     argv = _worker_run_exec_argv()
+    if sys.platform == "win32" and _current_worker_is_managed():
+        service_launcher = _windows_task_launcher_path()
+        if service_launcher.is_file():
+            pythonw = str(_windows_pythonw_executable())
+            argv = [pythonw, str(service_launcher.resolve())]
     lock_fd = prepare_worker_lock_reexec()
     try:
         os.execv(argv[0], argv)
@@ -1819,6 +1830,7 @@ def _reexec_updated_worker_runtime() -> None:
 
 async def _upgrade_worker_runtime(server: str, target_version: str) -> None:
     from .remote_worker_installer import install_or_update_runtime
+    from .remote_worker_service import refresh_installed_service_definition
 
     result = await asyncio.to_thread(install_or_update_runtime, server)
     installed_version = str(result.get("version") or "")
@@ -1827,6 +1839,7 @@ async def _upgrade_worker_runtime(server: str, target_version: str) -> None:
             f"controller requested worker {target_version}, but manifest provides "
             f"{installed_version or 'no version'}"
         )
+    await asyncio.to_thread(refresh_installed_service_definition)
     print(
         f"Status: worker runtime updated to {installed_version or 'unknown'}; restarting...",
         file=sys.stderr,

--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -1183,6 +1183,12 @@ def _worker_curl_timeout(timeout_s: int | None) -> int:
     return max(30, min(requested, maximum))
 
 
+def _worker_subprocess_creationflags() -> int:
+    if os.name != "nt":
+        return 0
+    return int(getattr(subprocess, "CREATE_NO_WINDOW", 0))
+
+
 def _worker_upload_url(
     path: str,
     url: str,
@@ -1253,6 +1259,7 @@ def _worker_upload_url(
         input=data,
         capture_output=True,
         check=False,
+        creationflags=_worker_subprocess_creationflags(),
     )
     raw_stdout = completed.stdout or b""
     raw_stderr = completed.stderr or b""
@@ -1329,6 +1336,7 @@ def _worker_put_url(
         ],
         capture_output=True,
         check=False,
+        creationflags=_worker_subprocess_creationflags(),
     )
     raw_stdout = completed.stdout or b""
     raw_stderr = completed.stderr or b""
@@ -1391,6 +1399,7 @@ def _worker_download_url(
             capture_output=True,
             text=True,
             check=False,
+            creationflags=_worker_subprocess_creationflags(),
         )
         if completed.returncode != 0:
             detail = completed.stderr.strip() or completed.stdout.strip()
@@ -1881,6 +1890,7 @@ def _worker_post_json_with_curl(
         input=body,
         capture_output=True,
         check=False,
+        creationflags=_worker_subprocess_creationflags(),
     )
     stdout = completed.stdout.decode("utf-8", errors="replace")
     stderr = completed.stderr.decode("utf-8", errors="replace").strip()

--- a/src/local_shell_mcp/remote_worker_service.py
+++ b/src/local_shell_mcp/remote_worker_service.py
@@ -500,7 +500,9 @@ def refresh_installed_service_definition() -> Path | None:
         launcher = _installed_launchd_launcher_path() or worker_launcher_path()
         return _write_launchd_plist(launcher)
     if kind == "scheduled-task" and _windows_task_status() is not None:
-        return _write_windows_task_launcher()
+        service_file = _write_windows_task_launcher()
+        _register_windows_task(service_file)
+        return service_file
     return None
 
 

--- a/src/local_shell_mcp/remote_worker_service.py
+++ b/src/local_shell_mcp/remote_worker_service.py
@@ -18,6 +18,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from .process_utils import managed_process_kwargs
 from .remote_worker_state import (
     ensure_user_bin_on_path,
     install_launcher,
@@ -219,11 +220,13 @@ def _launchd_plist_path() -> Path:
 
 
 def _windows_task_launcher_path() -> Path:
-    return worker_state_dir() / "worker-service.cmd"
+    return worker_state_dir() / "worker-service.pyw"
 
 
 def _run(command: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(command, check=check, capture_output=True, text=True)  # noqa: S603
+    return subprocess.run(
+        command, check=check, capture_output=True, text=True, **managed_process_kwargs()
+    )  # noqa: S603
 
 
 def _powershell_executable() -> str | None:
@@ -347,46 +350,70 @@ def _write_launchd_plist(launcher: Path | None = None) -> Path:
     return path
 
 
-def _batch_path(path: Path) -> str:
-    return str(path).replace("%", "%%")
-
-
-def _write_windows_task_launcher(launcher: Path | None = None) -> Path:
-    launcher = launcher or worker_launcher_path()
+def _write_windows_task_launcher() -> Path:
     path = _windows_task_launcher_path()
-    content = f'''@echo off
-setlocal
-set "PYTHONUNBUFFERED=1"
-set "{_WORKER_MANAGED_ENV}=1"
-set "LOCAL_SHELL_MCP_WORKER_STATE_DIR={_batch_path(worker_state_dir().resolve())}"
-call "{_batch_path(launcher.resolve())}" worker run >> "{_batch_path(worker_log_path().resolve())}" 2>&1
-exit /b %ERRORLEVEL%
+    state_dir = str(worker_state_dir().resolve())
+    runtime_dir = str(worker_runtime_dir().resolve())
+    vendor_dir = str((worker_runtime_dir() / "vendor").resolve())
+    log_path = str(worker_log_path().resolve())
+    content = f'''from __future__ import annotations
+
+import os
+import sys
+import traceback
+
+STATE_DIR = {state_dir!r}
+RUNTIME_DIR = {runtime_dir!r}
+VENDOR_DIR = {vendor_dir!r}
+LOG_PATH = {log_path!r}
+
+os.environ["PYTHONUNBUFFERED"] = "1"
+os.environ[{_WORKER_MANAGED_ENV!r}] = "1"
+os.environ["LOCAL_SHELL_MCP_WORKER_STATE_DIR"] = STATE_DIR
+existing_pythonpath = os.environ.get("PYTHONPATH")
+runtime_pythonpath = os.pathsep.join((RUNTIME_DIR, VENDOR_DIR))
+os.environ["PYTHONPATH"] = (
+    runtime_pythonpath
+    if not existing_pythonpath
+    else runtime_pythonpath + os.pathsep + existing_pythonpath
+)
+sys.path[:0] = [RUNTIME_DIR, VENDOR_DIR]
+
+with open(LOG_PATH, "a", encoding="utf-8", buffering=1) as worker_log:
+    sys.stdout = worker_log
+    sys.stderr = worker_log
+    try:
+        from local_shell_mcp.main import main
+
+        main(["worker", "run"])
+    except BaseException:
+        traceback.print_exc()
+        raise
 '''
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
     return path
 
 
-def _installed_windows_launcher_path() -> Path | None:
-    try:
-        content = _windows_task_launcher_path().read_text(encoding="utf-8")
-    except OSError:
-        return None
-    match = re.search(r'^call "([^"\r\n]+)" worker run >> ', content, re.MULTILINE)
-    if not match:
-        return None
-    path = Path(match.group(1).replace("%%", "%"))
-    return path if path.is_absolute() else None
+def _windows_pythonw_executable() -> Path:
+    executable = Path(sys.executable).resolve()
+    pythonw = executable.with_name("pythonw.exe")
+    if pythonw.is_file():
+        return pythonw
+    raise RuntimeError(
+        f"pythonw.exe is required for the Windows remote worker service: {pythonw}"
+    )
 
 
 def _register_windows_task(service_file: Path) -> None:
-    action_arguments = f'/d /c ""{service_file.resolve()}""'
+    action_arguments = f'"{service_file.resolve()}"'
     script = "\n".join(
         [
             "$ErrorActionPreference = 'Stop'",
             "$user = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name",
             (
-                "$action = New-ScheduledTaskAction -Execute $env:ComSpec "
+                "$action = New-ScheduledTaskAction "
+                f"-Execute {_powershell_literal(str(_windows_pythonw_executable()))} "
                 f"-Argument {_powershell_literal(action_arguments)} "
                 f"-WorkingDirectory {_powershell_literal(str(worker_state_dir().resolve()))}"
             ),
@@ -473,8 +500,7 @@ def refresh_installed_service_definition() -> Path | None:
         launcher = _installed_launchd_launcher_path() or worker_launcher_path()
         return _write_launchd_plist(launcher)
     if kind == "scheduled-task" and _windows_task_status() is not None:
-        launcher = _installed_windows_launcher_path() or worker_launcher_path()
-        return _write_windows_task_launcher(launcher)
+        return _write_windows_task_launcher()
     return None
 
 
@@ -699,7 +725,7 @@ def install_service(*, start: bool = True) -> dict[str, Any]:
         _stop_process()
         if _windows_task_status() is not None:
             _stop_windows_task()
-        service_file = _write_windows_task_launcher(launcher)
+        service_file = _write_windows_task_launcher()
         _register_windows_task(service_file)
         if start:
             _start_windows_task()

--- a/src/local_shell_mcp/search_ops.py
+++ b/src/local_shell_mcp/search_ops.py
@@ -5,6 +5,7 @@ import json
 from contextlib import suppress
 
 from .fs_ops import missing_path_context, resolve_path
+from .process_utils import managed_process_kwargs
 from .settings import get_settings
 from .shell_ops import _close_process_transport
 
@@ -27,6 +28,7 @@ async def grep(query: str, cwd: str = ".", glob: str | None = None, regex: bool 
         cwd=str(base),
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
+        **managed_process_kwargs(),
     )
     matches = []
     stderr_parts: list[bytes] = []

--- a/src/local_shell_mcp/shell_ops.py
+++ b/src/local_shell_mcp/shell_ops.py
@@ -21,6 +21,7 @@ from .audit import audit
 from .errors import process_start_not_found_error
 from .fs_ops import relative_display, resolve_path
 from .models import CommandResult
+from .process_utils import managed_process_kwargs
 from .settings import get_settings
 from .shell_environment import (
     persistent_shell_args,
@@ -217,6 +218,7 @@ async def _spawn_process(command: str, cwd: str) -> asyncio.subprocess.Process:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             start_new_session=(sys.platform != "win32"),
+            **managed_process_kwargs(),
         )
     except FileNotFoundError as exc:
         raise process_start_not_found_error(
@@ -425,6 +427,7 @@ async def _run_exec(
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             start_new_session=(sys.platform != "win32"),
+            **managed_process_kwargs(),
         )
         reader_tasks.extend(
             [
@@ -593,6 +596,7 @@ async def _native_start_shell(
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
             start_new_session=(sys.platform != "win32"),
+            **managed_process_kwargs(),
         )
     except FileNotFoundError as exc:
         raise process_start_not_found_error(
@@ -633,6 +637,7 @@ def _native_descendant_pids(parent_pid: int) -> list[int]:
             text=True,
             check=False,
             timeout=1,
+            **managed_process_kwargs(),
         )
     except (OSError, subprocess.SubprocessError):
         return []

--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -68,6 +68,7 @@ from .models import ok_result as _ok
 from .oauth import ALL_OAUTH_SCOPES
 from .patch_ops import git_apply_command, git_apply_prefix, normalize_patch_text
 from .playwright_ops import playwright_run_script
+from .process_utils import managed_process_kwargs
 from .remote import remote_manager
 from .remote_transfer import (
     create_download_ticket,
@@ -903,7 +904,8 @@ def _secret_scan_candidates(base: Any, glob: str | None = None) -> list[Any]:
         args.extend(["--glob", glob])
     try:
         result = subprocess.run(
-            args, cwd=str(base), text=True, capture_output=True, timeout=30, check=False
+            args, cwd=str(base), text=True, capture_output=True, timeout=30, check=False,
+            **managed_process_kwargs(),
         )
     except Exception:
         result = None

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import urllib.error
 from io import BytesIO
+from types import SimpleNamespace
 
 import pytest
 
@@ -186,8 +187,8 @@ async def test_join_script_reports_download_progress_and_uses_worker_entrypoint(
 def test_worker_post_json_uses_curl_and_parses_success(monkeypatch):
     calls = []
 
-    def fake_run(command, *, input, capture_output, check):  # noqa: A002
-        calls.append((command, input, check))
+    def fake_run(command, *, input, capture_output, check, creationflags):  # noqa: A002
+        calls.append((command, input, check, creationflags))
         assert capture_output is True
         return subprocess.CompletedProcess(
             command,
@@ -207,7 +208,7 @@ def test_worker_post_json_uses_curl_and_parses_success(monkeypatch):
     )
 
     assert result == {"ok": True, "data": {"registered": True}}
-    command, body, check = calls[0]
+    command, body, check, creationflags = calls[0]
     assert command[:7] == [
         "/usr/bin/curl",
         "--connect-timeout",
@@ -221,10 +222,14 @@ def test_worker_post_json_uses_curl_and_parses_success(monkeypatch):
     assert command[-1] == "https://example.test/remote/register"
     assert body == b'{"invite": "abc"}'
     assert check is False
+    assert creationflags == 0
 
 
 def test_worker_post_json_curl_reports_non_2xx_body(monkeypatch):
-    def fake_run(command, *, input, capture_output, check):  # noqa: A002, ARG001
+    def fake_run(  # noqa: A002, ARG001
+        command, *, input, capture_output, check, creationflags
+    ):
+        assert creationflags == 0
         return subprocess.CompletedProcess(
             command,
             0,
@@ -237,6 +242,12 @@ def test_worker_post_json_curl_reports_non_2xx_body(monkeypatch):
 
     with pytest.raises(RuntimeError, match="failed with 403: <html>Cloudflare 1010</html>"):
         remote._worker_post_json("https://example.test/remote/register", {"invite": "abc"})  # noqa: SLF001
+
+
+def test_worker_curl_subprocess_hides_windows_console(monkeypatch):
+    monkeypatch.setattr(remote, "os", SimpleNamespace(name="nt"))
+    monkeypatch.setattr(remote.subprocess, "CREATE_NO_WINDOW", 0x08000000, raising=False)
+    assert remote._worker_subprocess_creationflags() == 0x08000000  # noqa: SLF001
 
 
 def test_worker_post_json_falls_back_to_urllib_when_curl_unavailable(monkeypatch):

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -222,14 +222,14 @@ def test_worker_post_json_uses_curl_and_parses_success(monkeypatch):
     assert command[-1] == "https://example.test/remote/register"
     assert body == b'{"invite": "abc"}'
     assert check is False
-    assert creationflags == 0
+    assert creationflags == remote._worker_subprocess_creationflags()  # noqa: SLF001
 
 
 def test_worker_post_json_curl_reports_non_2xx_body(monkeypatch):
     def fake_run(  # noqa: A002, ARG001
         command, *, input, capture_output, check, creationflags
     ):
-        assert creationflags == 0
+        assert creationflags == remote._worker_subprocess_creationflags()  # noqa: SLF001
         return subprocess.CompletedProcess(
             command,
             0,

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -336,7 +336,7 @@ def test_worker_retry_delay_is_capped():
 
 
 def test_reexec_updated_worker_runtime_prefers_installed_bundle(tmp_path, monkeypatch):
-    from local_shell_mcp import remote_worker_cli
+    from local_shell_mcp import remote_worker_cli, remote_worker_service
 
     state_dir = tmp_path / "state"
     runtime = state_dir / "runtime"
@@ -347,6 +347,7 @@ def test_reexec_updated_worker_runtime_prefers_installed_bundle(tmp_path, monkey
         "_worker_run_exec_argv",
         lambda: [sys.executable, "-m", "local_shell_mcp.main", "worker", "run"],
     )
+    monkeypatch.setattr(remote_worker_service, "_current_worker_is_managed", lambda: False)
     calls = []
     monkeypatch.setattr(remote.os, "execv", lambda executable, argv: calls.append((executable, argv)))
 
@@ -363,9 +364,35 @@ def test_reexec_updated_worker_runtime_prefers_installed_bundle(tmp_path, monkey
     ]
 
 
+def test_reexec_updated_managed_windows_worker_uses_service_launcher(tmp_path, monkeypatch):
+    from local_shell_mcp import remote_worker_cli, remote_worker_service
+
+    state_dir = tmp_path / "state"
+    launcher = state_dir / "worker-service.pyw"
+    launcher.parent.mkdir(parents=True)
+    launcher.write_text("# launcher\n", encoding="utf-8")
+    pythonw = tmp_path / "pythonw.exe"
+    pythonw.write_bytes(b"")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKER_STATE_DIR", str(state_dir))
+    monkeypatch.setattr(remote.sys, "platform", "win32")
+    monkeypatch.setattr(
+        remote_worker_cli,
+        "_worker_run_exec_argv",
+        lambda: [sys.executable, "-m", "local_shell_mcp.main", "worker", "run"],
+    )
+    monkeypatch.setattr(remote_worker_service, "_current_worker_is_managed", lambda: True)
+    monkeypatch.setattr(remote_worker_service, "_windows_pythonw_executable", lambda: pythonw)
+    calls = []
+    monkeypatch.setattr(remote.os, "execv", lambda executable, argv: calls.append((executable, argv)))
+
+    remote._reexec_updated_worker_runtime()  # noqa: SLF001
+
+    assert calls == [(str(pythonw), [str(pythonw), str(launcher.resolve())])]
+
+
 @pytest.mark.asyncio
 async def test_upgrade_worker_runtime_validates_manifest_version(monkeypatch):
-    from local_shell_mcp import remote_worker_installer
+    from local_shell_mcp import remote_worker_installer, remote_worker_service
 
     monkeypatch.setattr(
         remote_worker_installer,
@@ -377,6 +404,11 @@ async def test_upgrade_worker_runtime_validates_manifest_version(monkeypatch):
         "_reexec_updated_worker_runtime",
         lambda: pytest.fail("re-executed mismatched runtime"),
     )
+    monkeypatch.setattr(
+        remote_worker_service,
+        "refresh_installed_service_definition",
+        lambda: pytest.fail("refreshed service for mismatched runtime"),
+    )
     with pytest.raises(RuntimeError, match="manifest provides 3.1.0"):
         await remote._upgrade_worker_runtime("https://example.test", "3.2.0")  # noqa: SLF001
 
@@ -386,9 +418,14 @@ async def test_upgrade_worker_runtime_validates_manifest_version(monkeypatch):
         "install_or_update_runtime",
         lambda server: {"version": "3.2.0"},
     )
+    monkeypatch.setattr(
+        remote_worker_service,
+        "refresh_installed_service_definition",
+        lambda: calls.append("refresh"),
+    )
     monkeypatch.setattr(remote, "_reexec_updated_worker_runtime", lambda: calls.append("reexec"))
     await remote._upgrade_worker_runtime("https://example.test", "3.2.0")  # noqa: SLF001
-    assert calls == ["reexec"]
+    assert calls == ["refresh", "reexec"]
 
 
 def test_worker_cli_keyboard_interrupt_exits_cleanly():

--- a/tests/test_remote_worker_service.py
+++ b/tests/test_remote_worker_service.py
@@ -105,6 +105,9 @@ def test_install_and_manage_windows_scheduled_task(tmp_path, monkeypatch):
     monkeypatch.setattr(service.platform, "system", lambda: "Windows")
     monkeypatch.setattr(service, "service_kind", lambda: "scheduled-task")
     monkeypatch.setattr(service, "_powershell_executable", lambda: "powershell.exe")
+    pythonw = tmp_path / "pythonw.exe"
+    pythonw.write_bytes(b"")
+    monkeypatch.setattr(service, "_windows_pythonw_executable", lambda: pythonw)
     state = {"installed": False, "value": 3}
     scripts = []
 
@@ -136,12 +139,16 @@ def test_install_and_manage_windows_scheduled_task(tmp_path, monkeypatch):
     assert result["service_file"] == str(service_file)
     assert service_file.exists()
     launcher_text = service_file.read_text(encoding="utf-8")
-    assert "LOCAL_SHELL_MCP_WORKER_MANAGED=1" in launcher_text
-    assert "LOCAL_SHELL_MCP_WORKER_STATE_DIR=" in launcher_text
+    assert "os.environ['LOCAL_SHELL_MCP_WORKER_MANAGED'] = \"1\"" in launcher_text
+    assert 'os.environ["LOCAL_SHELL_MCP_WORKER_STATE_DIR"] = STATE_DIR' in launcher_text
+    assert 'main(["worker", "run"])' in launcher_text
+    assert 'open(LOG_PATH, "a", encoding="utf-8", buffering=1)' in launcher_text
     registration = next(script for script, _ in scripts if "Register-ScheduledTask" in script)
     assert "New-ScheduledTaskTrigger -AtLogOn -User $user" in registration
     assert "-LogonType Interactive -RunLevel Limited" in registration
     assert "-RestartCount 999" in registration
+    assert str(pythonw) in registration
+    assert "New-ScheduledTaskAction -Execute $env:ComSpec" not in registration
     assert service.service_status()["running"] is True
 
     assert service.stop_service()["running"] is False
@@ -193,8 +200,7 @@ def test_windows_task_status_parses_state_and_handles_missing_task(monkeypatch):
 
 def test_windows_service_refresh_and_process_fallback(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
-    custom_launcher = tmp_path / "custom-bin" / "local-shell-mcp.cmd"
-    service._write_windows_task_launcher(custom_launcher)  # noqa: SLF001
+    service._write_windows_task_launcher()  # noqa: SLF001
     monkeypatch.setattr(service, "service_kind", lambda: "scheduled-task")
     monkeypatch.setattr(
         service,
@@ -204,8 +210,7 @@ def test_windows_service_refresh_and_process_fallback(tmp_path, monkeypatch):
     refreshed = service.refresh_installed_service_definition()
     assert refreshed == service._windows_task_launcher_path()  # noqa: SLF001
     assert refreshed.exists()
-    assert f'call "{custom_launcher.resolve()}" worker run' in refreshed.read_text(encoding="utf-8")
-    assert service._installed_windows_launcher_path() == custom_launcher.resolve()  # noqa: SLF001
+    assert 'main(["worker", "run"])' in refreshed.read_text(encoding="utf-8")
 
     monkeypatch.setattr(service, "_windows_task_status", lambda: None)
     monkeypatch.setattr(service, "_read_pid", lambda: 42)

--- a/tests/test_remote_worker_service.py
+++ b/tests/test_remote_worker_service.py
@@ -202,6 +202,12 @@ def test_windows_service_refresh_and_process_fallback(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
     service._write_windows_task_launcher()  # noqa: SLF001
     monkeypatch.setattr(service, "service_kind", lambda: "scheduled-task")
+    registrations = []
+    monkeypatch.setattr(
+        service,
+        "_register_windows_task",
+        lambda service_file: registrations.append(service_file),
+    )
     monkeypatch.setattr(
         service,
         "_windows_task_status",
@@ -211,6 +217,7 @@ def test_windows_service_refresh_and_process_fallback(tmp_path, monkeypatch):
     assert refreshed == service._windows_task_launcher_path()  # noqa: SLF001
     assert refreshed.exists()
     assert 'main(["worker", "run"])' in refreshed.read_text(encoding="utf-8")
+    assert registrations == [refreshed]
 
     monkeypatch.setattr(service, "_windows_task_status", lambda: None)
     monkeypatch.setattr(service, "_read_pid", lambda: 42)

--- a/tests/test_windows_native_backend.py
+++ b/tests/test_windows_native_backend.py
@@ -107,3 +107,33 @@ async def test_native_shell_creation_is_serialized(tmp_path, monkeypatch):
 
     spawned[0].returncode = 0
     await ops.kill_shell("duplicate")
+
+
+def test_managed_process_kwargs_uses_create_no_window_on_windows(monkeypatch):
+    from local_shell_mcp import process_utils
+
+    monkeypatch.setattr(process_utils.sys, "platform", "win32")
+    monkeypatch.setattr(process_utils.subprocess, "CREATE_NO_WINDOW", 0x08000000, raising=False)
+
+    assert process_utils.managed_process_kwargs() == {"creationflags": 0x08000000}
+
+
+@pytest.mark.asyncio
+async def test_run_shell_spawn_uses_managed_process_kwargs(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    get_settings.cache_clear()
+    captured = {}
+
+    class FakeProcess:
+        returncode = 0
+
+    async def fake_create_subprocess_exec(*args, **kwargs):  # noqa: ANN002, ANN003
+        captured.update(kwargs)
+        return FakeProcess()
+
+    monkeypatch.setattr(ops.asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr(ops, "managed_process_kwargs", lambda: {"creationflags": 0x08000000})
+
+    await ops._spawn_process("echo hidden", str(tmp_path))  # noqa: SLF001
+
+    assert captured["creationflags"] == 0x08000000


### PR DESCRIPTION
## Summary
- run the persistent Windows worker via `pythonw.exe` so the worker itself has no console window
- apply a shared `CREATE_NO_WINDOW` policy to every LSM-managed Windows subprocess whose I/O is captured or redirected: run-shell, persistent shells, background jobs, ripgrep searches, git helpers, secret scans, worker service management, polling/result curl, and file-transfer curl
- preserve interactive I/O through LSM pipes/PTYs; intentionally user-launched TUI processes are not hidden
- add regression coverage for both the shared creation flag and the actual run-shell spawn path

## Validation
- full suite: 700 passed, 1 skipped
- targeted Windows/process suites: 168 passed
- Ruff passes
- `git diff --check` passes