### PR TITLE
ci: keep aggregate gate neutral unless jobs fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -764,11 +764,19 @@ jobs:
           import sys
 
           needs = json.loads(os.environ["NEEDS_JSON"])
-          failed = {name: data["result"] for name, data in needs.items() if data["result"] != "success"}
+          failed = {name: data["result"] for name, data in needs.items() if data["result"] == "failure"}
           if failed:
               print("Failed jobs:")
               for name, result in failed.items():
                   print(f"- {name}: {result}")
               sys.exit(1)
+
+          incomplete = {name: data["result"] for name, data in needs.items() if data["result"] != "success"}
+          if incomplete:
+              print("CI run did not complete, but no job failed:")
+              for name, result in incomplete.items():
+                  print(f"- {name}: {result}")
+              sys.exit(0)
+
           print("All CI matrix jobs passed.")
           PY


### PR DESCRIPTION
## Summary
- keep the aggregate CI gate running after upstream jobs finish or are cancelled
- fail the aggregate gate only when an upstream job has a genuine `failure` result
- treat `cancelled`/`skipped` dependencies as non-failing, so manually cancelling a partial CI run does not leave `CI / all matrix jobs passed` red

## Validation
- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- live cancellation test: workflow run `31944133932` was cancelled mid-matrix; `CI / all matrix jobs passed` completed with `success` while the workflow itself remained `cancelled`