### PR TITLE
fix: harden tunnel auth, PowerShell run_python, and session routing

### DIFF
--- a/src/local_shell_mcp/session_runtime.py
+++ b/src/local_shell_mcp/session_runtime.py
@@ -811,6 +811,18 @@ class SessionRuntimeManager:
         normalized_action = str(action).strip().lower()
         with self._lock:
             self._ensure_loaded_locked()
+            if (
+                session_run_id is not None
+                and normalized_action not in {"start", "resume", "list", "delete"}
+            ):
+                attachment = self._attachments.get(session_key)
+                if attachment is None or attachment[1] != session_run_id:
+                    self._recover_attachment_by_run_id_locked(
+                        session_key,
+                        session_run_id,
+                        subject=subject,
+                        refresh_shared=not _state_locks_held,
+                    )
             if not _state_locks_held and normalized_action not in {"get", "list"}:
                 attachment = self._attachments.get(session_key)
                 lock_ids: list[str] = []
@@ -1300,14 +1312,30 @@ class SessionRuntimeManager:
         """
         with self._lock:
             self._ensure_loaded_locked()
-            if session_key not in self._attachments:
+            attachment = self._attachments.get(session_key)
+            if attachment is None or (
+                expected_run_id is not None and attachment[1] != expected_run_id
+            ):
                 if expected_run_id is None:
                     return None
-                logical = self._find_active_run_locked(
-                    expected_run_id,
-                    subject=subject,
-                    refresh_shared=not _state_lock_held,
-                )
+                try:
+                    logical = self._find_active_run_locked(
+                        expected_run_id,
+                        subject=subject,
+                        refresh_shared=not _state_lock_held,
+                    )
+                except RuntimeError:
+                    if attachment is not None:
+                        # Preserve the existing stale-token fencing error when the
+                        # supplied run id is no longer active. Cross-transport
+                        # recovery is only valid for another current active run.
+                        self._assert_attachment_locked(
+                            session_key,
+                            expected_run_id=expected_run_id,
+                            require_run_token=require_run_token,
+                            subject=subject,
+                        )
+                    raise
                 if not _state_lock_held and self._uses_shared_state_backend():
                     with self._shared_session_locks_locked([logical.session_id]):
                         self._refresh_session_locked(logical.session_id)
@@ -1616,6 +1644,16 @@ class SessionRuntimeManager:
             self._ensure_loaded_locked()
             normalized_action = action.strip().lower()
             attachment = self._attachments.get(session_key)
+            if session_run_id is not None and (
+                attachment is None or attachment[1] != session_run_id
+            ):
+                self._recover_attachment_by_run_id_locked(
+                    session_key,
+                    session_run_id,
+                    subject=self._authenticated_subject(),
+                    refresh_shared=not _state_lock_held,
+                )
+                attachment = self._attachments.get(session_key)
             if (
                 not _state_lock_held
                 and normalized_action != "get"

--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -270,7 +270,7 @@ async def _run_python(code: str, cwd: str = ".", timeout_s: int = 60) -> dict:
     path = temp_dir() / f"script-{uuid.uuid4().hex}.py"
     path.parent.mkdir(parents=True, exist_ok=True)
     await asyncio.to_thread(path.write_text, code, encoding="utf-8")
-    python = quote_shell_argument(get_settings().python_bin)
+    python = quote_shell_executable(get_settings().python_bin)
     result = await run_shell(
         f"{python} {quote_shell_argument(str(path))}",
         cwd=cwd,
@@ -292,6 +292,7 @@ def _oauth_security_scheme(scopes: list[str] | tuple[str, ...]) -> dict[str, Any
     return {"type": "oauth2", "scopes": list(ALL_OAUTH_SCOPES)}
 
 
+NOAUTH_SECURITY_SCHEMES = [{"type": "noauth"}]
 PUBLIC_TOOL_TIMEOUT_S = PUBLIC_TOOL_WATCHDOG_TIMEOUT_S
 MCP_INSTRUCTIONS = (
     "When a task may benefit from an installed Agent Skill, call skill_list first "
@@ -346,6 +347,8 @@ def _security_meta(schemes: list[dict[str, Any]]) -> dict[str, Any]:
 
 
 def _oauth_meta(scopes: list[str]) -> dict[str, Any]:
+    if get_settings().auth_mode == "none":
+        return _security_meta([*NOAUTH_SECURITY_SCHEMES])
     return _security_meta([_oauth_security_scheme(scopes)])
 
 
@@ -789,6 +792,47 @@ async def _renew_session_tool_lease(
             return
 
 
+def _logical_session_routing_key(
+    base_session_key: str,
+    *,
+    tool_name: str,
+    session_run_id: str | None,
+    action: str | None = None,
+    session_id: str | None = None,
+) -> str:
+    """Route logical Sessions safely when one stdio MCP session is multiplexed.
+
+    HTTP transports already provide an affinity or MCP session id. Headerless stdio
+    transports do not, and a tunnel process may reuse one MCP session object for
+    multiple ChatGPT conversations. Once a durable run id exists it becomes the
+    authoritative routing capability. Session starts use a one-shot routing key,
+    while resume/get calls with a session id route by that durable session id, so
+    they cannot detach a different logical Session sharing the same transport key.
+    """
+    # Headerless MCP sessions are represented by a process-local mcp-session key.
+    # OpenAI's stdio tunnel can multiplex several ChatGPT conversations through
+    # one such underlying session object. The legacy "direct" key is kept on its
+    # existing single-client semantics for internal/direct callers.
+    multiplexed = base_session_key.startswith("mcp-session:")
+    if not multiplexed:
+        return base_session_key
+    if session_run_id:
+        return f"{base_session_key}:run:{session_run_id}"
+
+    normalized_tool = str(tool_name or "").strip().lower()
+    normalized_action = str(action or "").strip().lower()
+    if normalized_tool == "session_manage":
+        if normalized_action == "start":
+            return f"{base_session_key}:start:{uuid.uuid4().hex}"
+        if normalized_action in {"resume", "get"} and session_id:
+            return f"{base_session_key}:session:{session_id}"
+        if normalized_action == "get":
+            return f"{base_session_key}:unbound-get:{uuid.uuid4().hex}"
+    if normalized_tool == "plan_manage":
+        return f"{base_session_key}:unbound-plan:{uuid.uuid4().hex}"
+    return base_session_key
+
+
 def _install_mcp_tool_watchdogs(mcp: FastMCP) -> None:
     for tool in mcp._tool_manager._tools.values():  # noqa: SLF001
         original = tool.fn
@@ -839,6 +883,15 @@ def _install_mcp_tool_watchdogs(mcp: FastMCP) -> None:
             call_id = uuid.uuid4().hex
             started_at = time.monotonic()
             live_session_key = mcp_session_key(mcp)
+            logical_session_key = _logical_session_routing_key(
+                live_session_key,
+                tool_name=__tool_name,
+                session_run_id=(
+                    str(session_run_id) if session_run_id is not None else None
+                ),
+                action=call_arguments.get("action"),
+                session_id=call_arguments.get("session_id"),
+            )
             live_manager = get_live_channel_manager()
             logical_manager = get_session_runtime_manager()
             principal_subject = _current_principal_subject()
@@ -849,7 +902,7 @@ def _install_mcp_tool_watchdogs(mcp: FastMCP) -> None:
             if __tool_name == "session_manage" and normalized_tool_action == "get":
                 current_session_id = await asyncio.to_thread(
                     logical_manager.current_session_id,
-                    live_session_key,
+                    logical_session_key,
                     subject=principal_subject,
                 )
                 requested_session_id = str(call_arguments.get("session_id") or "").strip()
@@ -868,7 +921,7 @@ def _install_mcp_tool_watchdogs(mcp: FastMCP) -> None:
                 try:
                     logical_lease = await asyncio.to_thread(
                         logical_manager.begin_tool_call,
-                        live_session_key,
+                        logical_session_key,
                         call_id,
                         expected_run_id=(
                             str(session_run_id) if session_run_id is not None else None
@@ -2977,7 +3030,14 @@ def _register_maintenance_tools(mcp: FastMCP, read_only_tool: ToolAnnotations) -
         takeover: bool = False,
     ) -> ToolResult:
         """Manage a durable logical task session independent of machine and cwd. Start one before substantive tool-driven work; report semantic progress at meaningful checkpoints; resume by session_id to hand work to a new GPT/MCP run. resume with takeover=true always creates a new agent run and supersedes the old one. Use the returned active_run.run_id as session_run_id for report/finish/cancel and subsequent tools. Actions: start, resume, get, report, list, finish, cancel, delete. start may include label/objective; report accepts summary/findings/next/blockers/objective/label. delete permanently removes a detached or terminal Session and frees retained history capacity."""
-        session_key = mcp_session_key(mcp)
+        live_session_key = mcp_session_key(mcp)
+        session_key = _logical_session_routing_key(
+            live_session_key,
+            tool_name="session_manage",
+            session_run_id=session_run_id,
+            action=action,
+            session_id=session_id,
+        )
         subject = _current_principal_subject()
         result = await _tool_call(
             asyncio.to_thread,
@@ -3004,7 +3064,7 @@ def _register_maintenance_tools(mcp: FastMCP, read_only_tool: ToolAnnotations) -
                 "resume",
             }:
                 get_live_channel_manager().bind_logical_session(
-                    session_key,
+                    live_session_key,
                     str(data["session_id"]),
                     subject,
                     exclusive_model_owner=True,
@@ -3039,7 +3099,12 @@ def _register_maintenance_tools(mcp: FastMCP, read_only_tool: ToolAnnotations) -
         return await _tool_call(
             asyncio.to_thread,
             get_session_runtime_manager().manage_plan,
-            mcp_session_key(mcp),
+            _logical_session_routing_key(
+                mcp_session_key(mcp),
+                tool_name="plan_manage",
+                session_run_id=session_run_id,
+                action=action,
+            ),
             action=action,
             session_run_id=session_run_id,
             require_run_token=True,

--- a/tests/test_audit_regressions.py
+++ b/tests/test_audit_regressions.py
@@ -365,7 +365,8 @@ async def test_python_and_playwright_tools_honor_configured_interpreter_and_clea
 
     monkeypatch.setattr(tools_module, "run_shell", fake_run)
     await tools_module._run_python("print('x')")
-    assert commands[-1].startswith("'/opt/custom python' ")
+    expected_python = tools_module.quote_shell_executable("/opt/custom python")
+    assert commands[-1].startswith(f"{expected_python} ")
 
     stale = tmp_path / "screenshots" / "page.png"
     stale.parent.mkdir()

--- a/tests/test_live_workspace.py
+++ b/tests/test_live_workspace.py
@@ -1178,7 +1178,7 @@ async def test_mcp_app_resource_and_render_result_hide_live_token(tmp_path, monk
     assert render_tool.meta["openai/outputTemplate"] == LIVE_RESOURCE_VERSIONED_URI
     assert render_tool.meta["openai/widgetAccessible"] is True
     assert "live_id" not in render_tool.inputSchema["properties"]
-    assert render_tool.meta["securitySchemes"][0]["scopes"] == list(ALL_OAUTH_SCOPES)
+    assert render_tool.meta["securitySchemes"] == [{"type": "noauth"}]
     assert render_tool.outputSchema["title"] == "LiveChannelResult"
     assert "session_run_id" in render_tool.inputSchema["properties"]
     assert "session_run_id" in render_tool.inputSchema["required"]

--- a/tests/test_tunnel_connector_regressions.py
+++ b/tests/test_tunnel_connector_regressions.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import pytest
+
+import local_shell_mcp.tools as tools
+from local_shell_mcp.models import CommandResult
+from local_shell_mcp.session_runtime import SessionRuntimeManager
+from local_shell_mcp.settings import get_settings
+
+
+def _configure(tmp_path, monkeypatch, *, auth_mode: str = "none") -> None:
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(tmp_path / ".state"))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_AUDIT_LOG_PATH", str(tmp_path / "audit.jsonl"))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_AUTH_MODE", auth_mode)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_REMOTE_ENABLED", "false")
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_noauth_mode_advertises_noauth_security_scheme(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch, auth_mode="none")
+
+    advertised = await tools.build_mcp().list_tools()
+
+    assert advertised
+    for tool in advertised:
+        schemes = (tool.meta or {}).get("securitySchemes", [])
+        assert {scheme.get("type") for scheme in schemes} == {"noauth"}, tool.name
+
+
+@pytest.mark.asyncio
+async def test_run_python_uses_executable_quoting_for_powershell(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_SHELL_EXECUTABLE", "powershell.exe")
+    monkeypatch.setenv(
+        "LOCAL_SHELL_MCP_PYTHON_BIN", r"C:\Program Files\Python\python.exe"
+    )
+    get_settings.cache_clear()
+    commands: list[str] = []
+
+    async def fake_run_shell(command: str, **_kwargs) -> CommandResult:
+        commands.append(command)
+        return CommandResult(
+            ok=True,
+            exit_code=0,
+            timed_out=False,
+            duration_ms=1,
+            cwd=".",
+            command=command,
+            stdout="ok",
+            stderr="",
+            truncated=False,
+        )
+
+    monkeypatch.setattr(tools, "run_shell", fake_run_shell)
+
+    result = await tools._run_python("print(1)")
+
+    assert result["ok"] is True
+    assert len(commands) == 1
+    assert commands[0].startswith("& 'C:\\Program Files\\Python\\python.exe' '")
+
+
+def test_multiplexed_stdio_routes_logical_sessions_by_durable_run_id(tmp_path):
+    manager = SessionRuntimeManager(tmp_path / ".state")
+    subject = "user"
+    transport_key = "mcp-session:shared-tunnel"
+
+    start_a_key = tools._logical_session_routing_key(
+        transport_key,
+        tool_name="session_manage",
+        session_run_id=None,
+        action="start",
+    )
+    start_b_key = tools._logical_session_routing_key(
+        transport_key,
+        tool_name="session_manage",
+        session_run_id=None,
+        action="start",
+    )
+    assert start_a_key != start_b_key
+
+    session_a = manager.manage(start_a_key, subject, action="start", objective="A")
+    session_b = manager.manage(start_b_key, subject, action="start", objective="B")
+    session_a_id = session_a["session_id"]
+    session_b_id = session_b["session_id"]
+    run_a = session_a["active_run"]["run_id"]
+    run_b = session_b["active_run"]["run_id"]
+
+    route_a = tools._logical_session_routing_key(
+        transport_key,
+        tool_name="session_manage",
+        session_run_id=run_a,
+        action="report",
+    )
+    route_b = tools._logical_session_routing_key(
+        transport_key,
+        tool_name="session_manage",
+        session_run_id=run_b,
+        action="report",
+    )
+    assert route_a != route_b
+
+    manager.manage(
+        route_a,
+        subject,
+        action="report",
+        session_run_id=run_a,
+        summary="A-report",
+    )
+    manager.manage(
+        route_b,
+        subject,
+        action="report",
+        session_run_id=run_b,
+        summary="B-report",
+    )
+
+    lease_a = manager.begin_tool_call(
+        route_a,
+        "call-a",
+        expected_run_id=run_a,
+        subject=subject,
+        data={"tool": "run_shell"},
+    )
+    lease_b = manager.begin_tool_call(
+        route_b,
+        "call-b",
+        expected_run_id=run_b,
+        subject=subject,
+        data={"tool": "run_shell"},
+    )
+    assert lease_a is not None
+    assert lease_b is not None
+    manager.finish_tool_call(lease_a, "tool.completed")
+    manager.finish_tool_call(lease_b, "tool.completed")
+
+    plan_a_key = tools._logical_session_routing_key(
+        transport_key,
+        tool_name="plan_manage",
+        session_run_id=run_a,
+        action="start",
+    )
+    plan_b_key = tools._logical_session_routing_key(
+        transport_key,
+        tool_name="plan_manage",
+        session_run_id=run_b,
+        action="start",
+    )
+    manager.manage_plan(
+        plan_a_key,
+        action="start",
+        session_run_id=run_a,
+        objective="Goal A",
+        steps=[{"id": "a1", "text": "A"}],
+    )
+    manager.manage_plan(
+        plan_b_key,
+        action="start",
+        session_run_id=run_b,
+        objective="Goal B",
+        steps=[{"id": "b1", "text": "B"}],
+    )
+
+    state_a = manager.get(session_a_id, subject=subject)
+    state_b = manager.get(session_b_id, subject=subject)
+    assert state_a["active_run"]["run_id"] == run_a
+    assert state_b["active_run"]["run_id"] == run_b
+    assert state_a["progress"]["summary"] == "A-report"
+    assert state_b["progress"]["summary"] == "B-report"
+    assert state_a["plan"]["objective"] == "Goal A"
+    assert state_b["plan"]["objective"] == "Goal B"
+
+    # Header-backed transports already have real client affinity and must retain
+    # the existing one-session-per-transport routing semantics.
+    assert (
+        tools._logical_session_routing_key(
+            "mcp-http:real-client",
+            tool_name="session_manage",
+            session_run_id=None,
+            action="start",
+        )
+        == "mcp-http:real-client"
+    )
+
+
+def test_multiplexed_resume_routes_by_target_session_id():
+    base = "mcp-session:shared-tunnel"
+    first = tools._logical_session_routing_key(
+        base,
+        tool_name="session_manage",
+        session_run_id=None,
+        action="resume",
+        session_id="s_first",
+    )
+    first_again = tools._logical_session_routing_key(
+        base,
+        tool_name="session_manage",
+        session_run_id=None,
+        action="resume",
+        session_id="s_first",
+    )
+    second = tools._logical_session_routing_key(
+        base,
+        tool_name="session_manage",
+        session_run_id=None,
+        action="resume",
+        session_id="s_second",
+    )
+    assert first == first_again == f"{base}:session:s_first"
+    assert second == f"{base}:session:s_second"
+    assert first != second


### PR DESCRIPTION
## Summary

This fixes the three v4.0.1 regressions reported in #193:

1. **No-auth tool metadata** — when `LOCAL_SHELL_MCP_AUTH_MODE=none`, public tools now advertise a `noauth` security scheme instead of `oauth2`.
2. **PowerShell `run_python` invocation** — `_run_python` now uses `quote_shell_executable(...)`, so PowerShell receives the required call operator (`& '...python.exe' '...script.py'`).
3. **Logical Session isolation over multiplexed headerless stdio/tunnel transports** — durable `session_run_id` / `session_id` values now route logical Session and Goal operations independently even when multiple ChatGPT conversations share one underlying MCP stdio session.

### Session-routing detail

The original issue described the collision as a fallback to the literal `"direct"` key. On current `main`, headerless requests normally receive a process-local `mcp-session:<uuid>` key derived from `request_context.session`. With the Secure MCP Tunnel, multiple ChatGPT conversations can still be multiplexed through the same underlying session object, so they share that `mcp-session:*` key and previously detached/superseded one another.

This change deliberately scopes the special routing behavior to **headerless `mcp-session:*` keys only**:

- `start` uses an isolated one-shot logical routing key;
- `resume` / explicit `get` route by durable logical `session_id`;
- subsequent tool calls and `plan_manage` route by durable `session_run_id`;
- stale run-token fencing and existing superseded-run errors are preserved;
- legacy `direct`, header-backed `mcp-http:*`, and `mcp-affinity:*` semantics are unchanged.

Live Workspace transport routing remains transport-scoped; only Logical Session ownership/leases are separated.

## Regression coverage

Added `tests/test_tunnel_connector_regressions.py` covering:

- `auth_mode=none` => `noauth` metadata;
- PowerShell executable quoting for `_run_python`;
- two logical Sessions sharing one simulated `mcp-session:*` transport, including independent reports, ordinary tool leases, and Goal plans;
- resume routing by target logical `session_id`;
- unchanged header-backed HTTP routing.

Existing assertions that encoded the two fixed behaviors were updated accordingly.

## Validation

- Focused + compatibility suite: **75 passed**
- Ruff: **all checks passed**
- `git diff --check`: **passed**
- Full Windows suite: **848 passed, 11 skipped, 3 failed**

The same remaining three failures reproduce unchanged on pristine `origin/main@4429826` in the same environment:

- `test_completed_job_retains_output_and_exit_code` (`printf` under PowerShell)
- `test_job_log_is_bounded_and_reports_truncation` (`python3` under PowerShell)
- `test_remote_copy_dir_packs_transfers_and_unpacks` (existing Windows temp-path failure)

So the PR introduces no additional full-suite failures in this Windows environment.

Fixes #193
