### PR TITLE
fix: let environment override YAML config

### DIFF
--- a/src/local_shell_mcp/settings.py
+++ b/src/local_shell_mcp/settings.py
@@ -304,6 +304,16 @@ def _flatten_yaml(path: Path) -> dict[str, Any]:
     return flat
 
 
+def _without_environment_overrides(values: dict[str, Any]) -> dict[str, Any]:
+    """Drop YAML values that have an explicit LOCAL_SHELL_MCP_* override."""
+
+    return {
+        key: value
+        for key, value in values.items()
+        if f"LOCAL_SHELL_MCP_{key.upper()}" not in os.environ
+    }
+
+
 if _PYDANTIC_AVAILABLE:
 
     class Settings(BaseSettings):
@@ -505,8 +515,10 @@ if _PYDANTIC_AVAILABLE:
                 self.path_denylist = []
             return self
 
-        def apply_yaml(self, path: Path) -> Settings:
+        def apply_yaml(self, path: Path, *, preserve_environment: bool = False) -> Settings:
             flat = _flatten_yaml(path)
+            if preserve_environment:
+                flat = _without_environment_overrides(flat)
             merged = self.model_dump()
             merged.update(flat)
             return Settings(**merged)
@@ -730,9 +742,12 @@ else:
         def model_copy(self, update: dict[str, Any] | None = None) -> Settings:
             return replace(self, _load_environment=False, **(update or {}))
 
-        def apply_yaml(self, path: Path) -> Settings:
+        def apply_yaml(self, path: Path, *, preserve_environment: bool = False) -> Settings:
+            flat = _flatten_yaml(path)
+            if preserve_environment:
+                flat = _without_environment_overrides(flat)
             merged = self.model_dump()
-            merged.update(_flatten_yaml(path))
+            merged.update(flat)
             return Settings(**merged, _load_environment=False)
 
         def with_workspace_relative_defaults(self) -> Settings:
@@ -756,7 +771,7 @@ def get_settings() -> Settings:
     settings = Settings()
     config = os.getenv("LOCAL_SHELL_MCP_CONFIG")
     if config:
-        settings = settings.apply_yaml(Path(config).expanduser())
+        settings = settings.apply_yaml(Path(config).expanduser(), preserve_environment=True)
     settings = settings.with_workspace_relative_defaults()
     if not settings.stateless_controller:
         settings.workspace_root.mkdir(parents=True, exist_ok=True)

--- a/src/local_shell_mcp/settings.py
+++ b/src/local_shell_mcp/settings.py
@@ -307,10 +307,11 @@ def _flatten_yaml(path: Path) -> dict[str, Any]:
 def _without_environment_overrides(values: dict[str, Any]) -> dict[str, Any]:
     """Drop YAML values that have an explicit LOCAL_SHELL_MCP_* override."""
 
+    environment_names = {name.casefold() for name in os.environ}
     return {
         key: value
         for key, value in values.items()
-        if f"LOCAL_SHELL_MCP_{key.upper()}" not in os.environ
+        if f"LOCAL_SHELL_MCP_{key}".casefold() not in environment_names
     }
 
 
@@ -699,15 +700,15 @@ else:
 
         def __post_init__(self, _load_environment: bool) -> None:
             if _load_environment:
+                environment = {name.casefold(): value for name, value in os.environ.items()}
                 for item in fields(self):
-                    env_name = "LOCAL_SHELL_MCP_" + item.name.upper()
-                    if env_name in os.environ:
+                    env_name = "LOCAL_SHELL_MCP_" + item.name
+                    env_value = environment.get(env_name.casefold())
+                    if env_value is not None:
                         setattr(
                             self,
                             item.name,
-                            _coerce_env_value(
-                                os.environ[env_name], getattr(self, item.name)
-                            ),
+                            _coerce_env_value(env_value, getattr(self, item.name)),
                         )
             for attr in ("workspace_root", "audit_log_path", "state_dir", "agent_config_dir"):
                 setattr(

--- a/tests/test_settings_complete.py
+++ b/tests/test_settings_complete.py
@@ -72,6 +72,14 @@ port: 9001
 
     monkeypatch.setattr(settings, "yaml", yaml)
     workspace = tmp_path / "workspace"
+    for name in (
+        "LOCAL_SHELL_MCP_MODE",
+        "LOCAL_SHELL_MCP_DISABLE_LOCAL",
+        "LOCAL_SHELL_MCP_UI_WALLPAPER",
+        "LOCAL_SHELL_MCP_REMOTE_ENABLED",
+        "LOCAL_SHELL_MCP_PORT",
+    ):
+        monkeypatch.delenv(name, raising=False)
     monkeypatch.setenv("LOCAL_SHELL_MCP_CONFIG", str(config))
     monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(workspace))
     monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(tmp_path / "state"))

--- a/tests/test_settings_complete.py
+++ b/tests/test_settings_complete.py
@@ -130,6 +130,19 @@ ui:
     assert loaded.disable_local is True
 
 
+def test_lowercase_environment_variable_overrides_yaml_config(tmp_path, monkeypatch):
+    if not settings._PYDANTIC_AVAILABLE:
+        pytest.skip("Pydantic settings runtime is unavailable")
+    config = tmp_path / "config.yaml"
+    config.write_text("port: 9001\n", encoding="utf-8")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_CONFIG", str(config))
+    monkeypatch.delenv("LOCAL_SHELL_MCP_PORT", raising=False)
+    monkeypatch.setenv("local_shell_mcp_port", "9102")
+    settings.get_settings.cache_clear()
+
+    assert settings.get_settings().port == 9102
+
+
 def test_pydantic_settings_validation_and_copy_paths(tmp_path):
     model = settings.Settings(
         workspace_root=tmp_path,

--- a/tests/test_settings_complete.py
+++ b/tests/test_settings_complete.py
@@ -94,6 +94,34 @@ port: 9001
     assert settings.safe_settings_dump(loaded)["oauth_admin_pin"] is None
 
 
+def test_environment_variables_override_yaml_config(tmp_path, monkeypatch):
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        """
+port: 9001
+disable_local: true
+workspace_root: /yaml/workspace
+ui:
+  wallpaper: none
+""".strip(),
+        encoding="utf-8",
+    )
+    workspace = tmp_path / "env-workspace"
+    monkeypatch.setenv("LOCAL_SHELL_MCP_CONFIG", str(config))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_PORT", "9102")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(workspace))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_UI_WALLPAPER", "aurora")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_AUTH_MODE", "none")
+    settings.get_settings.cache_clear()
+
+    loaded = settings.get_settings()
+
+    assert loaded.port == 9102
+    assert loaded.workspace_root == workspace.resolve()
+    assert loaded.ui_wallpaper == "aurora"
+    assert loaded.disable_local is True
+
+
 def test_pydantic_settings_validation_and_copy_paths(tmp_path):
     model = settings.Settings(
         workspace_root=tmp_path,
@@ -220,6 +248,9 @@ def test_dependency_light_fallback_settings(tmp_path, monkeypatch):
     applied = instance.apply_yaml(yaml_path)
     assert applied.port == 9030
     assert applied.ui_wallpaper == "none"
+    preserved = instance.apply_yaml(yaml_path, preserve_environment=True)
+    assert preserved.port == 9010
+    assert preserved.ui_wallpaper == "none"
 
     for name in (
         "LOCAL_SHELL_MCP_WORKSPACE_ROOT",

--- a/tests/test_settings_complete.py
+++ b/tests/test_settings_complete.py
@@ -136,6 +136,9 @@ def test_lowercase_environment_variable_overrides_yaml_config(tmp_path, monkeypa
     config = tmp_path / "config.yaml"
     config.write_text("port: 9001\n", encoding="utf-8")
     monkeypatch.setenv("LOCAL_SHELL_MCP_CONFIG", str(config))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path / "workspace"))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_AUTH_MODE", "none")
     monkeypatch.delenv("LOCAL_SHELL_MCP_PORT", raising=False)
     monkeypatch.setenv("local_shell_mcp_port", "9102")
     settings.get_settings.cache_clear()


### PR DESCRIPTION
## Summary
- preserve explicit LOCAL_SHELL_MCP_* environment values when loading YAML
- keep direct Settings.apply_yaml() behavior unchanged unless environment preservation is requested
- cover both Pydantic and dependency-light fallback settings paths

## Tests
- PYTHONPATH=src python -m pytest tests/test_settings_complete.py -q
- python -m ruff check src/local_shell_mcp/settings.py tests/test_settings_complete.py