### PR TITLE
perf: avoid full audit scan on every event

### DIFF
--- a/src/local_shell_mcp/audit.py
+++ b/src/local_shell_mcp/audit.py
@@ -30,6 +30,7 @@ _AUDIT_INLINE_VALUE_BYTES = 16 * 1024
 _AUDIT_PAYLOAD_PRUNE_GRACE_S = 300
 _AUDIT_MAINTENANCE_INTERVAL_S = _AUDIT_PAYLOAD_PRUNE_GRACE_S
 _AUDIT_LAST_MAINTENANCE: dict[str, float] = {}
+_AUDIT_PRESSURE_BACKOFF_UNTIL: dict[str, float] = {}
 _AUDIT_PAYLOAD_DIRECTORY = "audit-payloads"
 _AUDIT_PAYLOAD_MARKER = "$local_shell_mcp_audit_payload"
 _AUDIT_PAYLOAD_VERSION = 1
@@ -143,6 +144,7 @@ def _write_payload(value: Any) -> dict[str, Any]:
         finally:
             with contextlib.suppress(OSError):
                 temporary.unlink(missing_ok=True)
+    _AUDIT_PRESSURE_BACKOFF_UNTIL.pop(os.fspath(get_settings().audit_log_path), None)
     return {
         _AUDIT_PAYLOAD_MARKER: {
             "version": _AUDIT_PAYLOAD_VERSION,
@@ -256,6 +258,13 @@ def _prune_payload_store(log_path: Path) -> None:
             payload.unlink()
         except OSError:
             continue
+    for temporary in directory.glob(".*.tmp"):
+        try:
+            if temporary.stat().st_mtime > prune_before:
+                continue
+            temporary.unlink()
+        except OSError:
+            continue
 
 
 def _payload_file_size(digest: str, log_path: Path | None = None) -> int:
@@ -265,18 +274,23 @@ def _payload_file_size(digest: str, log_path: Path | None = None) -> int:
         return 0
 
 
-def _audit_storage_bytes(log_path: Path) -> int:
-    """Return the cheap on-disk size used by the audit log and payload store."""
-
+def _audit_log_bytes(log_path: Path) -> int:
     try:
-        total = log_path.stat().st_size
+        return log_path.stat().st_size
     except OSError:
-        total = 0
+        return 0
 
+
+def _audit_storage_bytes(log_path: Path) -> int:
+    """Return the cheap on-disk size used by retained audit data."""
+
+    total = _audit_log_bytes(log_path)
     directory = _payload_directory_path(log_path)
     try:
         with os.scandir(directory) as entries:
             for entry in entries:
+                if not entry.name.endswith(".json.gz"):
+                    continue
                 try:
                     if entry.is_file():
                         total += entry.stat().st_size
@@ -287,22 +301,43 @@ def _audit_storage_bytes(log_path: Path) -> int:
     return total
 
 
+def _audit_pressure_backoff_active(log_path: Path) -> bool:
+    key = os.fspath(log_path)
+    deadline = _AUDIT_PRESSURE_BACKOFF_UNTIL.get(key)
+    if deadline is None:
+        return False
+    if time.monotonic() < deadline:
+        return True
+    _AUDIT_PRESSURE_BACKOFF_UNTIL.pop(key, None)
+    return False
+
+
 def _audit_storage_limit_exceeded(log_path: Path, max_bytes: int) -> bool:
-    return max_bytes > 0 and _audit_storage_bytes(log_path) > max_bytes
+    if max_bytes <= 0:
+        return False
+    if _audit_log_bytes(log_path) > max_bytes:
+        return True
+    if _audit_pressure_backoff_active(log_path):
+        return False
+    return _audit_storage_bytes(log_path) > max_bytes
 
 
 def _audit_maintenance_due(log_path: Path) -> bool:
     now = time.monotonic()
-    key = os.fspath(log_path)
-    previous = _AUDIT_LAST_MAINTENANCE.get(key)
-    if previous is None:
-        _AUDIT_LAST_MAINTENANCE[key] = now
-        return False
-    return now - previous >= _AUDIT_MAINTENANCE_INTERVAL_S
+    previous = _AUDIT_LAST_MAINTENANCE.get(os.fspath(log_path))
+    return previous is None or now - previous >= _AUDIT_MAINTENANCE_INTERVAL_S
 
 
 def _mark_audit_maintenance(log_path: Path) -> None:
     _AUDIT_LAST_MAINTENANCE[os.fspath(log_path)] = time.monotonic()
+
+
+def _update_audit_pressure_backoff(log_path: Path, max_bytes: int) -> None:
+    key = os.fspath(log_path)
+    if max_bytes > 0 and _audit_storage_bytes(log_path) > max_bytes:
+        _AUDIT_PRESSURE_BACKOFF_UNTIL[key] = time.monotonic() + _AUDIT_PAYLOAD_PRUNE_GRACE_S
+    else:
+        _AUDIT_PRESSURE_BACKOFF_UNTIL.pop(key, None)
 
 
 def _encode_audit_record(record: dict[str, Any]) -> bytes:
@@ -565,6 +600,7 @@ def audit(event: str, **fields: Any) -> None:
         if retention_needed or maintenance_due:
             _enforce_audit_storage_limit(path, settings.max_audit_log_bytes)
             _mark_audit_maintenance(path)
+            _update_audit_pressure_backoff(path, settings.max_audit_log_bytes)
 
 
 _TOOL_OPERATION_GROUPS: dict[str, frozenset[str]] = {

--- a/src/local_shell_mcp/audit.py
+++ b/src/local_shell_mcp/audit.py
@@ -133,7 +133,8 @@ def _write_payload(value: Any) -> dict[str, Any]:
             "preview": _preview_audit_value(value),
         }
     path = _payload_path(digest)
-    if not path.exists():
+    created = not path.exists()
+    if created:
         temporary = path.with_name(f".{path.name}.{os.getpid()}.{threading.get_ident()}.tmp")
         try:
             _write_private_bytes(
@@ -144,7 +145,8 @@ def _write_payload(value: Any) -> dict[str, Any]:
         finally:
             with contextlib.suppress(OSError):
                 temporary.unlink(missing_ok=True)
-    _AUDIT_PRESSURE_BACKOFF_UNTIL.pop(os.fspath(get_settings().audit_log_path), None)
+    if created:
+        _AUDIT_PRESSURE_BACKOFF_UNTIL.pop(os.fspath(get_settings().audit_log_path), None)
     return {
         _AUDIT_PAYLOAD_MARKER: {
             "version": _AUDIT_PAYLOAD_VERSION,
@@ -235,15 +237,15 @@ def _collect_payload_ids(record: Any, destination: set[str]) -> None:
             destination.add(_payload_digest(value))
 
 
-def _prune_payload_store(log_path: Path) -> None:
+def _prune_payload_store(log_path: Path) -> bool:
     directory = _payload_directory_path(log_path)
     if not directory.is_dir():
-        return
+        return True
     referenced: set[str] = set()
     try:
         lines = log_path.read_text(encoding="utf-8", errors="ignore").splitlines()
     except OSError:
-        return
+        return False
     for line in lines:
         with contextlib.suppress(json.JSONDecodeError):
             _collect_payload_ids(json.loads(line), referenced)
@@ -265,6 +267,7 @@ def _prune_payload_store(log_path: Path) -> None:
             temporary.unlink()
         except OSError:
             continue
+    return True
 
 
 def _payload_file_size(digest: str, log_path: Path | None = None) -> int:
@@ -459,20 +462,19 @@ def _select_retention_lines(
     return selected
 
 
-def _enforce_audit_storage_limit(log_path: Path, max_bytes: int) -> None:
+def _enforce_audit_storage_limit(log_path: Path, max_bytes: int) -> bool:
     if max_bytes <= 0 or not log_path.exists():
-        return
+        return True
     try:
         raw_lines = log_path.read_bytes().splitlines(keepends=True)
     except OSError:
-        return
+        return False
 
     parsed, all_referenced = _parse_retention_lines(raw_lines)
     payload_sizes = {digest: _payload_file_size(digest, log_path) for digest in all_referenced}
     selected = _select_retention_lines(parsed, payload_sizes, max_bytes)
     if selected is None:
-        _prune_payload_store(log_path)
-        return
+        return _prune_payload_store(log_path)
 
     temporary = log_path.with_name(f".{log_path.name}.{os.getpid()}.{threading.get_ident()}.tmp")
     try:
@@ -481,7 +483,7 @@ def _enforce_audit_storage_limit(log_path: Path, max_bytes: int) -> None:
     finally:
         with contextlib.suppress(OSError):
             temporary.unlink(missing_ok=True)
-    _prune_payload_store(log_path)
+    return _prune_payload_store(log_path)
 
 
 def _enforce_state_audit_storage_limit(max_bytes: int) -> None:
@@ -598,9 +600,10 @@ def audit(event: str, **fields: Any) -> None:
         retention_needed = _audit_storage_limit_exceeded(path, settings.max_audit_log_bytes)
         maintenance_due = settings.max_audit_log_bytes > 0 and _audit_maintenance_due(path)
         if retention_needed or maintenance_due:
-            _enforce_audit_storage_limit(path, settings.max_audit_log_bytes)
-            _mark_audit_maintenance(path)
-            _update_audit_pressure_backoff(path, settings.max_audit_log_bytes)
+            maintained = _enforce_audit_storage_limit(path, settings.max_audit_log_bytes)
+            if maintained:
+                _mark_audit_maintenance(path)
+                _update_audit_pressure_backoff(path, settings.max_audit_log_bytes)
 
 
 _TOOL_OPERATION_GROUPS: dict[str, frozenset[str]] = {

--- a/src/local_shell_mcp/audit.py
+++ b/src/local_shell_mcp/audit.py
@@ -250,6 +250,7 @@ def _prune_payload_store(log_path: Path) -> bool:
         with contextlib.suppress(json.JSONDecodeError):
             _collect_payload_ids(json.loads(line), referenced)
     prune_before = time.time() - _AUDIT_PAYLOAD_PRUNE_GRACE_S
+    complete = True
     for payload in directory.glob("*.json.gz"):
         digest = payload.name.removesuffix(".json.gz")
         if digest in referenced:
@@ -259,15 +260,15 @@ def _prune_payload_store(log_path: Path) -> bool:
                 continue
             payload.unlink()
         except OSError:
-            continue
+            complete = False
     for temporary in directory.glob(".*.tmp"):
         try:
             if temporary.stat().st_mtime > prune_before:
                 continue
             temporary.unlink()
         except OSError:
-            continue
-    return True
+            complete = False
+    return complete
 
 
 def _payload_file_size(digest: str, log_path: Path | None = None) -> int:

--- a/src/local_shell_mcp/audit.py
+++ b/src/local_shell_mcp/audit.py
@@ -28,6 +28,8 @@ _AUDIT_PREVIEW_STRING_CHARS = 2_000
 _AUDIT_PREVIEW_ITEMS = 100
 _AUDIT_INLINE_VALUE_BYTES = 16 * 1024
 _AUDIT_PAYLOAD_PRUNE_GRACE_S = 300
+_AUDIT_MAINTENANCE_INTERVAL_S = _AUDIT_PAYLOAD_PRUNE_GRACE_S
+_AUDIT_LAST_MAINTENANCE: dict[str, float] = {}
 _AUDIT_PAYLOAD_DIRECTORY = "audit-payloads"
 _AUDIT_PAYLOAD_MARKER = "$local_shell_mcp_audit_payload"
 _AUDIT_PAYLOAD_VERSION = 1
@@ -261,6 +263,46 @@ def _payload_file_size(digest: str, log_path: Path | None = None) -> int:
         return _payload_path(digest, log_path).stat().st_size
     except OSError:
         return 0
+
+
+def _audit_storage_bytes(log_path: Path) -> int:
+    """Return the cheap on-disk size used by the audit log and payload store."""
+
+    try:
+        total = log_path.stat().st_size
+    except OSError:
+        total = 0
+
+    directory = _payload_directory_path(log_path)
+    try:
+        with os.scandir(directory) as entries:
+            for entry in entries:
+                try:
+                    if entry.is_file():
+                        total += entry.stat().st_size
+                except OSError:
+                    continue
+    except OSError:
+        pass
+    return total
+
+
+def _audit_storage_limit_exceeded(log_path: Path, max_bytes: int) -> bool:
+    return max_bytes > 0 and _audit_storage_bytes(log_path) > max_bytes
+
+
+def _audit_maintenance_due(log_path: Path) -> bool:
+    now = time.monotonic()
+    key = os.fspath(log_path)
+    previous = _AUDIT_LAST_MAINTENANCE.get(key)
+    if previous is None:
+        _AUDIT_LAST_MAINTENANCE[key] = now
+        return False
+    return now - previous >= _AUDIT_MAINTENANCE_INTERVAL_S
+
+
+def _mark_audit_maintenance(log_path: Path) -> None:
+    _AUDIT_LAST_MAINTENANCE[os.fspath(log_path)] = time.monotonic()
 
 
 def _encode_audit_record(record: dict[str, Any]) -> bytes:
@@ -518,7 +560,11 @@ def audit(event: str, **fields: Any) -> None:
             f.flush()
         with contextlib.suppress(OSError):
             path.chmod(0o600)
-        _enforce_audit_storage_limit(path, settings.max_audit_log_bytes)
+        retention_needed = _audit_storage_limit_exceeded(path, settings.max_audit_log_bytes)
+        maintenance_due = settings.max_audit_log_bytes > 0 and _audit_maintenance_due(path)
+        if retention_needed or maintenance_due:
+            _enforce_audit_storage_limit(path, settings.max_audit_log_bytes)
+            _mark_audit_maintenance(path)
 
 
 _TOOL_OPERATION_GROUPS: dict[str, frozenset[str]] = {

--- a/tests/test_audit_ui_complete.py
+++ b/tests/test_audit_ui_complete.py
@@ -296,13 +296,19 @@ def test_payload_pruning_defers_recent_unreferenced_files(tmp_path, monkeypatch)
     reference = audit_module._write_payload("pending:" + "x" * 30_000)
     payload = audit_module._payload_path(audit_module._payload_digest(reference))
 
+    temporary = audit_module._payload_directory(log_path) / ".interrupted.json.gz.123.tmp"
+    temporary.write_bytes(b"partial")
+
     audit_module._prune_payload_store(log_path)
     assert payload.exists()
+    assert temporary.exists()
 
     stale = time.time() - audit_module._AUDIT_PAYLOAD_PRUNE_GRACE_S - 1
     os.utime(payload, (stale, stale))
+    os.utime(temporary, (stale, stale))
     audit_module._prune_payload_store(log_path)
     assert not payload.exists()
+    assert not temporary.exists()
 
 
 def test_payload_pruning_defers_when_the_log_cannot_be_read(tmp_path, monkeypatch):
@@ -475,7 +481,7 @@ def test_audit_skips_full_retention_scan_while_storage_is_below_budget(tmp_path,
     for index in range(100):
         audit_module.audit("small_event", index=index)
 
-    assert calls == 0
+    assert calls == 1
     assert len(log_path.read_text(encoding="utf-8").splitlines()) == 101
 
 
@@ -484,7 +490,7 @@ def test_audit_periodically_runs_payload_housekeeping_below_budget(tmp_path, mon
     monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_LOG_BYTES", "20000000")
     get_settings.cache_clear()
     log_path = get_settings().audit_log_path
-    audit_module._AUDIT_LAST_MAINTENANCE[os.fspath(log_path)] = 0.0
+    audit_module._AUDIT_LAST_MAINTENANCE.pop(os.fspath(log_path), None)
     calls = 0
     original = audit_module._enforce_audit_storage_limit
 
@@ -496,6 +502,67 @@ def test_audit_periodically_runs_payload_housekeeping_below_budget(tmp_path, mon
     monkeypatch.setattr(audit_module, "_enforce_audit_storage_limit", track_enforcement)
 
     audit_module.audit("maintenance_event")
+
+    assert calls == 1
+
+
+def test_audit_pressure_backoff_avoids_repeated_scans_for_recent_orphans(
+    tmp_path, monkeypatch
+):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_LOG_BYTES", "12000")
+    get_settings.cache_clear()
+    log_path = get_settings().audit_log_path
+    log_path.write_text("{}\n", encoding="utf-8")
+    audit_module._write_payload(os.urandom(18_000).hex())
+    calls = 0
+    original = audit_module._enforce_audit_storage_limit
+
+    def track_enforcement(path: Path, max_bytes: int) -> None:
+        nonlocal calls
+        calls += 1
+        original(path, max_bytes)
+
+    monkeypatch.setattr(audit_module, "_enforce_audit_storage_limit", track_enforcement)
+
+    audit_module.audit("pressure_trigger")
+    for index in range(20):
+        audit_module.audit("small_event", index=index)
+
+    assert calls == 1
+    assert audit_module._audit_pressure_backoff_active(log_path) is True
+
+
+def test_audit_storage_size_ignores_interrupted_payload_temporaries(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    log_path = get_settings().audit_log_path
+    log_path.write_bytes(b"{}\n")
+    directory = log_path.parent / audit_module._AUDIT_PAYLOAD_DIRECTORY
+    directory.mkdir()
+    (directory / ".interrupted.json.gz.123.tmp").write_bytes(b"x" * 50_000)
+
+    assert audit_module._audit_storage_bytes(log_path) == log_path.stat().st_size
+
+
+def test_new_payload_clears_pressure_backoff_and_rechecks_budget(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_LOG_BYTES", "12000")
+    get_settings.cache_clear()
+    log_path = get_settings().audit_log_path
+    key = os.fspath(log_path)
+    audit_module._AUDIT_LAST_MAINTENANCE[key] = time.monotonic()
+    audit_module._AUDIT_PRESSURE_BACKOFF_UNTIL[key] = time.monotonic() + 300
+    calls = 0
+    original = audit_module._enforce_audit_storage_limit
+
+    def track_enforcement(path: Path, max_bytes: int) -> None:
+        nonlocal calls
+        calls += 1
+        original(path, max_bytes)
+
+    monkeypatch.setattr(audit_module, "_enforce_audit_storage_limit", track_enforcement)
+
+    audit_module.audit("large_event", payload=os.urandom(18_000).hex())
 
     assert calls == 1
 

--- a/tests/test_audit_ui_complete.py
+++ b/tests/test_audit_ui_complete.py
@@ -324,9 +324,35 @@ def test_payload_pruning_defers_when_the_log_cannot_be_read(tmp_path, monkeypatc
         raise OSError("temporary read failure")
 
     monkeypatch.setattr(Path, "read_text", fail_read_text)
-    audit_module._prune_payload_store(log_path)
 
+    assert audit_module._prune_payload_store(log_path) is False
     assert payload.exists()
+
+
+def test_payload_pruning_retries_transient_stale_delete_failure(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    log_path = get_settings().audit_log_path
+    log_path.write_text("{}\n", encoding="utf-8")
+    reference = audit_module._write_payload(os.urandom(18_000).hex())
+    payload = audit_module._payload_path(audit_module._payload_digest(reference))
+    stale = time.time() - audit_module._AUDIT_PAYLOAD_PRUNE_GRACE_S - 1
+    os.utime(payload, (stale, stale))
+    original_unlink = Path.unlink
+    failures = 0
+
+    def fail_once(path: Path, *args, **kwargs):
+        nonlocal failures
+        if path == payload and failures == 0:
+            failures += 1
+            raise OSError("transient delete failure")
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fail_once)
+
+    assert audit_module._enforce_audit_storage_limit(log_path, 200_000) is False
+    assert payload.exists()
+    assert audit_module._enforce_audit_storage_limit(log_path, 200_000) is True
+    assert not payload.exists()
 
 
 def test_get_audit_entry_rejects_empty_and_unknown_ids(tmp_path, monkeypatch):

--- a/tests/test_audit_ui_complete.py
+++ b/tests/test_audit_ui_complete.py
@@ -453,6 +453,76 @@ def test_audit_payload_helpers_cover_edge_paths(tmp_path, monkeypatch):
     assert retained["audit_payloads_omitted"] == "record exceeded audit retention limit"
 
 
+def test_audit_skips_full_retention_scan_while_storage_is_below_budget(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_LOG_BYTES", "20000000")
+    get_settings.cache_clear()
+    log_path = get_settings().audit_log_path
+    log_path.write_text(
+        json.dumps({"id": "seed", "ts": 1, "event": "seed", "detail": "x" * 1_000_000}) + "\n",
+        encoding="utf-8",
+    )
+    calls = 0
+    original = audit_module._enforce_audit_storage_limit
+
+    def track_enforcement(path: Path, max_bytes: int) -> None:
+        nonlocal calls
+        calls += 1
+        original(path, max_bytes)
+
+    monkeypatch.setattr(audit_module, "_enforce_audit_storage_limit", track_enforcement)
+
+    for index in range(100):
+        audit_module.audit("small_event", index=index)
+
+    assert calls == 0
+    assert len(log_path.read_text(encoding="utf-8").splitlines()) == 101
+
+
+def test_audit_periodically_runs_payload_housekeeping_below_budget(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_LOG_BYTES", "20000000")
+    get_settings.cache_clear()
+    log_path = get_settings().audit_log_path
+    audit_module._AUDIT_LAST_MAINTENANCE[os.fspath(log_path)] = 0.0
+    calls = 0
+    original = audit_module._enforce_audit_storage_limit
+
+    def track_enforcement(path: Path, max_bytes: int) -> None:
+        nonlocal calls
+        calls += 1
+        original(path, max_bytes)
+
+    monkeypatch.setattr(audit_module, "_enforce_audit_storage_limit", track_enforcement)
+
+    audit_module.audit("maintenance_event")
+
+    assert calls == 1
+
+
+def test_audit_enters_full_retention_scan_only_after_storage_exceeds_budget(
+    tmp_path, monkeypatch
+):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_LOG_BYTES", "3000")
+    get_settings.cache_clear()
+    calls = 0
+    original = audit_module._enforce_audit_storage_limit
+
+    def track_enforcement(path: Path, max_bytes: int) -> None:
+        nonlocal calls
+        calls += 1
+        original(path, max_bytes)
+
+    monkeypatch.setattr(audit_module, "_enforce_audit_storage_limit", track_enforcement)
+
+    for index in range(100):
+        audit_module.audit("budget_pressure", index=index, detail="x" * 80)
+
+    assert calls > 0
+    assert get_settings().audit_log_path.stat().st_size <= 3000
+
+
 def test_small_retention_budget_externalizes_recoverable_values(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
     monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_LOG_BYTES", "12000")

--- a/tests/test_audit_ui_complete.py
+++ b/tests/test_audit_ui_complete.py
@@ -471,10 +471,10 @@ def test_audit_skips_full_retention_scan_while_storage_is_below_budget(tmp_path,
     calls = 0
     original = audit_module._enforce_audit_storage_limit
 
-    def track_enforcement(path: Path, max_bytes: int) -> None:
+    def track_enforcement(path: Path, max_bytes: int) -> bool:
         nonlocal calls
         calls += 1
-        original(path, max_bytes)
+        return original(path, max_bytes)
 
     monkeypatch.setattr(audit_module, "_enforce_audit_storage_limit", track_enforcement)
 
@@ -494,10 +494,10 @@ def test_audit_periodically_runs_payload_housekeeping_below_budget(tmp_path, mon
     calls = 0
     original = audit_module._enforce_audit_storage_limit
 
-    def track_enforcement(path: Path, max_bytes: int) -> None:
+    def track_enforcement(path: Path, max_bytes: int) -> bool:
         nonlocal calls
         calls += 1
-        original(path, max_bytes)
+        return original(path, max_bytes)
 
     monkeypatch.setattr(audit_module, "_enforce_audit_storage_limit", track_enforcement)
 
@@ -518,10 +518,10 @@ def test_audit_pressure_backoff_avoids_repeated_scans_for_recent_orphans(
     calls = 0
     original = audit_module._enforce_audit_storage_limit
 
-    def track_enforcement(path: Path, max_bytes: int) -> None:
+    def track_enforcement(path: Path, max_bytes: int) -> bool:
         nonlocal calls
         calls += 1
-        original(path, max_bytes)
+        return original(path, max_bytes)
 
     monkeypatch.setattr(audit_module, "_enforce_audit_storage_limit", track_enforcement)
 
@@ -555,16 +555,72 @@ def test_new_payload_clears_pressure_backoff_and_rechecks_budget(tmp_path, monke
     calls = 0
     original = audit_module._enforce_audit_storage_limit
 
-    def track_enforcement(path: Path, max_bytes: int) -> None:
+    def track_enforcement(path: Path, max_bytes: int) -> bool:
         nonlocal calls
         calls += 1
-        original(path, max_bytes)
+        return original(path, max_bytes)
 
     monkeypatch.setattr(audit_module, "_enforce_audit_storage_limit", track_enforcement)
 
     audit_module.audit("large_event", payload=os.urandom(18_000).hex())
 
     assert calls == 1
+
+
+def test_reused_payload_preserves_pressure_backoff(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_LOG_BYTES", "12000")
+    get_settings.cache_clear()
+    log_path = get_settings().audit_log_path
+    key = os.fspath(log_path)
+    value = os.urandom(18_000).hex()
+    audit_module._write_payload(value)
+    audit_module._AUDIT_LAST_MAINTENANCE[key] = time.monotonic()
+    audit_module._AUDIT_PRESSURE_BACKOFF_UNTIL[key] = time.monotonic() + 300
+    calls = 0
+    original = audit_module._enforce_audit_storage_limit
+
+    def track_enforcement(path: Path, max_bytes: int) -> bool:
+        nonlocal calls
+        calls += 1
+        return original(path, max_bytes)
+
+    monkeypatch.setattr(audit_module, "_enforce_audit_storage_limit", track_enforcement)
+
+    audit_module.audit("reused_payload", payload=value)
+
+    assert calls == 0
+    assert audit_module._audit_pressure_backoff_active(log_path) is True
+
+
+def test_failed_retention_pass_is_retried_without_backoff(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_LOG_BYTES", "12000")
+    get_settings.cache_clear()
+    log_path = get_settings().audit_log_path
+    key = os.fspath(log_path)
+    original_read_bytes = Path.read_bytes
+    failures = 0
+
+    def fail_once(path: Path) -> bytes:
+        nonlocal failures
+        if path == log_path and failures == 0:
+            failures += 1
+            raise OSError("transient audit read failure")
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", fail_once)
+
+    audit_module.audit("large_event", payload=os.urandom(18_000).hex())
+
+    assert failures == 1
+    assert key not in audit_module._AUDIT_LAST_MAINTENANCE
+    assert key not in audit_module._AUDIT_PRESSURE_BACKOFF_UNTIL
+
+    audit_module.audit("retry_event")
+
+    assert key in audit_module._AUDIT_LAST_MAINTENANCE
+    assert audit_module._audit_pressure_backoff_active(log_path) is True
 
 
 def test_audit_enters_full_retention_scan_only_after_storage_exceeds_budget(
@@ -576,10 +632,10 @@ def test_audit_enters_full_retention_scan_only_after_storage_exceeds_budget(
     calls = 0
     original = audit_module._enforce_audit_storage_limit
 
-    def track_enforcement(path: Path, max_bytes: int) -> None:
+    def track_enforcement(path: Path, max_bytes: int) -> bool:
         nonlocal calls
         calls += 1
-        original(path, max_bytes)
+        return original(path, max_bytes)
 
     monkeypatch.setattr(audit_module, "_enforce_audit_storage_limit", track_enforcement)
 


### PR DESCRIPTION
## Summary
- replace per-event full audit JSONL retention scans with a cheap log + payload storage-size check
- run full retention immediately only under storage pressure
- retain stale payload housekeeping with a throttled maintenance pass aligned to the existing 5-minute payload prune grace period
- add regression tests for below-budget fast path, periodic housekeeping, and budget-pressure enforcement

## Why
`audit()` currently calls `_enforce_audit_storage_limit()` after every event. That reads and parses the entire audit JSONL while holding the global audit lock. With the live audit log around 14 MB and multiple MCP sessions, this serializes otherwise cheap tool calls and makes `apply_patch` routinely take tens of seconds.

A local benchmark against a copy of the current audit log measured roughly 620 ms for one full retention scan versus ~0.02 ms for the new log-size fast check before payload-directory scanning. The live payload directory has about 170 files and its size scan is ~2 ms, so the normal hot path remains orders of magnitude cheaper.

## Validation
- `ruff check .`
- `pytest -q` → 704 passed, 1 skipped
- existing audit payload, paired-call retention, and concurrent append tests pass
