### PR TITLE
fix(windows): harden shell and remote worker execution

### DIFF
--- a/src/local_shell_mcp/conpty_ops.py
+++ b/src/local_shell_mcp/conpty_ops.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import importlib
 import re
 import subprocess
 import time
@@ -56,6 +57,10 @@ class ConPtyShellSession:
 
 
 def is_available() -> bool:
+    global winpty
+    if winpty is None:
+        with contextlib.suppress(ImportError, OSError):
+            winpty = importlib.import_module("winpty")
     return winpty is not None and hasattr(winpty, "PtyProcess")
 
 

--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -1064,7 +1064,7 @@ async def _run_python(code: str, cwd: str = ".", timeout_s: int = 60) -> dict[st
     script.parent.mkdir(parents=True, exist_ok=True)
     await asyncio.to_thread(script.write_text, code, encoding="utf-8")
     result = await run_shell(
-        f"{quote_shell_argument(get_settings().python_bin)} {quote_shell_argument(str(script))}",
+        f"{quote_shell_executable(get_settings().python_bin)} {quote_shell_argument(str(script))}",
         cwd=cwd,
         timeout_s=public_run_shell_timeout(timeout_s),
         max_output_bytes=1_000_000,

--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -2202,6 +2202,17 @@ async def _run_worker_locked(
     workdir: str | None = None,
     persist: bool = False,
 ) -> None:  # noqa: ARG001
+    if sys.platform == "win32":
+        from .remote_worker_installer import ensure_platform_dependencies
+
+        dependency_status = await asyncio.to_thread(ensure_platform_dependencies)
+        if not dependency_status.get("available"):
+            print(
+                "Warning: pywinpty is unavailable; persistent shells will use the native "
+                f"pipe fallback: {dependency_status.get('error') or 'installation failed'}",
+                file=sys.stderr,
+                flush=True,
+            )
     workdir = str(Path(workdir or os.getcwd()).expanduser().resolve())
     os.environ["LOCAL_SHELL_MCP_WORKSPACE_ROOT"] = workdir
     os.environ["LOCAL_SHELL_MCP_ALLOW_FULL_CONTAINER"] = "true"

--- a/src/local_shell_mcp/remote_worker_installer.py
+++ b/src/local_shell_mcp/remote_worker_installer.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import hashlib
+import importlib
 import json
 import os
 import shutil
+import subprocess
+import sys
 import tarfile
 import tempfile
 import urllib.parse
@@ -20,6 +23,84 @@ from .remote_worker_state import (
 )
 
 _WORKER_MANIFEST_PATH = "/remote/worker-bundle.tgz?manifest=1"
+_WINDOWS_PTY_REQUIREMENT = "pywinpty>=2.0.13"
+
+
+def worker_dependency_dir() -> Path:
+    python_tag = f"py{sys.version_info.major}{sys.version_info.minor}"
+    return worker_state_dir() / "dependencies" / python_tag
+
+
+def _activate_worker_dependency_dir(path: Path) -> None:
+    value = str(path.resolve())
+    if value not in sys.path:
+        sys.path.insert(0, value)
+    current = [entry for entry in os.environ.get("PYTHONPATH", "").split(os.pathsep) if entry]
+    if value not in current:
+        os.environ["PYTHONPATH"] = os.pathsep.join([value, *current])
+
+
+def ensure_platform_dependencies() -> dict[str, Any]:
+    path = worker_dependency_dir()
+    _activate_worker_dependency_dir(path)
+    if sys.platform != "win32":
+        return {"available": True, "installed": False, "path": str(path)}
+    try:
+        module = importlib.import_module("winpty")
+    except (ImportError, OSError):
+        module = None
+    if module is not None and hasattr(module, "PtyProcess"):
+        return {"available": True, "installed": False, "path": str(path)}
+
+    path.mkdir(parents=True, exist_ok=True)
+    argv = [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "--disable-pip-version-check",
+        "--no-input",
+        "--retries",
+        "1",
+        "--timeout",
+        "5",
+        "--target",
+        str(path),
+        _WINDOWS_PTY_REQUIREMENT,
+    ]
+    try:
+        completed = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=60,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return {
+            "available": False,
+            "installed": False,
+            "path": str(path),
+            "error": str(exc),
+        }
+    importlib.invalidate_caches()
+    try:
+        module = importlib.import_module("winpty")
+    except (ImportError, OSError):
+        module = None
+    available = module is not None and hasattr(module, "PtyProcess")
+    result: dict[str, Any] = {
+        "available": available,
+        "installed": available and completed.returncode == 0,
+        "path": str(path),
+    }
+    if not available:
+        result["error"] = (
+            completed.stderr.strip()
+            or completed.stdout.strip()
+            or f"pip exited with code {completed.returncode}"
+        )
+    return result
 
 
 def _fetch_bytes(url: str, timeout: float = 60) -> bytes:

--- a/src/local_shell_mcp/shell_environment.py
+++ b/src/local_shell_mcp/shell_environment.py
@@ -34,6 +34,16 @@ def persistent_shell_args(shell: str, command: str | None = None) -> list[str]:
     return [shell]
 
 
+def persistent_pipe_shell_args(shell: str, command: str | None = None) -> list[str]:
+    if command:
+        return shell_command_args(shell, command)
+    name = shell_program_name(shell)
+    powershell = "power" + "shell"
+    if name in {powershell + ".exe", powershell, "pwsh.exe", "pwsh"}:
+        return [shell, "-NoLogo", "-NoProfile", "-NonInteractive", "-Command", "-"]
+    return [shell]
+
+
 def is_frozen_app() -> bool:
     return bool(getattr(sys, "frozen", False) or getattr(sys, "_MEIPASS", None))
 

--- a/src/local_shell_mcp/shell_ops.py
+++ b/src/local_shell_mcp/shell_ops.py
@@ -24,6 +24,7 @@ from .models import CommandResult
 from .process_utils import managed_process_kwargs
 from .settings import get_settings
 from .shell_environment import (
+    persistent_pipe_shell_args,
     persistent_shell_args,
     shell_command_args,
     subprocess_env,
@@ -198,6 +199,10 @@ def _shell_command_args(command: str) -> list[str]:
 
 def _persistent_shell_args(command: str | None = None) -> list[str]:
     return persistent_shell_args(get_settings().shell_executable, command)
+
+
+def _persistent_pipe_shell_args(command: str | None = None) -> list[str]:
+    return persistent_pipe_shell_args(get_settings().shell_executable, command)
 
 
 def _use_native_persistent_shell_backend() -> bool:
@@ -586,7 +591,7 @@ async def _native_start_shell(
 
     initial = command or get_settings().shell_executable
     check_command_policy(initial)
-    args = _persistent_shell_args(command)
+    args = _persistent_pipe_shell_args(command)
     try:
         proc = await asyncio.create_subprocess_exec(
             *args,

--- a/tests/test_conpty_backend.py
+++ b/tests/test_conpty_backend.py
@@ -9,6 +9,17 @@ from local_shell_mcp.errors import ShellExecutableNotFoundError
 from local_shell_mcp.settings import get_settings
 
 
+def test_conpty_availability_retries_import_after_worker_dependency_bootstrap(monkeypatch):
+    monkeypatch.setattr(conpty_ops, "winpty", None)
+    monkeypatch.setattr(
+        conpty_ops.importlib,
+        "import_module",
+        lambda name: SimpleNamespace(PtyProcess=object()),
+    )
+
+    assert conpty_ops.is_available() is True
+
+
 class FakePtyProcess:
     spawned = []
 

--- a/tests/test_conpty_backend.py
+++ b/tests/test_conpty_backend.py
@@ -149,7 +149,7 @@ async def test_windows_falls_back_to_native_when_pywinpty_unavailable(tmp_path, 
     monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
     get_settings.cache_clear()
     monkeypatch.setattr(ops, "_use_native_persistent_shell_backend", lambda: True)
-    monkeypatch.setattr(conpty_ops, "winpty", None)
+    monkeypatch.setattr(conpty_ops, "is_available", lambda: False)
 
     async def fake_native_start(cwd=".", name=None, command=None):
         return {"session_id": name, "cwd": cwd, "command": command or "shell", "backend": "native"}

--- a/tests/test_remote_complete.py
+++ b/tests/test_remote_complete.py
@@ -634,6 +634,29 @@ def test_worker_upload_protocol_and_generated_execution_edges(tmp_path, monkeypa
 
 
 @pytest.mark.asyncio
+async def test_worker_run_python_invokes_quoted_executable_in_powershell(
+    tmp_path, monkeypatch
+):
+    _configure(
+        tmp_path,
+        monkeypatch,
+        LOCAL_SHELL_MCP_SHELL_EXECUTABLE="powershell.exe",
+        LOCAL_SHELL_MCP_PYTHON_BIN=r"C:\Program Files\Python\python.exe",
+    )
+    captured = {}
+
+    async def fake_run_shell(command, **kwargs):
+        captured["command"] = command
+        return _result()
+
+    monkeypatch.setattr(remote, "run_shell", fake_run_shell)
+
+    await remote._run_python("print('ok')", ".", 5)
+
+    assert captured["command"].startswith("& 'C:\\Program Files\\Python\\python.exe' '")
+
+
+@pytest.mark.asyncio
 async def test_worker_apply_patch_honors_nested_cwd_in_git_worktree(
     tmp_path, monkeypatch
 ):

--- a/tests/test_remote_worker_installer.py
+++ b/tests/test_remote_worker_installer.py
@@ -162,6 +162,65 @@ def test_install_without_existing_config_rejects_incomplete_bundle(tmp_path, mon
         installer.install_or_update_runtime("https://s")
 
 
+
+def test_worker_dependency_bootstrap_is_noop_off_windows(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setattr(installer.sys, "platform", "linux")
+    monkeypatch.setattr(installer.sys, "path", list(installer.sys.path))
+    monkeypatch.setenv("PYTHONPATH", "")
+
+    result = installer.ensure_platform_dependencies()
+
+    assert result["available"] is True
+    assert result["installed"] is False
+
+
+def test_windows_worker_reuses_existing_pywinpty(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setattr(installer.sys, "platform", "win32")
+    monkeypatch.setattr(installer.sys, "path", list(installer.sys.path))
+    monkeypatch.setenv("PYTHONPATH", "")
+    monkeypatch.setattr(
+        installer.importlib,
+        "import_module",
+        lambda name: SimpleNamespace(PtyProcess=object()),
+    )
+    monkeypatch.setattr(
+        installer.subprocess,
+        "run",
+        lambda *args, **kwargs: pytest.fail("pip should not run when pywinpty is available"),
+    )
+
+    result = installer.ensure_platform_dependencies()
+
+    assert result["available"] is True
+    assert result["installed"] is False
+
+
+def test_windows_worker_reports_failed_import_after_successful_pip(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setattr(installer.sys, "platform", "win32")
+    monkeypatch.setattr(installer.sys, "path", list(installer.sys.path))
+    monkeypatch.setenv("PYTHONPATH", "")
+    def missing(name):
+        raise ImportError(name)
+
+    monkeypatch.setattr(installer.importlib, "import_module", missing)
+    monkeypatch.setattr(installer.importlib, "invalidate_caches", lambda: None)
+    monkeypatch.setattr(
+        installer.subprocess,
+        "run",
+        lambda argv, **kwargs: subprocess.CompletedProcess(
+            argv, 0, stdout="installed but unavailable", stderr=""
+        ),
+    )
+
+    result = installer.ensure_platform_dependencies()
+
+    assert result["available"] is False
+    assert result["installed"] is False
+    assert result["error"] == "installed but unavailable"
+
 def test_windows_worker_installs_pywinpty_into_state_dir(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
     monkeypatch.setattr(installer.sys, "platform", "win32")

--- a/tests/test_remote_worker_installer.py
+++ b/tests/test_remote_worker_installer.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import hashlib
 import io
 import json
+import subprocess
 import tarfile
+from types import SimpleNamespace
 
 import pytest
 
@@ -158,3 +160,60 @@ def test_install_without_existing_config_rejects_incomplete_bundle(tmp_path, mon
     monkeypatch.setattr(installer, "_fetch_bytes", lambda *args, **kwargs: payload)
     with pytest.raises(ValueError, match="does not contain local_shell_mcp"):
         installer.install_or_update_runtime("https://s")
+
+
+def test_windows_worker_installs_pywinpty_into_state_dir(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setattr(installer.sys, "platform", "win32")
+    monkeypatch.setattr(installer.sys, "path", list(installer.sys.path))
+    monkeypatch.setenv("PYTHONPATH", "")
+    imports = []
+
+    def import_module(name):
+        imports.append(name)
+        if len(imports) == 1:
+            raise ImportError(name)
+        return SimpleNamespace(PtyProcess=object())
+
+    captured = {}
+
+    def run(argv, **kwargs):
+        captured["argv"] = argv
+        captured["kwargs"] = kwargs
+        return subprocess.CompletedProcess(argv, 0, stdout="installed", stderr="")
+
+    monkeypatch.setattr(installer.importlib, "import_module", import_module)
+    monkeypatch.setattr(installer.importlib, "invalidate_caches", lambda: None)
+    monkeypatch.setattr(installer.subprocess, "run", run)
+
+    result = installer.ensure_platform_dependencies()
+
+    target = installer.worker_dependency_dir()
+    assert result["available"] is True
+    assert result["installed"] is True
+    assert captured["argv"][-1] == "pywinpty>=2.0.13"
+    assert captured["argv"][captured["argv"].index("--target") + 1] == str(target)
+    assert str(target.resolve()) in installer.sys.path
+    assert captured["kwargs"]["timeout"] == 60
+
+
+def test_windows_worker_falls_back_when_pywinpty_install_fails(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setattr(installer.sys, "platform", "win32")
+    monkeypatch.setattr(installer.sys, "path", list(installer.sys.path))
+    monkeypatch.setenv("PYTHONPATH", "")
+
+    def missing(name):
+        raise ImportError(name)
+
+    def timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(args[0], 60)
+
+    monkeypatch.setattr(installer.importlib, "import_module", missing)
+    monkeypatch.setattr(installer.subprocess, "run", timeout)
+
+    result = installer.ensure_platform_dependencies()
+
+    assert result["available"] is False
+    assert result["installed"] is False
+    assert "timed out" in result["error"]

--- a/tests/test_runtime_edge_complete.py
+++ b/tests/test_runtime_edge_complete.py
@@ -431,9 +431,15 @@ def test_conpty_helpers_cleanup_start_send_read_kill_and_list(tmp_path, monkeypa
         assert conpty._shell_command_args("x")[1:] == suffix
     assert isinstance(conpty._spawn_command(["a", "b c"]), str)
 
-    monkeypatch.setattr(conpty, "winpty", None)
-    with pytest.raises(RuntimeError, match="not available"):
-        conpty._spawn_pty(["x"], tmp_path)
+    with monkeypatch.context() as patch:
+        patch.setattr(conpty, "winpty", None)
+
+        def missing_winpty(name):
+            raise ImportError(name)
+
+        patch.setattr(conpty.importlib, "import_module", missing_winpty)
+        with pytest.raises(RuntimeError, match="not available"):
+            conpty._spawn_pty(["x"], tmp_path)
 
     class Process:
         def __init__(self, alive=True):

--- a/tests/test_shell_environment.py
+++ b/tests/test_shell_environment.py
@@ -4,8 +4,23 @@ import pytest
 from conftest import python_shell_command
 
 from local_shell_mcp.settings import get_settings
-from local_shell_mcp.shell_environment import subprocess_env
+from local_shell_mcp.shell_environment import persistent_pipe_shell_args, subprocess_env
 from local_shell_mcp.shell_ops import run_shell
+
+
+def test_persistent_pipe_powershell_reads_commands_from_stdin():
+    assert persistent_pipe_shell_args("powershell.exe") == [
+        "powershell.exe",
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        "-",
+    ]
+
+
+def test_persistent_pipe_shell_keeps_regular_interactive_invocation():
+    assert persistent_pipe_shell_args("/bin/bash") == ["/bin/bash"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_windows_native_backend.py
+++ b/tests/test_windows_native_backend.py
@@ -15,14 +15,19 @@ async def test_native_persistent_shell_backend_roundtrip(tmp_path, monkeypatch):
     monkeypatch.setattr(ops.conpty_ops, "is_available", lambda: False)
     session = await ops.start_shell(name="native-roundtrip")
     try:
-        await ops.send_shell(session["session_id"], "echo native-ok")
+        command = (
+            "Write-Output ('native-' + 'executed')"
+            if ops.sys.platform == "win32"
+            else "printf 'native-%s\\n' executed"
+        )
+        await ops.send_shell(session["session_id"], command)
         data = {"output": ""}
         for _ in range(100):
             data = await ops.read_shell(session["session_id"], lines=20)
-            if "native-ok" in data["output"]:
+            if "native-executed" in data["output"]:
                 break
             await asyncio.sleep(0.05)
-        assert "native-ok" in data["output"]
+        assert "native-executed" in data["output"]
         assert session["backend"] == "native"
         listed = await ops.list_shells()
         assert any(item["session_id"] == session["session_id"] for item in listed["sessions"])


### PR DESCRIPTION
## Summary

- make the Windows native persistent-shell fallback launch PowerShell in explicit stdin mode (`-Command -`) instead of relying on bare interactive behavior over redirected pipes
- strengthen the native round-trip test so it verifies executed command output rather than accepting PowerShell command echo
- fix remote `run_python` on PowerShell by invoking quoted Python executables with the PowerShell call operator
- let Windows remote workers install `pywinpty` into their isolated worker state when it is missing, then lazily enable ConPTY; installation/import failures keep the native pipe backend as a safe fallback
- preserve explicit coverage for the no-ConPTY fallback after making pywinpty discovery lazy

The pywinpty bootstrap only runs on Windows workers when `winpty.PtyProcess` is unavailable. It installs into `<worker state>/dependencies/pyXY`, does not modify the user's global Python environment, and falls back to the native pipe backend if pip is unavailable, offline, or times out.

## Validation

- [x] `ruff check .`
- [x] `pytest -q` — 842 passed, 1 skipped
- [x] `mkdocs build --strict` if docs changed — not applicable; no docs changed
- [x] VS Code extension compile if extension files changed — not applicable; no extension files changed
- [x] Windows Python 3.12 targeted regressions — 7 passed on a real Windows machine
- [x] Windows Python 3.13 clean worker state — pywinpty installed into isolated state and `conpty True`
- [x] Windows remote `run_python` end-to-end — returned `remote-python-ok` with exit code 0

## Safety checklist

- [x] No secrets, tunnel tokens, OAuth pins, private keys, or bearer file-link URLs are committed.
- [x] New or changed MCP tools are documented and tested. No MCP tool surface changed.
- [x] Host-control, remote-worker, file-link, or credential behavior is explicitly described. Windows worker dependency bootstrap behavior is described above.
- [x] Backwards compatibility impact is noted. Existing Windows workers keep the native pipe fallback when ConPTY cannot be installed; non-Windows behavior is unchanged.
