### PR TITLE
fix: publish compliant manylinux wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -443,6 +443,10 @@ jobs:
           python -m pip install --upgrade pip build
           python -m build --wheel
 
+      - name: Validate wheel platform compatibility
+        shell: bash
+        run: python scripts/check-wheel-compatibility.py "${{ matrix.artifact }}" dist/*.whl
+
       - name: Build source distribution
         if: matrix.artifact == 'wheel-linux-x86_64'
         run: python -m build --sdist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,6 +155,10 @@ jobs:
           python -m pip install --upgrade pip build
           python -m build --wheel
 
+      - name: Validate wheel platform compatibility
+        shell: bash
+        run: python scripts/check-wheel-compatibility.py "${{ matrix.artifact }}" dist/*.whl
+
       - name: Build source distribution
         if: matrix.build_sdist
         run: python -m build --sdist
@@ -586,12 +590,6 @@ jobs:
           pattern: python-dist-*
           path: dist
           merge-multiple: true
-
-      - name: Exclude raw Linux wheels unsupported by PyPI
-        shell: bash
-        run: |
-          rm -f dist/*-linux_*.whl
-          ls -lh dist
 
       - name: Publish Python distributions
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,10 +1,38 @@
 from __future__ import annotations
 
 import os
+import platform
+import sys
 from pathlib import Path
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 from packaging.tags import sys_tags
+
+MANYLINUX_BASELINE = "2_17"
+
+
+def wheel_platform_tag() -> str:
+    """Return the platform tag for the native runtime bundled in the wheel."""
+
+    if sys.platform.startswith("linux"):
+        machine = platform.machine().lower()
+        architectures = {
+            "amd64": "x86_64",
+            "x86_64": "x86_64",
+            "arm64": "aarch64",
+            "aarch64": "aarch64",
+        }
+        try:
+            architecture = architectures[machine]
+        except KeyError as exc:
+            raise RuntimeError(f"Unsupported Linux wheel architecture: {machine}") from exc
+        return f"manylinux_{MANYLINUX_BASELINE}_{architecture}"
+
+    return next(
+        tag.platform
+        for tag in sys_tags()
+        if "manylinux" not in tag.platform and "musllinux" not in tag.platform
+    )
 
 
 class CustomBuildHook(BuildHookInterface):
@@ -27,12 +55,7 @@ class CustomBuildHook(BuildHookInterface):
             # workflows compile the runtime before invoking the wheel builder.
             return
 
-        platform_tag = next(
-            tag.platform
-            for tag in sys_tags()
-            if "manylinux" not in tag.platform and "musllinux" not in tag.platform
-        )
-        build_data["tag"] = f"py3-none-{platform_tag}"
+        build_data["tag"] = f"py3-none-{wheel_platform_tag()}"
         build_data["pure_python"] = False
         build_data["force_include"][str(payload)] = (
             f"local_shell_mcp/ui_runtime/{payload.name}"

--- a/scripts/check-release-matrix.py
+++ b/scripts/check-release-matrix.py
@@ -60,6 +60,11 @@ def main() -> int:
         print("Release wheels must be built directly from the platform checkout.")
         return 1
 
+    wheel_validation_script = step_script(python_job, "Validate wheel platform compatibility")
+    if "check-wheel-compatibility.py" not in wheel_validation_script:
+        print("Release wheels must validate their platform tags and native runtime compatibility.")
+        return 1
+
     wheel_smoke_script = step_script(python_job, "Install wheel and smoke test packaged UI")
     if "standalone-ui-smoke.py" not in wheel_smoke_script:
         print("Release wheels must exercise their packaged OpenTUI runtime.")
@@ -109,9 +114,8 @@ def main() -> int:
     if pypi_job.get("environment") != "pypi":
         print("Release workflow must publish Python artifacts from the protected pypi environment.")
         return 1
-    pypi_filter_script = step_script(pypi_job, "Exclude raw Linux wheels unsupported by PyPI")
-    if "dist/*-linux_*.whl" not in pypi_filter_script:
-        print("PyPI publishing must exclude raw linux_* wheels until compliant manylinux wheels are built.")
+    if step_script(pypi_job, "Exclude raw Linux wheels unsupported by PyPI"):
+        print("PyPI publishing must not discard validated manylinux wheels.")
         return 1
 
     smoke_script = step_script(binary_job, "Smoke test embedded OpenTUI runtime")

--- a/scripts/check-wheel-compatibility.py
+++ b/scripts/check-wheel-compatibility.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import gzip
+import re
+import struct
+import zipfile
+from pathlib import Path
+
+MANYLINUX_GLIBC_MAX = (2, 17)
+LINUX_TARGETS = {
+    "linux-x86_64": ("manylinux_2_17_x86_64", 62),
+    "linux-aarch64": ("manylinux_2_17_aarch64", 183),
+}
+OTHER_TARGETS = {
+    "macos-x86_64": ("macosx_", "x86_64"),
+    "macos-aarch64": ("macosx_", "arm64"),
+    "windows-x86_64": ("win_amd64", None),
+}
+
+
+def normalize_target(value: str) -> str:
+    return value.removeprefix("wheel-")
+
+
+def wheel_tags(archive: zipfile.ZipFile) -> set[str]:
+    metadata_name = next(name for name in archive.namelist() if name.endswith(".dist-info/WHEEL"))
+    metadata = archive.read(metadata_name).decode("utf-8")
+    return {
+        line.removeprefix("Tag: ").strip()
+        for line in metadata.splitlines()
+        if line.startswith("Tag: ")
+    }
+
+
+def embedded_tui(archive: zipfile.ZipFile) -> bytes:
+    payload_name = next(
+        name
+        for name in archive.namelist()
+        if name.endswith("local_shell_mcp/ui_runtime/local-shell-mcp-tui.gz")
+    )
+    return gzip.decompress(archive.read(payload_name))
+
+
+def elf_machine(binary: bytes) -> int:
+    if binary[:4] != b"\x7fELF":
+        raise ValueError("embedded Linux TUI is not an ELF executable")
+    if len(binary) < 20:
+        raise ValueError("embedded Linux TUI has a truncated ELF header")
+    byte_order = {1: "<", 2: ">"}.get(binary[5])
+    if byte_order is None:
+        raise ValueError("embedded Linux TUI has an unknown ELF byte order")
+    return struct.unpack_from(f"{byte_order}H", binary, 18)[0]
+
+
+def glibc_versions(binary: bytes) -> set[tuple[int, int]]:
+    return {
+        (int(major), int(minor))
+        for major, minor in re.findall(rb"GLIBC_(\d+)\.(\d+)", binary)
+    }
+
+
+def check_linux(target: str, wheel: Path, archive: zipfile.ZipFile, tags: set[str]) -> None:
+    platform_tag, expected_machine = LINUX_TARGETS[target]
+    expected_tag = f"py3-none-{platform_tag}"
+    if tags != {expected_tag}:
+        raise SystemExit(f"{wheel.name}: expected wheel tag {expected_tag}, got {sorted(tags)}")
+    if platform_tag not in wheel.name:
+        raise SystemExit(f"{wheel.name}: filename does not contain {platform_tag}")
+
+    binary = embedded_tui(archive)
+    machine = elf_machine(binary)
+    if machine != expected_machine:
+        raise SystemExit(
+            f"{wheel.name}: embedded TUI ELF machine {machine} does not match {expected_machine}"
+        )
+
+    versions = glibc_versions(binary)
+    if not versions:
+        raise SystemExit(f"{wheel.name}: could not determine embedded TUI GLIBC requirements")
+    highest = max(versions)
+    if highest > MANYLINUX_GLIBC_MAX:
+        raise SystemExit(
+            f"{wheel.name}: embedded TUI requires GLIBC {highest[0]}.{highest[1]}, "
+            f"above the manylinux_2_17 baseline"
+        )
+    print(
+        f"{wheel.name}: {expected_tag}; embedded TUI GLIBC <= "
+        f"{highest[0]}.{highest[1]}"
+    )
+
+
+def check_other(target: str, wheel: Path, tags: set[str]) -> None:
+    platform_prefix, architecture = OTHER_TARGETS[target]
+    if len(tags) != 1:
+        raise SystemExit(f"{wheel.name}: expected one wheel tag, got {sorted(tags)}")
+    tag = next(iter(tags))
+    if not tag.startswith(f"py3-none-{platform_prefix}"):
+        raise SystemExit(f"{wheel.name}: unexpected wheel tag {tag}")
+    if architecture and architecture not in tag:
+        raise SystemExit(f"{wheel.name}: expected architecture {architecture} in {tag}")
+    print(f"{wheel.name}: {tag}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("target", help="release target, optionally prefixed with wheel-")
+    parser.add_argument("wheel", type=Path)
+    args = parser.parse_args()
+
+    target = normalize_target(args.target)
+    if target not in LINUX_TARGETS | OTHER_TARGETS:
+        raise SystemExit(f"unsupported wheel target: {target}")
+    if not args.wheel.is_file():
+        raise SystemExit(f"wheel not found: {args.wheel}")
+
+    with zipfile.ZipFile(args.wheel) as archive:
+        tags = wheel_tags(archive)
+        if target in LINUX_TARGETS:
+            check_linux(target, args.wheel, archive, tags)
+        else:
+            check_other(target, args.wheel, tags)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- tag Linux Python wheels as manylinux_2_17 for x86_64 and aarch64
- validate wheel platform tags, embedded ELF architecture, and GLIBC <= 2.17 in CI/release builds
- publish validated Linux wheels to PyPI instead of discarding raw linux_* wheels

## Validation
- built local_shell_mcp-4.0.0-py3-none-manylinux_2_17_x86_64.whl locally
- clean-venv install + local-shell-mcp/lsm version checks + standalone UI smoke passed
- embedded x86_64 TUI GLIBC max = 2.17
- existing v3.2.0 aarch64 TUI inspected: GLIBC max = 2.17
- scripts/check-release-matrix.py
- ruff check
- workflow YAML parse
- git diff --check