### PR TITLE
fix: address connector regressions in no-auth, PowerShell, and stdio sessions

### DIFF
--- a/src/local_shell_mcp/session_runtime.py
+++ b/src/local_shell_mcp/session_runtime.py
@@ -811,6 +811,18 @@ class SessionRuntimeManager:
         normalized_action = str(action).strip().lower()
         with self._lock:
             self._ensure_loaded_locked()
+            if (
+                session_run_id is not None
+                and normalized_action not in {"start", "resume", "list", "delete"}
+            ):
+                attachment = self._attachments.get(session_key)
+                if attachment is None or attachment[1] != session_run_id:
+                    self._recover_attachment_by_run_id_locked(
+                        session_key,
+                        session_run_id,
+                        subject=subject,
+                        refresh_shared=not _state_locks_held,
+                    )
             if not _state_locks_held and normalized_action not in {"get", "list"}:
                 attachment = self._attachments.get(session_key)
                 lock_ids: list[str] = []
@@ -1616,6 +1628,16 @@ class SessionRuntimeManager:
             self._ensure_loaded_locked()
             normalized_action = action.strip().lower()
             attachment = self._attachments.get(session_key)
+            if session_run_id is not None and (
+                attachment is None or attachment[1] != session_run_id
+            ):
+                self._recover_attachment_by_run_id_locked(
+                    session_key,
+                    session_run_id,
+                    subject=self._authenticated_subject(),
+                    refresh_shared=not _state_lock_held,
+                )
+                attachment = self._attachments.get(session_key)
             if (
                 not _state_lock_held
                 and normalized_action != "get"

--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -9,6 +9,7 @@ import time
 import uuid
 from collections.abc import Awaitable, Callable
 from contextlib import suppress
+from contextvars import ContextVar
 from pathlib import Path
 from typing import Any, cast
 from urllib.parse import urlparse
@@ -115,6 +116,10 @@ from .transfer_ops import (
     transfer_unpack_archive,
 )
 from .version import version_info as get_version_info
+
+_CURRENT_LOGICAL_SESSION_ID: ContextVar[str | None] = ContextVar(
+    "local_shell_mcp_current_logical_session_id", default=None
+)
 
 
 class TextEdit(BaseModel):
@@ -270,7 +275,7 @@ async def _run_python(code: str, cwd: str = ".", timeout_s: int = 60) -> dict:
     path = temp_dir() / f"script-{uuid.uuid4().hex}.py"
     path.parent.mkdir(parents=True, exist_ok=True)
     await asyncio.to_thread(path.write_text, code, encoding="utf-8")
-    python = quote_shell_argument(get_settings().python_bin)
+    python = quote_shell_executable(get_settings().python_bin)
     result = await run_shell(
         f"{python} {quote_shell_argument(str(path))}",
         cwd=cwd,
@@ -341,11 +346,16 @@ NON_CANCELLABLE_TOOL_NAMES = frozenset(
 REMOTE_MACHINE_ARGUMENTS = frozenset({"machine", "source_machine", "destination_machine"})
 
 
+NOAUTH_SECURITY_SCHEMES = [{"type": "noauth"}]
+
+
 def _security_meta(schemes: list[dict[str, Any]]) -> dict[str, Any]:
     return {"securitySchemes": schemes}
 
 
 def _oauth_meta(scopes: list[str]) -> dict[str, Any]:
+    if get_settings().auth_mode == "none":
+        return _security_meta([*NOAUTH_SECURITY_SCHEMES])
     return _security_meta([_oauth_security_scheme(scopes)])
 
 
@@ -789,6 +799,24 @@ async def _renew_session_tool_lease(
             return
 
 
+def _logical_session_key(
+    transport_key: str,
+    *,
+    session_run_id: str | None = None,
+    action: str | None = None,
+    session_id: str | None = None,
+) -> str:
+    """Route durable logical Sessions independently of multiplexed transports."""
+    if session_run_id:
+        return f"{transport_key}:run:{session_run_id}"
+    normalized_action = str(action or "").strip().lower()
+    if normalized_action == "start":
+        return f"{transport_key}:start:{uuid.uuid4().hex}"
+    if normalized_action == "resume" and session_id:
+        return f"{transport_key}:resume:{session_id}"
+    return transport_key
+
+
 def _install_mcp_tool_watchdogs(mcp: FastMCP) -> None:
     for tool in mcp._tool_manager._tools.values():  # noqa: SLF001
         original = tool.fn
@@ -839,6 +867,12 @@ def _install_mcp_tool_watchdogs(mcp: FastMCP) -> None:
             call_id = uuid.uuid4().hex
             started_at = time.monotonic()
             live_session_key = mcp_session_key(mcp)
+            logical_session_key = _logical_session_key(
+                live_session_key,
+                session_run_id=(str(session_run_id) if session_run_id is not None else None),
+                action=call_arguments.get("action"),
+                session_id=call_arguments.get("session_id"),
+            )
             live_manager = get_live_channel_manager()
             logical_manager = get_session_runtime_manager()
             principal_subject = _current_principal_subject()
@@ -846,17 +880,26 @@ def _install_mcp_tool_watchdogs(mcp: FastMCP) -> None:
             logical_lease = None
             normalized_tool_action = str(call_arguments.get("action") or "").strip().lower()
             session_get_tracks_activity = False
+            session_get_run_id: str | None = None
             if __tool_name == "session_manage" and normalized_tool_action == "get":
-                current_session_id = await asyncio.to_thread(
-                    logical_manager.current_session_id,
-                    live_session_key,
-                    subject=principal_subject,
-                )
                 requested_session_id = str(call_arguments.get("session_id") or "").strip()
-                session_get_tracks_activity = bool(
-                    current_session_id
-                    and (not requested_session_id or requested_session_id == current_session_id)
-                )
+                if requested_session_id:
+                    requested_state = await asyncio.to_thread(
+                        logical_manager.get,
+                        requested_session_id,
+                        subject=principal_subject,
+                    )
+                    active_run = requested_state.get("active_run")
+                    if isinstance(active_run, dict) and active_run.get("run_id"):
+                        session_get_run_id = str(active_run["run_id"])
+                        session_get_tracks_activity = True
+                else:
+                    current_session_id = await asyncio.to_thread(
+                        logical_manager.current_session_id,
+                        live_session_key,
+                        subject=principal_subject,
+                    )
+                    session_get_tracks_activity = bool(current_session_id)
             if (
                 __tool_name not in {"session_manage", "live_workspace_reconnect"}
                 or session_get_tracks_activity
@@ -868,10 +911,18 @@ def _install_mcp_tool_watchdogs(mcp: FastMCP) -> None:
                 try:
                     logical_lease = await asyncio.to_thread(
                         logical_manager.begin_tool_call,
-                        live_session_key,
+                        (
+                            _logical_session_key(
+                                live_session_key,
+                                session_run_id=session_get_run_id,
+                            )
+                            if session_get_run_id
+                            else logical_session_key
+                        ),
                         call_id,
                         expected_run_id=(
-                            str(session_run_id) if session_run_id is not None else None
+                            session_get_run_id
+                            or (str(session_run_id) if session_run_id is not None else None)
                         ),
                         subject=principal_subject,
                         require_run_token=require_run_token,
@@ -988,6 +1039,11 @@ def _install_mcp_tool_watchdogs(mcp: FastMCP) -> None:
                         stage="setup",
                     )
                 raise
+            logical_context_token = _CURRENT_LOGICAL_SESSION_ID.set(
+                str(logical_lease["session_id"])
+                if logical_lease and logical_lease.get("session_id")
+                else None
+            )
             try:
                 with audit_call_context(call_id) as call_state:
                     if local_access_error is not None:
@@ -1128,6 +1184,7 @@ def _install_mcp_tool_watchdogs(mcp: FastMCP) -> None:
                 logical_activity_finished = True
                 raise
             finally:
+                _CURRENT_LOGICAL_SESSION_ID.reset(logical_context_token)
                 if lease_heartbeat_task is not None:
                     lease_heartbeat_task.cancel()
                     with suppress(asyncio.CancelledError, Exception):
@@ -2978,11 +3035,17 @@ def _register_maintenance_tools(mcp: FastMCP, read_only_tool: ToolAnnotations) -
     ) -> ToolResult:
         """Manage a durable logical task session independent of machine and cwd. Start one before substantive tool-driven work; report semantic progress at meaningful checkpoints; resume by session_id to hand work to a new GPT/MCP run. resume with takeover=true always creates a new agent run and supersedes the old one. Use the returned active_run.run_id as session_run_id for report/finish/cancel and subsequent tools. Actions: start, resume, get, report, list, finish, cancel, delete. start may include label/objective; report accepts summary/findings/next/blockers/objective/label. delete permanently removes a detached or terminal Session and frees retained history capacity."""
         session_key = mcp_session_key(mcp)
+        logical_session_key = _logical_session_key(
+            session_key,
+            session_run_id=session_run_id,
+            action=action,
+            session_id=session_id,
+        )
         subject = _current_principal_subject()
         result = await _tool_call(
             asyncio.to_thread,
             get_session_runtime_manager().manage,
-            session_key,
+            logical_session_key,
             subject,
             action=action,
             session_id=session_id,
@@ -3039,7 +3102,11 @@ def _register_maintenance_tools(mcp: FastMCP, read_only_tool: ToolAnnotations) -
         return await _tool_call(
             asyncio.to_thread,
             get_session_runtime_manager().manage_plan,
-            mcp_session_key(mcp),
+            _logical_session_key(
+                mcp_session_key(mcp),
+                session_run_id=session_run_id,
+                action=action,
+            ),
             action=action,
             session_run_id=session_run_id,
             require_run_token=True,
@@ -3335,12 +3402,13 @@ def _register_live_workspace_tools(
         )
         session_key = mcp_session_key(mcp)
         session_manager = get_session_runtime_manager()
-        logical_session_id = await asyncio.to_thread(
+        transport_session_id = await asyncio.to_thread(
             session_manager.current_session_id,
             session_key,
             subject=subject,
         )
-        if logical_session_id is None and session_id:
+        logical_session_id = _CURRENT_LOGICAL_SESSION_ID.get() or transport_session_id
+        if session_id:
             try:
                 await asyncio.to_thread(session_manager.get, session_id, subject=subject)
             except ValueError as exc:
@@ -3349,6 +3417,7 @@ def _register_live_workspace_tools(
                 # A suspended app can miss the detach/delete event. Treat only a
                 # missing Session as stale; ownership errors still propagate.
                 get_live_channel_manager().detach_logical_session(session_id)
+                logical_session_id = None
             else:
                 logical_session_id = session_id
         channel, live_token = get_live_channel_manager().open(

--- a/tests/test_audit_regressions.py
+++ b/tests/test_audit_regressions.py
@@ -365,7 +365,7 @@ async def test_python_and_playwright_tools_honor_configured_interpreter_and_clea
 
     monkeypatch.setattr(tools_module, "run_shell", fake_run)
     await tools_module._run_python("print('x')")
-    assert commands[-1].startswith("'/opt/custom python' ")
+    assert commands[-1].startswith(f"{tools_module.quote_shell_executable('/opt/custom python')} ")
 
     stale = tmp_path / "screenshots" / "page.png"
     stale.parent.mkdir()
@@ -377,6 +377,39 @@ async def test_python_and_playwright_tools_honor_configured_interpreter_and_clea
     assert commands[-1].startswith("'/opt/custom python' ")
     assert result["capture_path"] is None
     assert not stale.exists()
+
+
+@pytest.mark.asyncio
+async def test_run_python_uses_powershell_call_operator_for_configured_executable(
+    tmp_path, monkeypatch
+):
+    _configure_workspace(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_SHELL_EXECUTABLE", "powershell.exe")
+    monkeypatch.setenv(
+        "LOCAL_SHELL_MCP_PYTHON_BIN", r"C:\Program Files\Python\python.exe"
+    )
+    get_settings.cache_clear()
+    commands = []
+
+    async def fake_run(command, **kwargs):
+        del kwargs
+        commands.append(command)
+        return CommandResult(
+            ok=True,
+            exit_code=0,
+            timed_out=False,
+            duration_ms=1,
+            cwd=".",
+            command=command,
+            stdout="ok",
+            stderr="",
+            truncated=False,
+        )
+
+    monkeypatch.setattr(tools_module, "run_shell", fake_run)
+    await tools_module._run_python("print('ok')")
+
+    assert commands[-1].startswith("& 'C:\\Program Files\\Python\\python.exe' ")
 
 
 def test_rest_validation_and_readiness(tmp_path, monkeypatch):

--- a/tests/test_live_workspace.py
+++ b/tests/test_live_workspace.py
@@ -1178,7 +1178,7 @@ async def test_mcp_app_resource_and_render_result_hide_live_token(tmp_path, monk
     assert render_tool.meta["openai/outputTemplate"] == LIVE_RESOURCE_VERSIONED_URI
     assert render_tool.meta["openai/widgetAccessible"] is True
     assert "live_id" not in render_tool.inputSchema["properties"]
-    assert render_tool.meta["securitySchemes"][0]["scopes"] == list(ALL_OAUTH_SCOPES)
+    assert render_tool.meta["securitySchemes"] == [{"type": "noauth"}]
     assert render_tool.outputSchema["title"] == "LiveChannelResult"
     assert "session_run_id" in render_tool.inputSchema["properties"]
     assert "session_run_id" in render_tool.inputSchema["required"]
@@ -1724,7 +1724,7 @@ async def test_mcp_run_lease_blocks_stale_same_transport_agent(tmp_path, monkeyp
     second_run_id = resumed["data"]["active_run"]["run_id"]
     assert second_run_id != first_run_id
 
-    with pytest.raises(Exception, match="superseded"):
+    with pytest.raises(Exception, match="superseded|does not identify a current logical session run"):
         await mcp.call_tool(
             "file_write",
             {

--- a/tests/test_mcp_chatgpt_compat.py
+++ b/tests/test_mcp_chatgpt_compat.py
@@ -87,6 +87,7 @@ async def test_request_body_limit_counts_chunked_payloads(tmp_path, monkeypatch)
 @pytest.mark.asyncio
 async def test_mcp_metadata_for_chatgpt_developer_mode(tmp_path, monkeypatch):
     monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_AUTH_MODE", "oauth")
     monkeypatch.setenv("LOCAL_SHELL_MCP_PUBLIC_BASE_URL", "https://local-shell-mcp.example.com")
     get_settings.cache_clear()
 
@@ -120,6 +121,21 @@ async def test_mcp_metadata_for_chatgpt_developer_mode(tmp_path, monkeypatch):
     assert structured["data"]["settings"]["default_timeout_s"] == 10
     assert structured["data"]["settings"]["max_timeout_s"] == 120
 
+
+@pytest.mark.asyncio
+async def test_mcp_metadata_uses_noauth_when_auth_is_disabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_AUTH_MODE", "none")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_REMOTE_ENABLED", "false")
+    get_settings.cache_clear()
+
+    tools = {tool.name: tool for tool in await build_mcp().list_tools()}
+
+    assert tools
+    assert all(
+        tool.meta["securitySchemes"] == [{"type": "noauth"}]
+        for tool in tools.values()
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_session_runtime_review_followup.py
+++ b/tests/test_session_runtime_review_followup.py
@@ -12,6 +12,7 @@ from local_shell_mcp.session_runtime import (
     AgentRun,
     SessionRuntimeManager,
 )
+from local_shell_mcp.tools import _logical_session_key
 
 
 def test_resume_persistence_failure_restores_both_sessions(tmp_path, monkeypatch):
@@ -115,6 +116,92 @@ def test_existing_attachment_is_rejected_after_principal_change(tmp_path, monkey
         manager.manage_plan("mcp:a", action="get")
     assert manager.current_session_id("mcp:a") is None
 
+
+
+def test_multiplexed_transport_routes_logical_sessions_by_run_id(tmp_path):
+    manager = SessionRuntimeManager(tmp_path / ".state")
+    transport_key = "mcp-session:shared-tunnel"
+
+    first_start_key = _logical_session_key(transport_key, action="start")
+    second_start_key = _logical_session_key(transport_key, action="start")
+    assert first_start_key != second_start_key
+    assert first_start_key != transport_key
+    assert second_start_key != transport_key
+
+    first = manager.manage(first_start_key, "user", action="start", objective="First")
+    second = manager.manage(second_start_key, "user", action="start", objective="Second")
+    first_id = first["session_id"]
+    second_id = second["session_id"]
+    first_run = first["active_run"]["run_id"]
+    second_run = second["active_run"]["run_id"]
+
+    assert manager.get(first_id)["active_run"]["run_id"] == first_run
+    assert manager.get(second_id)["active_run"]["run_id"] == second_run
+
+    first_key = _logical_session_key(transport_key, session_run_id=first_run)
+    second_key = _logical_session_key(transport_key, session_run_id=second_run)
+    assert first_key != second_key
+
+    manager.manage(
+        first_key,
+        "user",
+        action="report",
+        session_run_id=first_run,
+        summary="first report",
+    )
+    manager.manage(
+        second_key,
+        "user",
+        action="report",
+        session_run_id=second_run,
+        summary="second report",
+    )
+    manager.manage_plan(
+        first_key,
+        action="start",
+        session_run_id=first_run,
+        require_run_token=True,
+        objective="First plan",
+        steps=[{"id": "first", "text": "First"}],
+    )
+    manager.manage_plan(
+        second_key,
+        action="start",
+        session_run_id=second_run,
+        require_run_token=True,
+        objective="Second plan",
+        steps=[{"id": "second", "text": "Second"}],
+    )
+
+    first_lease = manager.begin_tool_call(
+        first_key,
+        "call-first",
+        expected_run_id=first_run,
+        subject="user",
+        require_run_token=True,
+        data={"tool": "file_read"},
+    )
+    second_lease = manager.begin_tool_call(
+        second_key,
+        "call-second",
+        expected_run_id=second_run,
+        subject="user",
+        require_run_token=True,
+        data={"tool": "file_read"},
+    )
+    assert first_lease is not None and first_lease["session_id"] == first_id
+    assert second_lease is not None and second_lease["session_id"] == second_id
+    manager.finish_tool_call(first_lease, "tool.completed")
+    manager.finish_tool_call(second_lease, "tool.completed")
+
+    assert manager.get(first_id)["progress"]["summary"] == "first report"
+    assert manager.get(second_id)["progress"]["summary"] == "second report"
+    assert manager.manage_plan(
+        first_key, action="get", session_run_id=first_run
+    )["plan"]["objective"] == "First plan"
+    assert manager.manage_plan(
+        second_key, action="get", session_run_id=second_run
+    )["plan"]["objective"] == "Second plan"
 
 
 def test_cross_principal_transport_reuse_does_not_detach_previous_run(tmp_path):


### PR DESCRIPTION
## Summary

This fixes the three connector regressions reported in #193:

- advertise `noauth` tool security metadata when `LOCAL_SHELL_MCP_AUTH_MODE=none`;
- invoke the configured Python executable with shell-aware executable quoting, including PowerShell's `&` call operator;
- decouple durable logical Session routing from a multiplexed MCP transport identity by using `session_run_id` as the routing capability for tool leases, Session updates, and Goal plans.

For the stdio/tunnel case, the transport-derived key is still retained for Live Workspace compatibility. Per-request logical identity is carried separately, so two ChatGPT conversations multiplexed through the same underlying MCP/stdio session no longer need to share logical-session ownership.

## Details

The stdio issue is slightly broader than the literal `direct` fallback described in the original report: `mcp_session_key()` can also derive an `mcp-session:<uuid>` key from the SDK session object. A tunnel can still multiplex multiple model conversations through that same underlying session object, so transport identity is not a safe durable logical-session identity.

This PR leaves the core `SessionRuntimeManager` same-key takeover/detach semantics intact. The separation happens at the MCP tool boundary, with run-id recovery in the runtime for replacement/multiplexed transports. Live Workspace uses a request-local logical-session context when a tool lease has already resolved a `session_run_id`, while explicit reconnect `session_id` remains authoritative.

## Validation

- affected Session / Live Workspace / MCP metadata / PowerShell suites: **176 passed**;
- full suite on Windows: **847 passed, 11 skipped, 3 failed**;
- the same 3 failures reproduce unchanged on pristine `origin/main` (`4429826`) in the same environment:
  - two job tests execute POSIX `printf` / `python3` commands under PowerShell;
  - one remote-transfer test fails on an existing temporary state-file path issue;
- `ruff check src tests`: passed;
- `git diff --check`: passed;
- real Windows PowerShell `_run_python` smoke test: passed.

Fixes #193
