### PR TITLE
chore: complete DSH plugin metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,10 @@
         "@deepseek-ai/dsh-client-ui-conversation"
       ],
       "platform": "web"
-    }
+    },
+    "category": "extension",
+    "displayName": "Local Shell MCP",
+    "image": "https://raw.githubusercontent.com/fwerkor/local-shell-mcp/main/docs/assets/logo.svg"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.30.0",


### PR DESCRIPTION
## Summary
- declare the DSH plugin category as `extension`
- add a human-readable `displayName`
- reuse the existing repository logo for DSH marketplace media

## Validation
- `python3 -m json.tool package.json`
- `npm pack --dry-run --json`
- verified the public logo URL returns HTTP 200 with `image/svg+xml`