### PR TITLE
feat: add unified package distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -456,6 +456,7 @@ jobs:
           /tmp/local-shell-mcp-wheel-venv/bin/python -m pip install --upgrade pip
           /tmp/local-shell-mcp-wheel-venv/bin/python -m pip install dist/*.whl
           /tmp/local-shell-mcp-wheel-venv/bin/local-shell-mcp --version
+          /tmp/local-shell-mcp-wheel-venv/bin/lsm --version
           /tmp/local-shell-mcp-wheel-venv/bin/local-shell-mcp version
           /tmp/local-shell-mcp-wheel-venv/bin/python scripts/standalone-ui-smoke.py \
             --server /tmp/local-shell-mcp-wheel-venv/bin/local-shell-mcp
@@ -468,6 +469,7 @@ jobs:
           & $env:TEMP\local-shell-mcp-wheel-venv\Scripts\python.exe -m pip install --upgrade pip
           & $env:TEMP\local-shell-mcp-wheel-venv\Scripts\python.exe -m pip install (Get-Item dist\*.whl).FullName
           & $env:TEMP\local-shell-mcp-wheel-venv\Scripts\local-shell-mcp.exe --version
+          & $env:TEMP\local-shell-mcp-wheel-venv\Scripts\lsm.exe --version
           & $env:TEMP\local-shell-mcp-wheel-venv\Scripts\local-shell-mcp.exe version
           & $env:TEMP\local-shell-mcp-wheel-venv\Scripts\python.exe scripts/standalone-ui-smoke.py `
             --server $env:TEMP\local-shell-mcp-wheel-venv\Scripts\local-shell-mcp.exe
@@ -706,6 +708,32 @@ jobs:
           path: dist/*.vsix
           if-no-files-found: error
 
+  npm-launcher:
+    name: npm launcher
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: npm/package-lock.json
+
+      - name: Install launcher metadata
+        working-directory: npm
+        run: npm ci --ignore-scripts
+
+      - name: Test launcher
+        working-directory: npm
+        run: npm test
+
+      - name: Inspect publish tarball
+        working-directory: npm
+        run: npm pack --dry-run
+
   ci-summary:
     name: CI / all matrix jobs passed
     runs-on: ubuntu-24.04
@@ -723,6 +751,7 @@ jobs:
       - compose
       - binary-release-matrix
       - vscode-extension
+      - npm-launcher
     if: always()
     steps:
       - name: Check aggregate result

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,6 +168,7 @@ jobs:
           /tmp/local-shell-mcp-wheel-venv/bin/python -m pip install --upgrade pip
           /tmp/local-shell-mcp-wheel-venv/bin/python -m pip install dist/*.whl
           /tmp/local-shell-mcp-wheel-venv/bin/local-shell-mcp --version
+          /tmp/local-shell-mcp-wheel-venv/bin/lsm --version
           /tmp/local-shell-mcp-wheel-venv/bin/python scripts/standalone-ui-smoke.py \
             --server /tmp/local-shell-mcp-wheel-venv/bin/local-shell-mcp
 
@@ -179,6 +180,7 @@ jobs:
           & $env:TEMP\local-shell-mcp-wheel-venv\Scripts\python.exe -m pip install --upgrade pip
           & $env:TEMP\local-shell-mcp-wheel-venv\Scripts\python.exe -m pip install (Get-Item dist\*.whl).FullName
           & $env:TEMP\local-shell-mcp-wheel-venv\Scripts\local-shell-mcp.exe --version
+          & $env:TEMP\local-shell-mcp-wheel-venv\Scripts\lsm.exe --version
           & $env:TEMP\local-shell-mcp-wheel-venv\Scripts\python.exe scripts/standalone-ui-smoke.py `
             --server $env:TEMP\local-shell-mcp-wheel-venv\Scripts\local-shell-mcp.exe
 
@@ -307,6 +309,12 @@ jobs:
             Generate and export LOCAL_SHELL_MCP_OAUTH_ADMIN_PIN as at least 8 random characters.
             Generate and export LOCAL_SHELL_MCP_OAUTH_JWT_SECRET as at least 32 random bytes.
           EOF
+          raw_name="local-shell-mcp-${{ matrix.artifact }}"
+          if [[ "${{ matrix.binary }}" == *.exe ]]; then
+            raw_name="${raw_name}.exe"
+          fi
+          cp "dist/${{ matrix.binary }}" "release/${raw_name}"
+
           cd release
           if [[ "${{ matrix.archive }}" == "zip" ]]; then
             7z a local-shell-mcp-${{ matrix.artifact }}.zip local-shell-mcp-${{ matrix.artifact }} >/dev/null
@@ -319,7 +327,7 @@ jobs:
         with:
           name: binary-${{ matrix.artifact }}
           path: |
-            release/local-shell-mcp-${{ matrix.artifact }}.*
+            release/local-shell-mcp-${{ matrix.artifact }}*
           if-no-files-found: error
 
 
@@ -361,7 +369,7 @@ jobs:
         with:
           name: vscode-extension
           path: |
-            dist/local-shell-mcp-vscode-*.vsix
+            dist/local-shell-mcp-*.vsix
           if-no-files-found: error
 
   publish-docker-platform:
@@ -497,6 +505,13 @@ jobs:
           path: dist
 
 
+      - name: Generate SHA256 checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dist
+          sha256sum * > SHA256SUMS
+
       - name: Create release notes
         run: |
           # shellcheck disable=SC2006
@@ -535,7 +550,7 @@ jobs:
           VS Code extension download:
 
           \`\`\`text
-          local-shell-mcp-vscode-${{ needs.validate-release.outputs.version }}.vsix
+          local-shell-mcp-${{ needs.validate-release.outputs.version }}.vsix
           \`\`\`
 
           Python package artifacts, executable archives, and the VS Code extension are attached below.
@@ -552,3 +567,113 @@ jobs:
           generate_release_notes: true
           body_path: RELEASE_NOTES.md
           files: dist/*
+
+  publish-pypi:
+    name: Publish to PyPI
+    if: ${{ vars.PYPI_PUBLISH_ENABLED == 'true' }}
+    runs-on: ubuntu-latest
+    needs:
+      - validate-release
+      - github-release
+    environment: pypi
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Download Python package artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: python-dist-*
+          path: dist
+          merge-multiple: true
+
+      - name: Publish Python distributions
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-npm:
+    name: Publish npm launcher
+    if: ${{ vars.NPM_PUBLISH_ENABLED == 'true' }}
+    runs-on: ubuntu-latest
+    needs:
+      - validate-release
+      - github-release
+    environment: npm
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          package-manager-cache: false
+
+      - name: Prepare npm launcher version
+        working-directory: npm
+        env:
+          RELEASE_TAG: ${{ github.event.inputs.tag }}
+          RELEASE_VERSION: ${{ needs.validate-release.outputs.version }}
+        run: |
+          npm version "$RELEASE_VERSION" --no-git-tag-version --allow-same-version
+          npm pkg set "localShellMcp.releaseTag=$RELEASE_TAG"
+
+      - name: Test npm launcher
+        working-directory: npm
+        run: npm test
+
+      - name: Publish npm launcher
+        working-directory: npm
+        run: |
+          npm install --global npm@11
+          npm publish --provenance
+
+  publish-vscode-marketplace:
+    name: Publish VS Code Marketplace extension
+    if: ${{ vars.VSCODE_MARKETPLACE_PUBLISH_ENABLED == 'true' }}
+    runs-on: ubuntu-latest
+    needs:
+      - validate-release
+      - github-release
+    environment: vscode-marketplace
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Download VSIX
+        uses: actions/download-artifact@v8
+        with:
+          name: vscode-extension
+          path: dist
+
+      - name: Publish extension
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: npx --yes @vscode/vsce@3.6.2 publish --packagePath "dist/local-shell-mcp-${{ needs.validate-release.outputs.version }}.vsix" -p "$VSCE_PAT"
+
+  publish-open-vsx:
+    name: Publish Open VSX extension
+    if: ${{ vars.OPENVSX_PUBLISH_ENABLED == 'true' }}
+    runs-on: ubuntu-latest
+    needs:
+      - validate-release
+      - github-release
+    environment: open-vsx
+    steps:
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Download VSIX
+        uses: actions/download-artifact@v8
+        with:
+          name: vscode-extension
+          path: dist
+
+      - name: Publish extension
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        run: npx --yes ovsx publish "dist/local-shell-mcp-${{ needs.validate-release.outputs.version }}.vsix" -p "$OVSX_PAT"

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ The intended safety boundary is the container or VM, not the host.
 
 ## Quick start
 
+Install the official launcher or Python package when you want a host runtime:
+
+```bash
+npx local-shell-mcp --help
+pipx install local-shell-mcp
+lsm --help
+```
+
+The npm and Python distributions both expose `local-shell-mcp`; installed packages also expose `lsm` as the short command. The npm distribution is only a verified launcher for the matching standalone release binary, not a second server implementation.
+
 Clone the repository and prepare configuration:
 
 ```bash
@@ -143,7 +153,7 @@ See the [DeepSeek Harness integration guide](https://fwerkor.github.io/local-she
 
 ## VS Code extension runtime
 
-Release assets include `local-shell-mcp-vscode-<version>.vsix`. The extension is a runtime launcher for the current VS Code workspace. It starts the same server, checks `/healthz`, copies the MCP URL, and copies a ready-to-paste ChatGPT setup prompt.
+Release assets include `local-shell-mcp-<version>.vsix`. The extension is a runtime launcher for the current VS Code workspace. It starts the same server, checks `/healthz`, copies the MCP URL, and copies a ready-to-paste ChatGPT setup prompt.
 
 Basic flow:
 

--- a/docs/installation/vscode-extension.md
+++ b/docs/installation/vscode-extension.md
@@ -48,7 +48,7 @@ or download the release binary for your OS and put it on `PATH`.
 Then install the VSIX release asset:
 
 ```bash
-code --install-extension local-shell-mcp-vscode-<version>.vsix
+code --install-extension local-shell-mcp-<version>.vsix
 ```
 
 Alternatively, use **Extensions: Install from VSIX...** in the command palette.

--- a/docs/installation/vscode-extension.zh-Hant.md
+++ b/docs/installation/vscode-extension.zh-Hant.md
@@ -48,7 +48,7 @@ pipx install local-shell-mcp
 然後安裝 VSIX release 資產：
 
 ```bash
-code --install-extension local-shell-mcp-vscode-<version>.vsix
+code --install-extension local-shell-mcp-<version>.vsix
 ```
 
 也可以在命令面板中使用 **Extensions: Install from VSIX...**。

--- a/docs/installation/vscode-extension.zh.md
+++ b/docs/installation/vscode-extension.zh.md
@@ -48,7 +48,7 @@ pipx install local-shell-mcp
 然后安装 VSIX release 资产：
 
 ```bash
-code --install-extension local-shell-mcp-vscode-<version>.vsix
+code --install-extension local-shell-mcp-<version>.vsix
 ```
 
 也可以在命令面板中使用 **Extensions: Install from VSIX...**。

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,18 @@
+# local-shell-mcp npm launcher
+
+This is the official npm launcher for [local-shell-mcp](https://github.com/fwerkor/local-shell-mcp).
+It downloads the matching release-attached standalone executable from the project's GitHub Release,
+verifies it against `SHA256SUMS`, caches it locally, and then passes through all command-line arguments.
+
+```bash
+npx local-shell-mcp --help
+```
+
+A global install also exposes the short `lsm` command:
+
+```bash
+npm install -g local-shell-mcp
+lsm --help
+```
+
+The npm package is a launcher, not a separate JavaScript implementation of the server.

--- a/npm/bin/local-shell-mcp.js
+++ b/npm/bin/local-shell-mcp.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { spawn } from "node:child_process";
+import { chmod, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const packageJson = JSON.parse(await readFile(join(packageRoot, "package.json"), "utf8"));
+
+function platformAsset() {
+  const key = `${process.platform}/${process.arch}`;
+  const assets = {
+    "linux/x64": "local-shell-mcp-linux-x86_64",
+    "linux/arm64": "local-shell-mcp-linux-aarch64",
+    "darwin/x64": "local-shell-mcp-macos-x86_64",
+    "darwin/arm64": "local-shell-mcp-macos-aarch64",
+    "win32/x64": "local-shell-mcp-windows-x86_64.exe"
+  };
+  const asset = assets[key];
+  if (!asset) {
+    throw new Error(
+      `No local-shell-mcp standalone executable is published for ${key}. ` +
+        "Use the Python, Docker, or source installation instead."
+    );
+  }
+  return asset;
+}
+
+function cacheRoot() {
+  if (process.env.LOCAL_SHELL_MCP_NPM_CACHE) return process.env.LOCAL_SHELL_MCP_NPM_CACHE;
+  if (process.platform === "win32" && process.env.LOCALAPPDATA) {
+    return join(process.env.LOCALAPPDATA, "local-shell-mcp", "npm");
+  }
+  if (process.platform === "darwin") {
+    return join(homedir(), "Library", "Caches", "local-shell-mcp", "npm");
+  }
+  return join(process.env.XDG_CACHE_HOME || join(homedir(), ".cache"), "local-shell-mcp", "npm");
+}
+
+async function fetchBytes(url) {
+  const response = await fetch(url, {
+    headers: { "User-Agent": `local-shell-mcp-npm/${packageJson.version}` },
+    redirect: "follow"
+  });
+  if (!response.ok) throw new Error(`HTTP ${response.status} while downloading ${url}`);
+  return Buffer.from(await response.arrayBuffer());
+}
+
+function checksumFor(checksumText, asset) {
+  for (const line of checksumText.split(/\r?\n/)) {
+    const match = line.match(/^([0-9a-fA-F]{64})\s+\*?(.+)$/);
+    if (match && match[2] === asset) return match[1].toLowerCase();
+  }
+  throw new Error(`SHA256SUMS does not contain ${asset}`);
+}
+
+async function ensureBinary() {
+  if (process.env.LOCAL_SHELL_MCP_BINARY) return process.env.LOCAL_SHELL_MCP_BINARY;
+
+  const version = packageJson.version;
+  const releaseTag = packageJson.localShellMcp?.releaseTag;
+  if (!releaseTag || version.includes("dev")) {
+    throw new Error("This development npm package is not bound to a published local-shell-mcp release.");
+  }
+
+  const asset = platformAsset();
+  const destination = join(cacheRoot(), version, asset);
+  const marker = `${destination}.sha256`;
+  try {
+    const [binary, recorded] = await Promise.all([readFile(destination), readFile(marker, "utf8")]);
+    const actual = createHash("sha256").update(binary).digest("hex");
+    if (actual === recorded.trim()) return destination;
+  } catch {
+    // Missing or stale cache entries are replaced below.
+  }
+
+  const base = `https://github.com/fwerkor/local-shell-mcp/releases/download/${encodeURIComponent(releaseTag)}`;
+  const [binary, checksumBytes] = await Promise.all([
+    fetchBytes(`${base}/${asset}`),
+    fetchBytes(`${base}/SHA256SUMS`)
+  ]);
+  const expected = checksumFor(checksumBytes.toString("utf8"), asset);
+  const actual = createHash("sha256").update(binary).digest("hex");
+  if (actual !== expected) {
+    throw new Error(`Checksum mismatch for ${asset}: expected ${expected}, got ${actual}`);
+  }
+
+  await mkdir(dirname(destination), { recursive: true });
+  const temporary = join(tmpdir(), `local-shell-mcp-${process.pid}-${Date.now()}`);
+  try {
+    await writeFile(temporary, binary, { mode: 0o755 });
+    if (process.platform !== "win32") await chmod(temporary, 0o755);
+    await rm(destination, { force: true });
+    await rename(temporary, destination);
+    await writeFile(marker, `${expected}\n`, "utf8");
+  } finally {
+    await rm(temporary, { force: true }).catch(() => {});
+  }
+  return destination;
+}
+
+async function main() {
+  const binary = await ensureBinary();
+  const child = spawn(binary, process.argv.slice(2), { stdio: "inherit" });
+  child.once("error", (error) => {
+    console.error(`local-shell-mcp: failed to start ${binary}: ${error.message}`);
+    process.exitCode = 1;
+  });
+  child.once("exit", (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exitCode = code ?? 1;
+  });
+}
+
+main().catch((error) => {
+  console.error(`local-shell-mcp: ${error.message}`);
+  process.exitCode = 1;
+});

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,0 +1,20 @@
+{
+  "name": "local-shell-mcp",
+  "version": "0.0.0-dev",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "local-shell-mcp",
+      "version": "0.0.0-dev",
+      "license": "MIT",
+      "bin": {
+        "local-shell-mcp": "bin/local-shell-mcp.js",
+        "lsm": "bin/local-shell-mcp.js"
+      },
+      "engines": {
+        "node": ">=18.17"
+      }
+    }
+  }
+}

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "local-shell-mcp",
+  "version": "0.0.0-dev",
+  "description": "Official npm launcher for local-shell-mcp, a ChatGPT-ready MCP control plane for shell, files, browser automation, and remote machines.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fwerkor/local-shell-mcp.git",
+    "directory": "npm"
+  },
+  "homepage": "https://github.com/fwerkor/local-shell-mcp#readme",
+  "bugs": {
+    "url": "https://github.com/fwerkor/local-shell-mcp/issues"
+  },
+  "keywords": [
+    "mcp",
+    "chatgpt",
+    "shell",
+    "coding-agent",
+    "playwright"
+  ],
+  "type": "module",
+  "bin": {
+    "local-shell-mcp": "./bin/local-shell-mcp.js",
+    "lsm": "./bin/local-shell-mcp.js"
+  },
+  "files": [
+    "bin/",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18.17"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  },
+  "localShellMcp": {
+    "releaseTag": "v0.0.0-dev"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/npm/test/launcher.test.mjs
+++ b/npm/test/launcher.test.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const launcher = join(root, "bin", "local-shell-mcp.js");
+
+test("launcher passes arguments to an explicitly configured executable", () => {
+  const result = spawnSync(process.execPath, [launcher, "--version"], {
+    encoding: "utf8",
+    env: { ...process.env, LOCAL_SHELL_MCP_BINARY: process.execPath }
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, new RegExp(`^v${process.versions.node.replaceAll(".", "\\.")}`));
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ Repository = "https://github.com/fwerkor/local-shell-mcp"
 
 [project.scripts]
 local-shell-mcp = "local_shell_mcp.main:main"
+lsm = "local_shell_mcp.main:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/local_shell_mcp"]

--- a/scripts/check-release-matrix.py
+++ b/scripts/check-release-matrix.py
@@ -82,6 +82,33 @@ def main() -> int:
     if "matrix.tui_binary" in package_script:
         print("Release archives must not include the OpenTUI sidecar executable.")
         return 1
+    if 'raw_name="local-shell-mcp-${{ matrix.artifact }}"' not in package_script:
+        print("Release binaries must publish raw platform executables for the npm launcher.")
+        return 1
+
+    upload_steps = binary_job.get("steps", [])
+    binary_upload = next((step for step in upload_steps if step.get("uses", "").startswith("actions/upload-artifact@")), None)
+    upload_path = str((binary_upload or {}).get("with", {}).get("path", ""))
+    if "release/local-shell-mcp-${{ matrix.artifact }}*" not in upload_path:
+        print("Release binary artifact upload must include extensionless raw executables.")
+        return 1
+
+    github_release_job = jobs.get("github-release", {})
+    checksum_script = step_script(github_release_job, "Generate SHA256 checksums")
+    if "sha256sum * > SHA256SUMS" not in checksum_script:
+        print("GitHub releases must publish SHA256SUMS for npm launcher verification.")
+        return 1
+
+    npm_job = jobs.get("publish-npm", {})
+    npm_publish_script = step_script(npm_job, "Publish npm launcher")
+    if "npm publish" not in npm_publish_script or npm_job.get("environment") != "npm":
+        print("Release workflow must publish the npm launcher from the protected npm environment.")
+        return 1
+
+    pypi_job = jobs.get("publish-pypi", {})
+    if pypi_job.get("environment") != "pypi":
+        print("Release workflow must publish Python artifacts from the protected pypi environment.")
+        return 1
 
     smoke_script = step_script(binary_job, "Smoke test embedded OpenTUI runtime")
     if "standalone-ui-smoke.py" not in smoke_script:

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "local-shell-mcp-vscode",
+  "name": "local-shell-mcp",
   "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "local-shell-mcp-vscode",
+      "name": "local-shell-mcp",
       "version": "2.3.1",
       "license": "MIT",
       "devDependencies": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "local-shell-mcp-vscode",
+  "name": "local-shell-mcp",
   "displayName": "local-shell-mcp",
   "description": "Start and manage local-shell-mcp from VS Code so ChatGPT can collaborate on the current workspace through MCP.",
   "version": "2.3.1",

--- a/vscode-extension/scripts/package-vsix.cjs
+++ b/vscode-extension/scripts/package-vsix.cjs
@@ -6,7 +6,7 @@ const path = require("node:path");
 const extensionRoot = path.resolve(__dirname, "..");
 const repoRoot = path.resolve(extensionRoot, "..");
 const pkg = require(path.join(extensionRoot, "package.json"));
-const out = path.join(repoRoot, "dist", `local-shell-mcp-vscode-${pkg.version}.vsix`);
+const out = path.join(repoRoot, "dist", `local-shell-mcp-${pkg.version}.vsix`);
 const vsce = require.resolve("@vscode/vsce/vsce");
 
 fs.mkdirSync(path.dirname(out), { recursive: true });


### PR DESCRIPTION
## Summary

- add the official `local-shell-mcp` npm launcher with `local-shell-mcp` and `lsm` commands
- expose `lsm` as a Python console-script alias
- publish raw standalone release binaries plus `SHA256SUMS` for launcher verification
- prepare gated PyPI/npm trusted publishing and VS Marketplace/Open VSX release jobs
- rename the VS Code extension id to `fwerkor.local-shell-mcp`
- add CI and release-matrix coverage for the distribution contract

## External account setup

Publishing jobs remain disabled with repository variables until registry ownership is established. GitHub environments `npm`, `pypi`, `vscode-marketplace`, and `open-vsx` already exist.

The one-time account-side steps still required are npm first publication/trusted-publisher setup, PyPI pending trusted publisher, Visual Studio Marketplace publisher/PAT, and Eclipse Open VSX publisher agreement/token. Snap name registration is separate from this PR.

## Validation

- `ruff check .`
- `python scripts/check-doc-i18n.py`
- `python scripts/check-release-matrix.py`
- npm launcher tests + `npm pack --dry-run`
- VS Code extension tests and VSIX packaging under Node 22
- workflow YAML parse
