### PR TITLE
fix(release): keep prereleases off stable channels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,6 @@ on:
         required: true
         default: false
         type: boolean
-      push_latest:
-        description: "Also publish the Docker image with the latest tag"
-        required: true
-        default: true
-        type: boolean
 
 permissions:
   contents: write
@@ -87,20 +82,20 @@ jobs:
         id: docker-tags
         env:
           RELEASE_TAG: ${{ github.event.inputs.tag }}
-          PUSH_LATEST: ${{ github.event.inputs.push_latest }}
+          PRERELEASE: ${{ github.event.inputs.prerelease }}
         run: |
           python - <<'PY' >> "$GITHUB_OUTPUT"
           import json
           import os
 
           release_tag = os.environ["RELEASE_TAG"]
-          push_latest = os.environ["PUSH_LATEST"] == "true"
+          prerelease = os.environ["PRERELEASE"] == "true"
 
           def tags_for(image_name: str) -> list[str]:
               tags = [f"{image_name}:{release_tag}"]
               if release_tag.startswith("v"):
                   tags.append(f"{image_name}:{release_tag[1:]}")
-              if push_latest:
+              if not prerelease:
                   tags.append(f"{image_name}:latest")
               return tags
 
@@ -367,7 +362,14 @@ jobs:
 
       - name: Package VSIX
         working-directory: vscode-extension
-        run: npm run package:vsix
+        env:
+          PRERELEASE: ${{ github.event.inputs.prerelease }}
+        run: |
+          if [[ "$PRERELEASE" == "true" ]]; then
+            npm run package:vsix -- --pre-release
+          else
+            npm run package:vsix
+          fi
 
 
       - uses: actions/upload-artifact@v7
@@ -526,7 +528,7 @@ jobs:
         run: |
           # shellcheck disable=SC2006
           cat > RELEASE_NOTES.md <<EOF
-          Docker images are published to Docker Hub and GHCR under the release tag, the unprefixed semantic-version tag, and optionally `latest`.
+          Docker images are published to Docker Hub and GHCR under the release tag and the unprefixed semantic-version tag. Stable releases also update `latest`; prereleases never do.
 
           Docker platforms are built in parallel and published as a multi-arch manifest:
 
@@ -580,7 +582,7 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    if: ${{ vars.PYPI_PUBLISH_ENABLED == 'true' }}
+    if: ${{ vars.PYPI_PUBLISH_ENABLED == 'true' && !inputs.prerelease }}
     runs-on: ubuntu-latest
     needs:
       - validate-release
@@ -634,9 +636,15 @@ jobs:
 
       - name: Publish npm launcher
         working-directory: npm
+        env:
+          PRERELEASE: ${{ github.event.inputs.prerelease }}
         run: |
           npm install --global npm@11
-          npm publish --provenance
+          if [[ "$PRERELEASE" == "true" ]]; then
+            npm publish --provenance --tag next
+          else
+            npm publish --provenance --tag latest
+          fi
 
   publish-vscode-marketplace:
     name: Publish VS Code Marketplace extension
@@ -662,7 +670,13 @@ jobs:
       - name: Publish extension
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
-        run: npx --yes @vscode/vsce@3.6.2 publish --packagePath "dist/local-shell-mcp-${{ needs.validate-release.outputs.version }}.vsix" -p "$VSCE_PAT"
+          PRERELEASE: ${{ github.event.inputs.prerelease }}
+        run: |
+          args=(publish --packagePath "dist/local-shell-mcp-${{ needs.validate-release.outputs.version }}.vsix" -p "$VSCE_PAT")
+          if [[ "$PRERELEASE" == "true" ]]; then
+            args+=(--pre-release)
+          fi
+          npx --yes @vscode/vsce@3.6.2 "${args[@]}"
 
   publish-open-vsx:
     name: Publish Open VSX extension

--- a/scripts/check-release-matrix.py
+++ b/scripts/check-release-matrix.py
@@ -8,6 +8,7 @@ import yaml
 REPO = Path(__file__).resolve().parents[1]
 RELEASE = REPO / ".github" / "workflows" / "release.yml"
 DOCKERFILE = REPO / "Dockerfile"
+VSCODE_PACKAGE_SCRIPT = REPO / "vscode-extension" / "scripts" / "package-vsix.cjs"
 EXPECTED_BINARY_ARTIFACTS = {
     "linux-x86_64",
     "linux-aarch64",
@@ -32,8 +33,19 @@ def step_script(job: dict, name: str) -> str:
 
 
 def main() -> int:
-    workflow = yaml.safe_load(RELEASE.read_text(encoding="utf-8"))
+    release_text = RELEASE.read_text(encoding="utf-8")
+    workflow = yaml.safe_load(release_text)
     jobs = workflow.get("jobs", {})
+
+    if "push_latest:" in release_text or "inputs.push_latest" in release_text:
+        print("Release workflow must derive stable latest tags from the prerelease flag, not a separate push_latest input.")
+        return 1
+
+    validate_job = jobs.get("validate-release", {})
+    docker_tag_script = step_script(validate_job, "Prepare Docker release tags")
+    if 'PRERELEASE' not in docker_tag_script or "if not prerelease:" not in docker_tag_script:
+        print("Docker latest tags must be emitted only for stable releases.")
+        return 1
 
     dockerfile = DOCKERFILE.read_text(encoding="utf-8")
     if "COPY requirements-agent.txt pyproject.toml hatch_build.py README.md LICENSE /app/" not in dockerfile:
@@ -118,13 +130,31 @@ def main() -> int:
     if "npm publish" not in npm_publish_script or npm_job.get("environment") != "npm":
         print("Release workflow must publish the npm launcher from the protected npm environment.")
         return 1
+    if "--tag next" not in npm_publish_script or "--tag latest" not in npm_publish_script:
+        print("npm prereleases must use a non-latest dist-tag while stable releases update latest.")
+        return 1
 
     pypi_job = jobs.get("publish-pypi", {})
     if pypi_job.get("environment") != "pypi":
         print("Release workflow must publish Python artifacts from the protected pypi environment.")
         return 1
+    if "!inputs.prerelease" not in str(pypi_job.get("if") or ""):
+        print("PyPI publication must be limited to stable releases so prereleases cannot replace the default install.")
+        return 1
     if step_script(pypi_job, "Exclude raw Linux wheels unsupported by PyPI"):
         print("PyPI publishing must not discard validated manylinux wheels.")
+        return 1
+
+    vscode_job = jobs.get("build-vscode-extension", {})
+    vscode_package_script = step_script(vscode_job, "Package VSIX")
+    package_script_text = VSCODE_PACKAGE_SCRIPT.read_text(encoding="utf-8")
+    if "--pre-release" not in vscode_package_script or 'args.push("--pre-release")' not in package_script_text:
+        print("VSIX prereleases must be packaged with the Marketplace/Open VSX prerelease marker.")
+        return 1
+
+    vscode_publish_job = jobs.get("publish-vscode-marketplace", {})
+    if "--pre-release" not in step_script(vscode_publish_job, "Publish extension"):
+        print("VS Code Marketplace prereleases must publish through the prerelease channel.")
         return 1
 
     smoke_script = step_script(binary_job, "Smoke test embedded OpenTUI runtime")

--- a/vscode-extension/scripts/package-vsix.cjs
+++ b/vscode-extension/scripts/package-vsix.cjs
@@ -8,9 +8,13 @@ const repoRoot = path.resolve(extensionRoot, "..");
 const pkg = require(path.join(extensionRoot, "package.json"));
 const out = path.join(repoRoot, "dist", `local-shell-mcp-${pkg.version}.vsix`);
 const vsce = require.resolve("@vscode/vsce/vsce");
+const args = [vsce, "package", "--no-dependencies", "--out", out];
+if (process.argv.includes("--pre-release")) {
+  args.push("--pre-release");
+}
 
 fs.mkdirSync(path.dirname(out), { recursive: true });
-execFileSync(process.execPath, [vsce, "package", "--no-dependencies", "--out", out], {
+execFileSync(process.execPath, args, {
   cwd: extensionRoot,
   stdio: "inherit",
 });


### PR DESCRIPTION
## Summary
- remove the separate `push_latest` workflow input and derive stable tags from the existing `prerelease` flag
- keep Docker Hub/GHCR `latest` and npm `latest` unchanged for prereleases; npm prereleases publish under `next`
- skip PyPI publication for GitHub prereleases so a stable-looking package version cannot replace the default pip install
- package VS Code/Open VSX artifacts with the prerelease marker and publish VS Marketplace prereleases through its prerelease channel
- add release-matrix regressions for these rules

## Validation
- `actionlint .github/workflows/release.yml`
- `python scripts/check-release-matrix.py`
- VS Code extension tests
- npm launcher tests
- actual stable/prerelease VSIX packaging; prerelease manifest contains `Microsoft.VisualStudio.Code.PreRelease`, stable manifest does not
- `git diff --check`
