### PR TITLE
Add Snap Store release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -379,6 +379,61 @@ jobs:
             dist/local-shell-mcp-*.vsix
           if-no-files-found: error
 
+  build-snap:
+    name: Build Snap package (${{ matrix.artifact }})
+    needs:
+      - validate-release
+      - build-binary
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - artifact: linux-x86_64
+            runner: ubuntu-latest
+          - artifact: linux-aarch64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download Linux release binary
+        uses: actions/download-artifact@v8
+        with:
+          name: binary-${{ matrix.artifact }}
+          path: dist
+
+      - name: Stage Snap payload
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ needs.validate-release.outputs.version }}
+        run: |
+          set -euo pipefail
+          raw_binary="$(find dist -type f -name "local-shell-mcp-${{ matrix.artifact }}" -print -quit)"
+          if [[ -z "$raw_binary" ]]; then
+            echo "Raw Linux release binary was not found" >&2
+            exit 1
+          fi
+          mkdir -p snap/payload
+          install -m 0755 "$raw_binary" snap/payload/local-shell-mcp
+          printf '%s\n' "$RELEASE_VERSION" > snap/version
+
+      - name: Build Snap package
+        id: snapcraft
+        uses: snapcore/action-build@v1
+
+      - name: Normalize Snap artifact name
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p snap-dist
+          cp "${{ steps.snapcraft.outputs.snap }}" "snap-dist/local-shell-mcp-${{ matrix.artifact }}.snap"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: snap-${{ matrix.artifact }}
+          path: snap-dist/local-shell-mcp-${{ matrix.artifact }}.snap
+          if-no-files-found: error
+
   publish-docker-platform:
     name: Publish Docker image (${{ matrix.platform }})
     needs: validate-release
@@ -487,6 +542,7 @@ jobs:
       - build-python-package
       - build-binary
       - build-vscode-extension
+      - build-snap
       - publish-docker-manifest
     steps:
       - uses: actions/checkout@v6
@@ -511,6 +567,12 @@ jobs:
           name: vscode-extension
           path: dist
 
+      - name: Download Snap package artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: snap-*
+          path: dist
+          merge-multiple: true
 
       - name: Generate SHA256 checksums
         shell: bash
@@ -565,7 +627,9 @@ jobs:
           local-shell-mcp-${{ needs.validate-release.outputs.version }}.vsix
           \`\`\`
 
-          Python package artifacts, executable archives, and the VS Code extension are attached below.
+          Snap packages for Linux x86_64 and ARM64 are attached below. Stable releases are published to Snap Store \`stable\`; prereleases are published to \`edge\`.
+
+          Python package artifacts, executable archives, the VS Code extension, and Snap packages are attached below.
 
           Python package version in \`pyproject.toml\`: \`${{ needs.validate-release.outputs.version }}\`
           EOF
@@ -579,6 +643,36 @@ jobs:
           generate_release_notes: true
           body_path: RELEASE_NOTES.md
           files: dist/*
+
+  publish-snap:
+    name: Publish Snap package (${{ matrix.artifact }})
+    if: ${{ vars.SNAP_PUBLISH_ENABLED == 'true' }}
+    runs-on: ubuntu-latest
+    needs:
+      - validate-release
+      - build-snap
+      - github-release
+    environment: snapcraft
+    strategy:
+      fail-fast: false
+      matrix:
+        artifact:
+          - linux-x86_64
+          - linux-aarch64
+    steps:
+      - name: Download Snap package
+        uses: actions/download-artifact@v8
+        with:
+          name: snap-${{ matrix.artifact }}
+          path: dist
+
+      - name: Publish Snap package
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        with:
+          snap: dist/local-shell-mcp-${{ matrix.artifact }}.snap
+          release: ${{ inputs.prerelease && 'edge' || 'stable' }}
 
   publish-pypi:
     name: Publish to PyPI

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ dist/
 
 src/local_shell_mcp/helpers/*/tmux
 src/local_shell_mcp/ui_runtime/
+
+# Snap release staging
+snap/payload/
+snap/version
+*.snap

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,5 @@ dist/
 src/local_shell_mcp/helpers/*/tmux
 src/local_shell_mcp/ui_runtime/
 
-# Snap release staging
-snap/payload/
-snap/version
+# Snap build output
 *.snap

--- a/scripts/check-release-matrix.py
+++ b/scripts/check-release-matrix.py
@@ -126,6 +126,10 @@ def main() -> int:
     if snap_apps.get("local-shell-mcp", {}).get("command") != "bin/local-shell-mcp":
         print("Snapcraft package must expose the local-shell-mcp command.")
         return 1
+    snap_part = snapcraft.get("parts", {}).get("local-shell-mcp", {})
+    if snap_part.get("organize", {}).get("local-shell-mcp") != "bin/local-shell-mcp":
+        print("Snapcraft package must stage the release binary at bin/local-shell-mcp.")
+        return 1
     snap_job = jobs.get("build-snap", {})
     snap_artifacts = matrix_values(snap_job, "artifact")
     missing_snap = sorted(EXPECTED_SNAP_ARTIFACTS - snap_artifacts)

--- a/scripts/check-release-matrix.py
+++ b/scripts/check-release-matrix.py
@@ -126,10 +126,6 @@ def main() -> int:
     if snap_apps.get("local-shell-mcp", {}).get("command") != "bin/local-shell-mcp":
         print("Snapcraft package must expose the local-shell-mcp command.")
         return 1
-    if snap_apps.get("lsm", {}).get("command") != "bin/local-shell-mcp":
-        print("Snapcraft package must expose the lsm command alias.")
-        return 1
-
     snap_job = jobs.get("build-snap", {})
     snap_artifacts = matrix_values(snap_job, "artifact")
     missing_snap = sorted(EXPECTED_SNAP_ARTIFACTS - snap_artifacts)

--- a/scripts/check-release-matrix.py
+++ b/scripts/check-release-matrix.py
@@ -8,6 +8,7 @@ import yaml
 REPO = Path(__file__).resolve().parents[1]
 RELEASE = REPO / ".github" / "workflows" / "release.yml"
 DOCKERFILE = REPO / "Dockerfile"
+SNAPCRAFT = REPO / "snap" / "snapcraft.yaml"
 VSCODE_PACKAGE_SCRIPT = REPO / "vscode-extension" / "scripts" / "package-vsix.cjs"
 EXPECTED_BINARY_ARTIFACTS = {
     "linux-x86_64",
@@ -17,6 +18,7 @@ EXPECTED_BINARY_ARTIFACTS = {
     "windows-x86_64",
 }
 EXPECTED_PYTHON_ARTIFACTS = EXPECTED_BINARY_ARTIFACTS
+EXPECTED_SNAP_ARTIFACTS = {"linux-x86_64", "linux-aarch64"}
 EXPECTED_DOCKER_PLATFORMS = {"linux/amd64", "linux/arm64"}
 
 
@@ -116,6 +118,39 @@ def main() -> int:
         print("Release binary artifact upload must include extensionless raw executables.")
         return 1
 
+    snapcraft = yaml.safe_load(SNAPCRAFT.read_text(encoding="utf-8"))
+    if snapcraft.get("name") != "local-shell-mcp" or snapcraft.get("confinement") != "classic":
+        print("Snapcraft package must publish local-shell-mcp with classic confinement.")
+        return 1
+    snap_apps = snapcraft.get("apps", {})
+    if snap_apps.get("local-shell-mcp", {}).get("command") != "bin/local-shell-mcp":
+        print("Snapcraft package must expose the local-shell-mcp command.")
+        return 1
+    if snap_apps.get("lsm", {}).get("command") != "bin/local-shell-mcp":
+        print("Snapcraft package must expose the lsm command alias.")
+        return 1
+
+    snap_job = jobs.get("build-snap", {})
+    snap_artifacts = matrix_values(snap_job, "artifact")
+    missing_snap = sorted(EXPECTED_SNAP_ARTIFACTS - snap_artifacts)
+    extra_snap = sorted(snap_artifacts - EXPECTED_SNAP_ARTIFACTS)
+    if missing_snap or extra_snap:
+        print("Release Snap matrix mismatch.")
+        print(f"missing: {missing_snap}")
+        print(f"extra: {extra_snap}")
+        return 1
+    snap_stage_script = step_script(snap_job, "Stage Snap payload")
+    if "needs.validate-release.outputs.version" not in release_text or "snap/version" not in snap_stage_script:
+        print("Snap builds must derive their version from validated release metadata.")
+        return 1
+    snap_build_step = next(
+        (step for step in snap_job.get("steps", []) if step.get("name") == "Build Snap package"),
+        {},
+    )
+    if snap_build_step.get("uses") != "snapcore/action-build@v1":
+        print("Release workflow must build snaps with snapcore/action-build@v1.")
+        return 1
+
     github_release_job = jobs.get("github-release", {})
     checksum_script = step_script(github_release_job, "Generate SHA256 checksums")
     if "find . -maxdepth 1 -type f" not in checksum_script:
@@ -132,6 +167,25 @@ def main() -> int:
         return 1
     if "--tag next" not in npm_publish_script or "--tag latest" not in npm_publish_script:
         print("npm prereleases must use a non-latest dist-tag while stable releases update latest.")
+        return 1
+
+    snap_publish_job = jobs.get("publish-snap", {})
+    if snap_publish_job.get("environment") != "snapcraft":
+        print("Snap Store publication must run from the protected snapcraft environment.")
+        return 1
+    if "SNAP_PUBLISH_ENABLED" not in str(snap_publish_job.get("if") or ""):
+        print("Snap Store publication must be controlled by SNAP_PUBLISH_ENABLED.")
+        return 1
+    snap_publish_step = next(
+        (step for step in snap_publish_job.get("steps", []) if step.get("name") == "Publish Snap package"),
+        {},
+    )
+    if snap_publish_step.get("uses") != "snapcore/action-publish@v1":
+        print("Release workflow must publish snaps with snapcore/action-publish@v1.")
+        return 1
+    snap_release = str(snap_publish_step.get("with", {}).get("release", ""))
+    if "edge" not in snap_release or "stable" not in snap_release or "prerelease" not in snap_release:
+        print("Snap prereleases must publish to edge while stable releases publish to stable.")
         return 1
 
     pypi_job = jobs.get("publish-pypi", {})

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,6 +24,8 @@ parts:
   local-shell-mcp:
     plugin: dump
     source: snap/payload
+    organize:
+      local-shell-mcp: bin/local-shell-mcp
     override-build: |
       craftctl default
       craftctl set version="$(cat "$CRAFT_PROJECT_DIR/snap/version")"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,8 +19,6 @@ issues: https://github.com/fwerkor/local-shell-mcp/issues
 apps:
   local-shell-mcp:
     command: bin/local-shell-mcp
-  lsm:
-    command: bin/local-shell-mcp
 
 parts:
   local-shell-mcp:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,31 @@
+name: local-shell-mcp
+base: core24
+adopt-info: local-shell-mcp
+summary: ChatGPT-ready MCP control plane for local development
+description: |
+  local-shell-mcp gives ChatGPT and other MCP clients controlled access to
+  shell commands, files, browser automation, durable sessions, and optional
+  remote workers.
+
+  This package uses classic confinement because its purpose is to operate on
+  user-selected host workspaces and invoke host development tools.
+grade: stable
+confinement: classic
+license: MIT
+website: https://fwerkor.github.io/local-shell-mcp/
+source-code: https://github.com/fwerkor/local-shell-mcp
+issues: https://github.com/fwerkor/local-shell-mcp/issues
+
+apps:
+  local-shell-mcp:
+    command: bin/local-shell-mcp
+  lsm:
+    command: bin/local-shell-mcp
+
+parts:
+  local-shell-mcp:
+    plugin: dump
+    source: snap/payload
+    override-build: |
+      craftctl default
+      craftctl set version="$(cat "$CRAFT_PROJECT_DIR/snap/version")"


### PR DESCRIPTION
## Summary
- add a classic `core24` Snapcraft package for the standalone Linux release binary
- build amd64 and arm64 snaps in the existing release workflow and attach them to GitHub Releases
- publish stable releases to Snap Store `stable` and prereleases to `edge`
- guard the Snap release matrix and publishing semantics in CI

## Validation
- `actionlint .github/workflows/release.yml`
- `python -m ruff check scripts/check-release-matrix.py`
- `python scripts/check-release-matrix.py`
- YAML parse checks for release workflow and Snapcraft manifest
- `git diff origin/main...HEAD --check`
