### PR TITLE
ci: pause Snap Store publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -627,7 +627,7 @@ jobs:
           local-shell-mcp-${{ needs.validate-release.outputs.version }}.vsix
           \`\`\`
 
-          Snap packages for Linux x86_64 and ARM64 are attached below. Stable releases are published to Snap Store \`stable\`; prereleases are published to \`edge\`.
+          Snap packages for Linux x86_64 and ARM64 are attached below. Snap Store publishing is temporarily paused while store review is pending.
 
           Python package artifacts, executable archives, the VS Code extension, and Snap packages are attached below.
 
@@ -646,7 +646,8 @@ jobs:
 
   publish-snap:
     name: Publish Snap package (${{ matrix.artifact }})
-    if: ${{ vars.SNAP_PUBLISH_ENABLED == 'true' }}
+    # Keep Store uploads paused until the current Snap review is approved.
+    if: ${{ vars.SNAP_PUBLISH_ENABLED == 'true' && vars.SNAP_STORE_REVIEW_APPROVED == 'true' }}
     runs-on: ubuntu-latest
     needs:
       - validate-release


### PR DESCRIPTION
Temporarily disable the Snap Store publishing job while the Snap application is still under review.

- keep Snap package builds enabled
- keep Snap artifacts attached to GitHub Releases
- update generated release notes to state Store publishing is paused
- comment out the publish-snap job for easy restoration