### PR TITLE
fix: preserve Live Workspace across app remounts

### DIFF
--- a/src/local_shell_mcp/live_channel.py
+++ b/src/local_shell_mcp/live_channel.py
@@ -76,6 +76,7 @@ LIVE_EVENT_LIMIT = 2_000
 LIVE_EVENT_BATCH = 300
 LIVE_LONG_POLL_S = 25.0
 LIVE_RECOVERY_CLAIM_TTL_S = 60.0
+LIVE_APP_REATTACH_CLAIM_TTL_S = 2 * 60.0
 _SESSION_KEYS: weakref.WeakKeyDictionary[Any, str] = weakref.WeakKeyDictionary()
 _SESSION_KEYS_LOCK = threading.Lock()
 
@@ -89,6 +90,8 @@ class LiveChannel:
     token_value: str = field(repr=False)
     created_at: float
     expires_at: float
+    machine: str = "local"
+    cwd: str = "."
     seq: int = 0
     events: deque[dict[str, Any]] = field(
         default_factory=lambda: deque(maxlen=LIVE_EVENT_LIMIT)
@@ -127,6 +130,7 @@ class LiveChannelManager:
         self._logical_session_channels: dict[str, str] = {}
         self._recovered_live_ids: dict[str, str] = {}
         self._recovery_claims: dict[str, dict[str, float]] = {}
+        self._app_reattach_claims: dict[str, dict[str, float]] = {}
         self._credentials: dict[str, dict[str, Any]] = {}
 
     @staticmethod
@@ -241,6 +245,19 @@ class LiveChannelManager:
         self._recovery_claims = {
             subject: claims for subject, claims in self._recovery_claims.items() if claims
         }
+        self._app_reattach_claims = {
+            subject: {
+                live_id: deadline
+                for live_id, deadline in claims.items()
+                if deadline > current and live_id in self._channels
+            }
+            for subject, claims in self._app_reattach_claims.items()
+        }
+        self._app_reattach_claims = {
+            subject: claims
+            for subject, claims in self._app_reattach_claims.items()
+            if claims
+        }
 
     def open(
         self,
@@ -252,6 +269,8 @@ class LiveChannelManager:
         live_id: str | None = None,
         logical_session_id: str | None = None,
         app_reattach: bool = False,
+        machine: str | None = None,
+        cwd: str | None = None,
     ) -> tuple[LiveChannel, str]:
         now = time.time()
         expires_at = now + LIVE_TOKEN_TTL_S
@@ -266,6 +285,7 @@ class LiveChannelManager:
                 else None
             )
             requested_live_id = live_id
+            recovered_empty_app = False
             resolved_live_id = self._recovered_live_ids.get(live_id or "", live_id or "")
             channel = self._channels.get(resolved_live_id or "")
             if app_reattach and channel is not None and channel.logical_session_id:
@@ -305,6 +325,20 @@ class LiveChannelManager:
                 if live_id:
                     raise PermissionError("Live workspace belongs to a different principal")
                 channel = None
+            if channel is None and app_reattach and not live_id and not logical_session_id:
+                claims = self._app_reattach_claims.get(subject, {})
+                candidates = [
+                    self._channels[claim_live_id]
+                    for claim_live_id, deadline in claims.items()
+                    if deadline > now and claim_live_id in self._channels
+                ]
+                if len(candidates) == 1:
+                    channel = candidates[0]
+                    recovered_empty_app = True
+                elif len(candidates) > 1:
+                    raise ValueError(
+                        "Live workspace reattach is ambiguous; provide live_id or session_id"
+                    )
             if channel is None:
                 token = secrets.token_urlsafe(32)
                 digest = self._digest(token)
@@ -316,6 +350,8 @@ class LiveChannelManager:
                     token_value=token,
                     created_at=now,
                     expires_at=expires_at,
+                    machine=machine or "local",
+                    cwd=cwd or ".",
                     logical_session_id=logical_session_id,
                 )
                 self._channels[channel.live_id] = channel
@@ -349,11 +385,19 @@ class LiveChannelManager:
                     expires_at=expires_at,
                     primary=True,
                 )
+            if not recovered_empty_app:
+                if machine:
+                    channel.machine = machine
+                if cwd:
+                    channel.cwd = cwd
             self._session_channels[session_key] = channel.live_id
             if app_reattach:
                 self._app_session_keys.add(session_key)
             else:
                 self._app_session_keys.discard(session_key)
+                self._app_reattach_claims.setdefault(subject, {})[channel.live_id] = (
+                    now + LIVE_APP_REATTACH_CLAIM_TTL_S
+                )
             if logical_session_id:
                 self._set_logical_session_locked(channel, logical_session_id)
                 if not app_reattach:

--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -3358,6 +3358,8 @@ def _register_live_workspace_tools(
             live_id=live_id,
             logical_session_id=logical_session_id,
             app_reattach=app_reattach,
+            machine=machine,
+            cwd=cwd,
             parent_expires_at=(
                 float(principal.claims["exp"])
                 if principal is not None and principal.claims.get("exp") is not None
@@ -3369,8 +3371,8 @@ def _register_live_workspace_tools(
             session_id=channel.logical_session_id,
             api_base=_live_workspace_api_base(),
             ui_path=settings.ui_path,
-            machine=machine or "local",
-            cwd=cwd,
+            machine=channel.machine,
+            cwd=channel.cwd,
         )
         return cast(
             LiveChannelResult,

--- a/tests/test_live_workspace.py
+++ b/tests/test_live_workspace.py
@@ -291,6 +291,60 @@ def test_app_reattach_does_not_shorten_shared_channel_expiry():
     assert manager.authenticate(token) is channel
 
 
+def test_empty_app_reattach_recovers_unique_recent_explicit_workspace():
+    manager = LiveChannelManager()
+    channel, model_token = manager.open(
+        session_key="mcp:model",
+        subject="user",
+        scopes=tuple(ALL_OAUTH_SCOPES),
+        logical_session_id="s_task",
+        machine="local",
+        cwd="/workspace/project",
+    )
+
+    attached, app_token = manager.open(
+        session_key="mcp:remounted-app",
+        subject="user",
+        scopes=("shell:read",),
+        app_reattach=True,
+        machine="local",
+        cwd=".",
+    )
+
+    assert attached is channel
+    assert attached.logical_session_id == "s_task"
+    assert attached.machine == "local"
+    assert attached.cwd == "/workspace/project"
+    assert manager.active_for_session("mcp:remounted-app") is channel
+    assert app_token != model_token
+    assert manager.authenticate(app_token) is channel
+
+
+def test_empty_app_reattach_refuses_ambiguous_recent_workspaces():
+    manager = LiveChannelManager()
+    first, _ = manager.open(
+        session_key="mcp:model-a",
+        subject="user",
+        scopes=tuple(ALL_OAUTH_SCOPES),
+        logical_session_id="s_first",
+    )
+    second, _ = manager.open(
+        session_key="mcp:model-b",
+        subject="user",
+        scopes=tuple(ALL_OAUTH_SCOPES),
+        logical_session_id="s_second",
+    )
+    assert first is not second
+
+    with pytest.raises(ValueError, match="reattach is ambiguous"):
+        manager.open(
+            session_key="mcp:remounted-app",
+            subject="user",
+            scopes=("shell:read",),
+            app_reattach=True,
+        )
+
+
 def test_live_workspace_can_reattach_a_second_mcp_session_by_live_id():
     manager = LiveChannelManager()
     channel, first_token = manager.open(
@@ -1200,6 +1254,40 @@ async def test_mcp_app_resource_and_render_result_hide_live_token(tmp_path, monk
         contents = list(await mcp.read_resource(uri))
         assert contents[0].mime_type == LIVE_RESOURCE_MIME
         assert "local-shell-mcp-live-workspace" in str(contents[0].content)
+
+
+@pytest.mark.asyncio
+async def test_empty_app_remount_recovers_recent_workspace_tool_result(
+    tmp_path, monkeypatch
+):
+    _configure(tmp_path, monkeypatch, auth="none")
+    current_key = {"value": "mcp:model"}
+    monkeypatch.setattr(tools_module, "mcp_session_key", lambda _mcp: current_key["value"])
+    mcp = build_mcp()
+
+    _, started = await mcp.call_tool(
+        "session_manage",
+        {"action": "start", "objective": "Survive ChatGPT app remount"},
+    )
+    session_id = started["data"]["session_id"]
+    run_id = started["data"]["active_run"]["run_id"]
+    opened = await mcp.call_tool(
+        "workspace_open",
+        {"cwd": "/workspace/project", "session_run_id": run_id},
+    )
+    old_live_id = opened.structuredContent["live_id"]
+    assert opened.structuredContent["session_id"] == session_id
+
+    current_key["value"] = "mcp:remounted-app"
+    reconnected = await mcp.call_tool(
+        "live_workspace_reconnect",
+        {"machine": "local", "cwd": "."},
+    )
+
+    assert isinstance(reconnected, CallToolResult)
+    assert reconnected.structuredContent["live_id"] == old_live_id
+    assert reconnected.structuredContent["session_id"] == session_id
+    assert reconnected.structuredContent["cwd"] == "/workspace/project"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fix ChatGPT MCP App frontend remounts that can lose the initial workspace_open tool result and issue an empty live_workspace_reconnect.

- remember short-lived explicit workspace reattach claims per principal
- recover only when the recent workspace is unambiguous
- preserve the original machine/cwd during fallback reattachment
- keep principal-change behavior and fail closed when multiple recent workspaces are ambiguous
- add an end-to-end regression matching the observed empty reconnect

Validation: 82 Live Workspace/tool tests passed; Ruff and git diff --check passed.