### PR TITLE
fix: prevent remote worker head-of-line stalls

### DIFF
--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -134,10 +134,38 @@ REMOTE_NON_CANCELLABLE_WORKER_TOOLS = frozenset(
 )
 
 
-def _worker_job_lane(tool: str) -> str:
+def _worker_job_lane(tool: str, lane: str | None = None) -> str:
+    if lane is not None:
+        if lane not in {REMOTE_WORKER_INTERACTIVE_LANE, REMOTE_WORKER_TRANSFER_LANE}:
+            raise ValueError(f"unsupported remote worker lane: {lane}")
+        return lane
     if tool.startswith("transfer_"):
         return REMOTE_WORKER_TRANSFER_LANE
     return REMOTE_WORKER_INTERACTIVE_LANE
+
+
+def _worker_poll_protocol_version(info: dict[str, Any]) -> int:
+    try:
+        return int(info.get("poll_protocol_version") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _migrate_worker_lane_queues(worker: RemoteWorker) -> None:
+    interactive_jobs: list[dict[str, Any]] = []
+    while True:
+        try:
+            job = worker.queue.get_nowait()
+        except asyncio.QueueEmpty:
+            break
+        worker.queue.task_done()
+        lane = _worker_job_lane(str(job.get("tool") or ""), job.get("lane"))
+        if lane == REMOTE_WORKER_TRANSFER_LANE:
+            worker.transfer_queue.put_nowait(job)
+        else:
+            interactive_jobs.append(job)
+    for job in interactive_jobs:
+        worker.queue.put_nowait(job)
 
 
 class RemoteJobCancelled(RuntimeError):
@@ -706,6 +734,8 @@ class RemoteManager:
                 worker.info["lsm_version"] = worker_version
             if protocol_version:
                 worker.info["poll_protocol_version"] = protocol_version
+            if protocol_version >= REMOTE_WORKER_LANE_PROTOCOL_VERSION:
+                _migrate_worker_lane_queues(worker)
         if upgrade and upgrade["required"]:
             return {
                 "job": None,
@@ -801,6 +831,8 @@ class RemoteManager:
         tool: str,
         args: dict[str, Any],
         timeout_s: int | None = None,
+        *,
+        lane: str | None = None,
     ) -> dict[str, Any]:
         settings = get_settings()
         effective_timeout = timeout_s or settings.remote_job_timeout_s
@@ -822,11 +854,12 @@ class RemoteManager:
                 raise RuntimeError(f"remote machine queue is full: {machine}")
             self.pending[job_id] = future
             self.pending_machines[job_id] = machine
-            protocol_version = int(worker.info.get("poll_protocol_version") or 0)
+            protocol_version = _worker_poll_protocol_version(worker.info)
+            job_lane = _worker_job_lane(tool, lane)
             queue = (
                 worker.transfer_queue
                 if protocol_version >= REMOTE_WORKER_LANE_PROTOCOL_VERSION
-                and _worker_job_lane(tool) == REMOTE_WORKER_TRANSFER_LANE
+                and job_lane == REMOTE_WORKER_TRANSFER_LANE
                 else worker.queue
             )
             queue.put_nowait(
@@ -834,6 +867,7 @@ class RemoteManager:
                     "id": job_id,
                     "tool": tool,
                     "args": args,
+                    "lane": job_lane,
                     "expires_at": _utc() + effective_timeout,
                 }
             )
@@ -2137,6 +2171,22 @@ def _worker_post_json(
 
 _WORKER_RETRY_INITIAL_DELAY_S = 1.0
 _WORKER_RETRY_MAX_DELAY_S = 30.0
+_WORKER_RESULT_MIN_TIMEOUT_S = 30.0
+_WORKER_RESULT_MAX_TIMEOUT_S = 120.0
+_WORKER_RESULT_TIMEOUT_GRACE_S = 15.0
+_WORKER_RESULT_MIN_UPLOAD_BYTES_PER_S = 16 * 1024
+
+
+def _worker_result_request_timeout_s(result: dict[str, Any]) -> float:
+    body_bytes = len(json.dumps(result).encode("utf-8"))
+    transfer_budget_s = body_bytes / _WORKER_RESULT_MIN_UPLOAD_BYTES_PER_S
+    return min(
+        _WORKER_RESULT_MAX_TIMEOUT_S,
+        max(
+            _WORKER_RESULT_MIN_TIMEOUT_S,
+            _WORKER_RESULT_TIMEOUT_GRACE_S + transfer_budget_s,
+        ),
+    )
 
 
 def _worker_poll_request_timeout_s(data: dict[str, Any]) -> float | None:
@@ -2322,30 +2372,38 @@ async def _submit_worker_result_with_heartbeat(
     headers: dict[str, str],
     heartbeat_interval_s: float,
 ) -> dict[str, Any]:
+    result_timeout_s = _worker_result_request_timeout_s(result)
     submission = asyncio.create_task(
         _worker_post_json_forever(
             f"{server}{REMOTE_API_PREFIX}/result",
             result,
             headers,
-            30,
+            result_timeout_s,
             "submit result",
         )
     )
+    cancelled_by_controller = False
 
     async def heartbeat_loop() -> None:
+        nonlocal cancelled_by_controller
         interval = max(0.01, heartbeat_interval_s)
         while not submission.done():
             await asyncio.sleep(interval)
             if submission.done():
                 return
             try:
-                await asyncio.to_thread(
+                response = await asyncio.to_thread(
                     _worker_post_json,
                     f"{server}{REMOTE_API_PREFIX}/heartbeat",
-                    {},
+                    {"job_id": result.get("job_id")},
                     headers,
                     30,
                 )
+                data = response.get("data", {}) if isinstance(response, dict) else {}
+                if data.get("cancelled"):
+                    cancelled_by_controller = True
+                    submission.cancel()
+                    return
             except Exception as exc:  # noqa: BLE001
                 if not _worker_error_is_retryable(exc):
                     return
@@ -2354,6 +2412,10 @@ async def _submit_worker_result_with_heartbeat(
     heartbeat = asyncio.create_task(heartbeat_loop())
     try:
         return await submission
+    except asyncio.CancelledError:
+        if cancelled_by_controller:
+            return {"ok": True, "data": {"accepted": False, "cancelled": True}}
+        raise
     finally:
         heartbeat.cancel()
         await asyncio.gather(heartbeat, return_exceptions=True)

--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -627,6 +627,7 @@ class RemoteManager:
             "poll_interval_s": 0,
             "poll_timeout_s": get_settings().remote_poll_timeout_s,
             "heartbeat_interval_s": _remote_heartbeat_interval_s(),
+            "poll_protocol_version": REMOTE_WORKER_POLL_PROTOCOL_VERSION,
         }
 
     async def resume_worker(self, access: str, payload: dict[str, Any]) -> dict[str, Any]:
@@ -655,6 +656,7 @@ class RemoteManager:
             "poll_interval_s": 0,
             "poll_timeout_s": get_settings().remote_poll_timeout_s,
             "heartbeat_interval_s": _remote_heartbeat_interval_s(),
+            "poll_protocol_version": REMOTE_WORKER_POLL_PROTOCOL_VERSION,
         }
 
     def _default_machine_name(self, payload: dict[str, Any]) -> str:
@@ -2451,7 +2453,7 @@ class _WorkerLaneState:
 
 
 async def _worker_poll_lane(
-    lane: str,
+    lane: str | None,
     server: str,
     headers: dict[str, str],
     heartbeat_interval_s: float,
@@ -2600,6 +2602,7 @@ async def _run_worker_locked(
         machine_name = data["name"]
     heartbeat_interval_s = float(data.get("heartbeat_interval_s") or _remote_heartbeat_interval_s())
     poll_request_timeout_s = _worker_poll_request_timeout_s(data)
+    controller_poll_protocol_version = _worker_poll_protocol_version(data)
     _write_worker_identity(
         {"server": server, "name": machine_name, "access": access, "workdir": workdir}
     )
@@ -2616,6 +2619,11 @@ async def _run_worker_locked(
     lane_state = _WorkerLaneState()
     lane_state_changed = asyncio.Event()
     upgrade_lock = asyncio.Lock()
+    lanes: tuple[str | None, ...]
+    if controller_poll_protocol_version >= REMOTE_WORKER_LANE_PROTOCOL_VERSION:
+        lanes = (REMOTE_WORKER_INTERACTIVE_LANE, REMOTE_WORKER_TRANSFER_LANE)
+    else:
+        lanes = (None,)
     lane_tasks = [
         asyncio.create_task(
             _worker_poll_lane(
@@ -2628,9 +2636,9 @@ async def _run_worker_locked(
                 lane_state_changed,
                 upgrade_lock,
             ),
-            name=f"remote-worker-{lane}-lane",
+            name=f"remote-worker-{lane or 'legacy'}-lane",
         )
-        for lane in (REMOTE_WORKER_INTERACTIVE_LANE, REMOTE_WORKER_TRANSFER_LANE)
+        for lane in lanes
     ]
     try:
         await asyncio.gather(*lane_tasks)

--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -2077,6 +2077,37 @@ def _parse_worker_http_json(url: str, status_code: int, response_body: str) -> d
     return parsed
 
 
+class _WorkerRequestCancellation:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._cancelled = False
+        self._process: subprocess.Popen[bytes] | None = None
+
+    def attach(self, process: subprocess.Popen[bytes]) -> None:
+        with self._lock:
+            self._process = process
+            cancelled = self._cancelled
+        if cancelled:
+            with contextlib.suppress(OSError):
+                process.kill()
+
+    def detach(self, process: subprocess.Popen[bytes]) -> None:
+        with self._lock:
+            if self._process is process:
+                self._process = None
+
+    def cancel(self) -> None:
+        with self._lock:
+            self._cancelled = True
+            process = self._process
+        if process is not None:
+            with contextlib.suppress(OSError):
+                process.kill()
+
+
+_worker_request_context = threading.local()
+
+
 def _worker_post_json_with_curl(
     url: str,
     body: bytes,
@@ -2111,13 +2142,29 @@ def _worker_post_json_with_curl(
         command.extend(["-H", f"{name}: {value}"])
     command.append(url)
 
-    completed = subprocess.run(  # noqa: S603
-        command,
-        input=body,
-        capture_output=True,
-        check=False,
-        creationflags=_worker_subprocess_creationflags(),
-    )
+    cancellation = getattr(_worker_request_context, "cancellation", None)
+    if cancellation is None:
+        completed = subprocess.run(  # noqa: S603
+            command,
+            input=body,
+            capture_output=True,
+            check=False,
+            creationflags=_worker_subprocess_creationflags(),
+        )
+    else:
+        process = subprocess.Popen(  # noqa: S603
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            creationflags=_worker_subprocess_creationflags(),
+        )
+        cancellation.attach(process)
+        try:
+            stdout, stderr = process.communicate(input=body)
+        finally:
+            cancellation.detach(process)
+        completed = subprocess.CompletedProcess(command, process.returncode, stdout, stderr)
     stdout = completed.stdout.decode("utf-8", errors="replace")
     stderr = completed.stderr.decode("utf-8", errors="replace").strip()
     response_body, marker, status_text = stdout.rpartition(status_marker)
@@ -2217,6 +2264,51 @@ def _worker_error_is_retryable(exc: Exception) -> bool:
     return not isinstance(exc, ValueError)
 
 
+def _worker_post_json_in_cancellable_thread(
+    url: str,
+    payload: dict[str, Any],
+    headers: dict[str, str] | None,
+    timeout: float | None,
+    cancellation: _WorkerRequestCancellation,
+) -> dict[str, Any]:
+    previous = getattr(_worker_request_context, "cancellation", None)
+    _worker_request_context.cancellation = cancellation
+    try:
+        return _worker_post_json(url, payload, headers, timeout)
+    finally:
+        if previous is None:
+            with contextlib.suppress(AttributeError):
+                del _worker_request_context.cancellation
+        else:
+            _worker_request_context.cancellation = previous
+
+
+async def _worker_post_json_cancellable(
+    url: str,
+    payload: dict[str, Any],
+    headers: dict[str, str] | None,
+    timeout: float | None,
+) -> dict[str, Any]:
+    cancellation = _WorkerRequestCancellation()
+    request = asyncio.create_task(
+        asyncio.to_thread(
+            _worker_post_json_in_cancellable_thread,
+            url,
+            payload,
+            headers,
+            timeout,
+            cancellation,
+        )
+    )
+    try:
+        return await asyncio.shield(request)
+    except asyncio.CancelledError:
+        cancellation.cancel()
+        with contextlib.suppress(Exception):
+            await asyncio.shield(request)
+        raise
+
+
 async def _worker_post_json_forever(
     url: str,
     payload: dict[str, Any],
@@ -2225,8 +2317,11 @@ async def _worker_post_json_forever(
     operation: str = "request",
 ) -> dict[str, Any]:
     attempt = 0
+    cancellable = urllib.parse.urlsplit(url).path.endswith(f"{REMOTE_API_PREFIX}/result")
     while True:
         try:
+            if cancellable:
+                return await _worker_post_json_cancellable(url, payload, headers, timeout)
             return await asyncio.to_thread(_worker_post_json, url, payload, headers, timeout)
         except Exception as exc:  # noqa: BLE001
             if not _worker_error_is_retryable(exc):

--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -94,7 +94,8 @@ REMOTE_JOIN_PATH = "/join"
 REMOTE_POWERSHELL_JOIN_PATH = REMOTE_JOIN_PATH + ".ps1"
 REMOTE_API_PREFIX = "/remote"
 REMOTE_WORKER_BUNDLE_PATH = "/remote/worker-bundle.tgz"
-REMOTE_WORKER_POLL_PROTOCOL_VERSION = 1
+REMOTE_WORKER_LANE_PROTOCOL_VERSION = 2
+REMOTE_WORKER_POLL_PROTOCOL_VERSION = REMOTE_WORKER_LANE_PROTOCOL_VERSION
 _WORKER_CONNECT_TIMEOUT_S = 10.0
 _WORKER_POLL_TIMEOUT_GRACE_S = 10.0
 # The remote worker is designed to start on machines that only have Python, curl,
@@ -109,6 +110,8 @@ REMOTE_WORKER_REGISTRY_GENERATION_FILE_NAME = "remote-workers.generation"
 REMOTE_WORKER_IDENTITY_FILE_NAME = "identity.json"
 MAX_REMOTE_INVITES = 1_024
 MAX_REMOTE_MACHINE_NAME_LENGTH = 128
+REMOTE_WORKER_INTERACTIVE_LANE = "interactive"
+REMOTE_WORKER_TRANSFER_LANE = "transfer"
 REMOTE_NON_CANCELLABLE_WORKER_TOOLS = frozenset(
     {
         "write_file",
@@ -129,6 +132,12 @@ REMOTE_NON_CANCELLABLE_WORKER_TOOLS = frozenset(
         "transfer_close_receiver",
     }
 )
+
+
+def _worker_job_lane(tool: str) -> str:
+    if tool.startswith("transfer_"):
+        return REMOTE_WORKER_TRANSFER_LANE
+    return REMOTE_WORKER_INTERACTIVE_LANE
 
 
 class RemoteJobCancelled(RuntimeError):
@@ -232,6 +241,7 @@ class RemoteWorker:
     capabilities: list[str] = field(default_factory=list)
     info: dict[str, Any] = field(default_factory=dict)
     queue: asyncio.Queue[dict[str, Any]] = field(default_factory=asyncio.Queue)
+    transfer_queue: asyncio.Queue[dict[str, Any]] = field(default_factory=asyncio.Queue)
 
 
 class RemoteManager:
@@ -672,6 +682,9 @@ class RemoteManager:
         payload = payload or {}
         worker_version = str(payload.get("worker_version") or "")
         protocol_version = int(payload.get("protocol_version") or 0)
+        lane = str(payload.get("lane") or REMOTE_WORKER_INTERACTIVE_LANE)
+        if lane not in {REMOTE_WORKER_INTERACTIVE_LANE, REMOTE_WORKER_TRANSFER_LANE}:
+            raise ValueError(f"unsupported remote worker lane: {lane}")
         configured_poll_timeout_s = float(get_settings().remote_poll_timeout_s)
         effective_poll_timeout_s = configured_poll_timeout_s
         try:
@@ -681,7 +694,7 @@ class RemoteManager:
         if math.isfinite(worker_poll_timeout_s) and worker_poll_timeout_s > 0:
             effective_poll_timeout_s = min(configured_poll_timeout_s, worker_poll_timeout_s)
         upgrade = None
-        if protocol_version >= REMOTE_WORKER_POLL_PROTOCOL_VERSION:
+        if protocol_version > 0:
             upgrade = {
                 "required": worker_version != __version__,
                 "version": __version__,
@@ -699,6 +712,12 @@ class RemoteManager:
                 "upgrade": upgrade,
                 "poll_timeout_s": configured_poll_timeout_s,
             }
+        queue = (
+            worker.transfer_queue
+            if protocol_version >= REMOTE_WORKER_LANE_PROTOCOL_VERSION
+            and lane == REMOTE_WORKER_TRANSFER_LANE
+            else worker.queue
+        )
         loop = asyncio.get_running_loop()
         deadline = loop.time() + effective_poll_timeout_s
         while True:
@@ -711,7 +730,7 @@ class RemoteManager:
                     "poll_timeout_s": configured_poll_timeout_s,
                 }
             try:
-                job = await asyncio.wait_for(worker.queue.get(), timeout=remaining)
+                job = await asyncio.wait_for(queue.get(), timeout=remaining)
             except TimeoutError:
                 return {
                     "job": None,
@@ -798,11 +817,19 @@ class RemoteManager:
                 raise RuntimeError(f"remote machine is offline: {machine}")
             max_pending = max(1, settings.remote_max_pending_jobs)
             machine_pending = sum(1 for value in self.pending_machines.values() if value == machine)
-            if worker.queue.qsize() >= max_pending or machine_pending >= max_pending:
+            queued = worker.queue.qsize() + worker.transfer_queue.qsize()
+            if queued >= max_pending or machine_pending >= max_pending:
                 raise RuntimeError(f"remote machine queue is full: {machine}")
             self.pending[job_id] = future
             self.pending_machines[job_id] = machine
-            worker.queue.put_nowait(
+            protocol_version = int(worker.info.get("poll_protocol_version") or 0)
+            queue = (
+                worker.transfer_queue
+                if protocol_version >= REMOTE_WORKER_LANE_PROTOCOL_VERSION
+                and _worker_job_lane(tool) == REMOTE_WORKER_TRANSFER_LANE
+                else worker.queue
+            )
+            queue.put_nowait(
                 {
                     "id": job_id,
                     "tool": tool,
@@ -885,7 +912,9 @@ class RemoteManager:
                         "last_seen": worker.last_seen,
                         "last_seen_age_s": last_seen_age_s,
                         "offline_after_s": offline_after_s,
-                        "queue_depth": worker.queue.qsize(),
+                        "queue_depth": worker.queue.qsize() + worker.transfer_queue.qsize(),
+                        "interactive_queue_depth": worker.queue.qsize(),
+                        "transfer_queue_depth": worker.transfer_queue.qsize(),
                         "capabilities": list(worker.capabilities),
                         "info": dict(worker.info),
                     }
@@ -905,10 +934,11 @@ class RemoteManager:
             for job_id, pending_machine in list(self.pending_machines.items()):
                 if pending_machine == machine:
                     self._cancel_job(job_id)
-            while not worker.queue.empty():
-                with contextlib.suppress(asyncio.QueueEmpty):
-                    queued = worker.queue.get_nowait()
-                    self.cancelled_jobs.pop(str(queued.get("id") or ""), None)
+            for queue in (worker.queue, worker.transfer_queue):
+                while not queue.empty():
+                    with contextlib.suppress(asyncio.QueueEmpty):
+                        queued = queue.get_nowait()
+                        self.cancelled_jobs.pop(str(queued.get("id") or ""), None)
             self._save_registry_unlocked()
         return {"machine": machine, "revoked": True}
 
@@ -1921,17 +1951,23 @@ def worker_info(workdir: str) -> dict[str, Any]:
         "cwd": os.getcwd(),
         "workdir": workdir,
         "lsm_version": __version__,
+        "poll_protocol_version": REMOTE_WORKER_POLL_PROTOCOL_VERSION,
         "python": sys.version.split()[0],
         "platform": sys.platform,
         "persistent_shell": persistent_shell_backend_info(),
     }
 
 
-def _worker_poll_payload(poll_request_timeout_s: float | None = None) -> dict[str, Any]:
+def _worker_poll_payload(
+    poll_request_timeout_s: float | None = None,
+    lane: str | None = None,
+) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "protocol_version": REMOTE_WORKER_POLL_PROTOCOL_VERSION,
         "worker_version": __version__,
     }
+    if lane is not None:
+        payload["lane"] = lane
     if poll_request_timeout_s is not None:
         payload["poll_timeout_s"] = max(
             0.001, poll_request_timeout_s - _WORKER_POLL_TIMEOUT_GRACE_S
@@ -2323,6 +2359,118 @@ async def _submit_worker_result_with_heartbeat(
         await asyncio.gather(heartbeat, return_exceptions=True)
 
 
+async def _run_worker_job(
+    job: dict[str, Any],
+    server: str,
+    headers: dict[str, str],
+    heartbeat_interval_s: float,
+) -> None:
+    expires_at = float(job.get("expires_at") or 0)
+    if expires_at and expires_at < _utc():
+        out = {
+            "job_id": job.get("id"),
+            "ok": False,
+            "error": "TimeoutError",
+            "message": "remote job expired before execution",
+        }
+    else:
+        try:
+            result = await _execute_worker_job_with_heartbeat(
+                job, server, headers, heartbeat_interval_s
+            )
+            out = {"job_id": job["id"], "ok": True, "data": result}
+        except Exception as exc:  # noqa: BLE001
+            out = {"job_id": job.get("id"), **_handled_remote_exception(exc)}
+    await _submit_worker_result_with_heartbeat(out, server, headers, heartbeat_interval_s)
+
+
+@dataclass
+class _WorkerLaneState:
+    polling: int = 0
+    active_jobs: int = 0
+    upgrading: bool = False
+    upgrade_attempt: int = 0
+
+
+async def _worker_poll_lane(
+    lane: str,
+    server: str,
+    headers: dict[str, str],
+    heartbeat_interval_s: float,
+    initial_poll_request_timeout_s: float | None,
+    state: _WorkerLaneState,
+    state_changed: asyncio.Event,
+    upgrade_lock: asyncio.Lock,
+) -> None:
+    poll_request_timeout_s = initial_poll_request_timeout_s
+    while True:
+        while state.upgrading:
+            state_changed.clear()
+            if state.upgrading:
+                await state_changed.wait()
+
+        state.polling += 1
+        try:
+            poll_body = await _worker_post_json_forever(
+                f"{server}{REMOTE_API_PREFIX}/poll",
+                _worker_poll_payload(poll_request_timeout_s, lane),
+                headers,
+                poll_request_timeout_s,
+                "poll",
+            )
+        except BaseException:
+            state.polling -= 1
+            state_changed.set()
+            raise
+
+        payload = poll_body.get("data", {})
+        updated_poll_request_timeout_s = _worker_poll_request_timeout_s(payload)
+        if updated_poll_request_timeout_s is not None:
+            poll_request_timeout_s = updated_poll_request_timeout_s
+        upgrade = payload.get("upgrade") if isinstance(payload, dict) else None
+        upgrade_required = isinstance(upgrade, dict) and upgrade.get("required")
+        job = payload.get("job") if isinstance(payload, dict) else None
+
+        state.polling -= 1
+        if job:
+            state.active_jobs += 1
+        if upgrade_required:
+            state.upgrading = True
+        state_changed.set()
+
+        if upgrade_required:
+            async with upgrade_lock:
+                if not state.upgrading:
+                    continue
+                while state.polling or state.active_jobs:
+                    state_changed.clear()
+                    if state.polling or state.active_jobs:
+                        await state_changed.wait()
+                target_version = str(upgrade.get("version") or "")
+                try:
+                    await _upgrade_worker_runtime(server, target_version)
+                except Exception as exc:  # noqa: BLE001
+                    delay_s = _worker_retry_delay(state.upgrade_attempt)
+                    state.upgrade_attempt += 1
+                    state.upgrading = False
+                    state_changed.set()
+                    _worker_log_retry("worker upgrade", exc, delay_s)
+                    await asyncio.sleep(delay_s)
+                else:
+                    state.upgrade_attempt = 0
+                    state.upgrading = False
+                    state_changed.set()
+            continue
+
+        if not job:
+            continue
+        try:
+            await _run_worker_job(job, server, headers, heartbeat_interval_s)
+        finally:
+            state.active_jobs -= 1
+            state_changed.set()
+
+
 async def run_worker(
     server: str,
     invite: str,
@@ -2407,52 +2555,31 @@ async def _run_worker_locked(
         flush=True,
     )
     headers = {"Author" + "ization": "B" + "earer " + access}
-    upgrade_attempt = 0
-    while True:
-        poll_body = await _worker_post_json_forever(
-            f"{server}{REMOTE_API_PREFIX}/poll",
-            _worker_poll_payload(poll_request_timeout_s),
-            headers,
-            poll_request_timeout_s,
-            "poll",
+    lane_state = _WorkerLaneState()
+    lane_state_changed = asyncio.Event()
+    upgrade_lock = asyncio.Lock()
+    lane_tasks = [
+        asyncio.create_task(
+            _worker_poll_lane(
+                lane,
+                server,
+                headers,
+                heartbeat_interval_s,
+                poll_request_timeout_s,
+                lane_state,
+                lane_state_changed,
+                upgrade_lock,
+            ),
+            name=f"remote-worker-{lane}-lane",
         )
-        payload = poll_body.get("data", {})
-        updated_poll_request_timeout_s = _worker_poll_request_timeout_s(payload)
-        if updated_poll_request_timeout_s is not None:
-            poll_request_timeout_s = updated_poll_request_timeout_s
-        upgrade = payload.get("upgrade") if isinstance(payload, dict) else None
-        if isinstance(upgrade, dict) and upgrade.get("required"):
-            target_version = str(upgrade.get("version") or "")
-            try:
-                await _upgrade_worker_runtime(server, target_version)
-            except Exception as exc:  # noqa: BLE001
-                delay_s = _worker_retry_delay(upgrade_attempt)
-                upgrade_attempt += 1
-                _worker_log_retry("worker upgrade", exc, delay_s)
-                await asyncio.sleep(delay_s)
-            continue
-        upgrade_attempt = 0
-        job = payload.get("job")
-        if not job:
-            continue
-        expires_at = float(job.get("expires_at") or 0)
-        if expires_at and expires_at < _utc():
-            out = {
-                "job_id": job.get("id"),
-                "ok": False,
-                "error": "TimeoutError",
-                "message": "remote job expired before execution",
-            }
-            await _submit_worker_result_with_heartbeat(out, server, headers, heartbeat_interval_s)
-            continue
-        try:
-            result = await _execute_worker_job_with_heartbeat(
-                job, server, headers, heartbeat_interval_s
-            )
-            out = {"job_id": job["id"], "ok": True, "data": result}
-        except Exception as exc:  # noqa: BLE001
-            out = {"job_id": job.get("id"), **_handled_remote_exception(exc)}
-        await _submit_worker_result_with_heartbeat(out, server, headers, heartbeat_interval_s)
+        for lane in (REMOTE_WORKER_INTERACTIVE_LANE, REMOTE_WORKER_TRANSFER_LANE)
+    ]
+    try:
+        await asyncio.gather(*lane_tasks)
+    finally:
+        for task in lane_tasks:
+            task.cancel()
+        await asyncio.gather(*lane_tasks, return_exceptions=True)
 
 
 def run_worker_cli(argv: list[str] | None = None) -> None:

--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -2172,7 +2172,6 @@ def _worker_post_json(
 _WORKER_RETRY_INITIAL_DELAY_S = 1.0
 _WORKER_RETRY_MAX_DELAY_S = 30.0
 _WORKER_RESULT_MIN_TIMEOUT_S = 30.0
-_WORKER_RESULT_MAX_TIMEOUT_S = 120.0
 _WORKER_RESULT_TIMEOUT_GRACE_S = 15.0
 _WORKER_RESULT_MIN_UPLOAD_BYTES_PER_S = 16 * 1024
 
@@ -2180,12 +2179,9 @@ _WORKER_RESULT_MIN_UPLOAD_BYTES_PER_S = 16 * 1024
 def _worker_result_request_timeout_s(result: dict[str, Any]) -> float:
     body_bytes = len(json.dumps(result).encode("utf-8"))
     transfer_budget_s = body_bytes / _WORKER_RESULT_MIN_UPLOAD_BYTES_PER_S
-    return min(
-        _WORKER_RESULT_MAX_TIMEOUT_S,
-        max(
-            _WORKER_RESULT_MIN_TIMEOUT_S,
-            _WORKER_RESULT_TIMEOUT_GRACE_S + transfer_budget_s,
-        ),
+    return max(
+        _WORKER_RESULT_MIN_TIMEOUT_S,
+        _WORKER_RESULT_TIMEOUT_GRACE_S + transfer_budget_s,
     )
 
 

--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -70,7 +70,7 @@ from .oauth import ALL_OAUTH_SCOPES
 from .patch_ops import git_apply_command, git_apply_prefix, normalize_patch_text
 from .playwright_ops import playwright_run_script
 from .process_utils import managed_process_kwargs
-from .remote import remote_manager
+from .remote import REMOTE_WORKER_TRANSFER_LANE, remote_manager
 from .remote_transfer import (
     create_download_ticket,
     create_upload_ticket,
@@ -1433,7 +1433,9 @@ def _unwrap_remote_transfer_result(result: dict, *, machine: str, tool: str) -> 
 async def _remote_transfer_data(
     machine: str, tool: str, args: dict, timeout_s: int | None = None
 ) -> Any:
-    result = await remote_manager().call(machine, tool, args, timeout_s)
+    result = await remote_manager().call(
+        machine, tool, args, timeout_s, lane=REMOTE_WORKER_TRANSFER_LANE
+    )
     return _unwrap_remote_transfer_result(result, machine=machine, tool=tool)
 
 

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -88,7 +88,7 @@ async def test_poll_requires_upgrade_before_dequeuing_jobs(tmp_path, monkeypatch
     mismatch = await manager.poll(
         worker.token,
         {
-            "protocol_version": remote.REMOTE_WORKER_POLL_PROTOCOL_VERSION,
+            "protocol_version": 1,
             "worker_version": "0.0.0",
         },
     )
@@ -100,6 +100,7 @@ async def test_poll_requires_upgrade_before_dequeuing_jobs(tmp_path, monkeypatch
     }
     assert worker.queue.qsize() == 1
     assert worker.info["lsm_version"] == "0.0.0"
+    assert worker.info["poll_protocol_version"] == 1
 
     matched = await manager.poll(
         worker.token,
@@ -154,6 +155,59 @@ async def test_remote_queue_is_bounded_per_worker(tmp_path, monkeypatch):
 
     with pytest.raises(RuntimeError, match="queue is full"):
         await manager.call("worker-a", "list_files", {"path": "."}, timeout_s=1)
+
+
+@pytest.mark.asyncio
+async def test_lane_aware_worker_routes_transfer_jobs_separately(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(tmp_path / ".state"))
+    get_settings.cache_clear()
+    manager = remote.RemoteManager()
+    worker = remote.RemoteWorker(
+        name="worker-a",
+        token="token-a",
+        info={"poll_protocol_version": remote.REMOTE_WORKER_POLL_PROTOCOL_VERSION},
+    )
+    manager.workers[worker.name] = worker
+    manager.tokens[worker.token] = worker.name
+
+    transfer_call = asyncio.create_task(
+        manager.call("worker-a", "transfer_stat", {"path": "."}, timeout_s=2)
+    )
+    interactive_call = asyncio.create_task(
+        manager.call("worker-a", "list_files", {"path": "."}, timeout_s=2)
+    )
+    await asyncio.sleep(0)
+
+    interactive = await manager.poll(
+        worker.token,
+        {
+            "protocol_version": remote.REMOTE_WORKER_POLL_PROTOCOL_VERSION,
+            "worker_version": remote.__version__,
+            "lane": remote.REMOTE_WORKER_INTERACTIVE_LANE,
+        },
+    )
+    transfer = await manager.poll(
+        worker.token,
+        {
+            "protocol_version": remote.REMOTE_WORKER_POLL_PROTOCOL_VERSION,
+            "worker_version": remote.__version__,
+            "lane": remote.REMOTE_WORKER_TRANSFER_LANE,
+        },
+    )
+
+    assert interactive["job"]["tool"] == "list_files"
+    assert transfer["job"]["tool"] == "transfer_stat"
+    await manager.submit_result(
+        worker.token,
+        {"job_id": interactive["job"]["id"], "ok": True, "data": []},
+    )
+    await manager.submit_result(
+        worker.token,
+        {"job_id": transfer["job"]["id"], "ok": True, "data": {"type": "directory"}},
+    )
+    await interactive_call
+    await transfer_call
 
 @pytest.mark.asyncio
 async def test_join_script_loads_vendored_worker_dependencies(tmp_path, monkeypatch):

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -737,10 +737,10 @@ async def test_worker_result_submission_sends_heartbeats_while_retrying(monkeypa
 
 def test_worker_result_request_timeout_scales_with_payload_size():
     small = {"job_id": "job-1", "ok": True, "data": {"stdout": "ok"}}
-    large = {"job_id": "job-1", "ok": True, "data": {"stdout": "x" * (1400 * 1024)}}
+    large = {"job_id": "job-1", "ok": True, "data": {"stdout": "x" * (3 * 1024 * 1024)}}
 
     assert remote._worker_result_request_timeout_s(small) == 30  # noqa: SLF001
-    assert 30 < remote._worker_result_request_timeout_s(large) <= 120  # noqa: SLF001
+    assert remote._worker_result_request_timeout_s(large) > 120  # noqa: SLF001
 
 
 @pytest.mark.asyncio

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -3,6 +3,7 @@
 import asyncio
 import subprocess
 import sys
+import threading
 import urllib.error
 from io import BytesIO
 from types import SimpleNamespace
@@ -348,6 +349,51 @@ def test_worker_post_json_uses_curl_and_parses_success(monkeypatch):
     assert body == b'{"invite": "abc"}'
     assert check is False
     assert creationflags == remote._worker_subprocess_creationflags()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_worker_result_cancellation_terminates_active_curl(monkeypatch):
+    started = threading.Event()
+    killed = threading.Event()
+
+    class FakePopen:
+        def __init__(self, command, *, stdin, stdout, stderr, creationflags):  # noqa: ANN001
+            assert command[0] == "/usr/bin/curl"
+            assert stdin is subprocess.PIPE
+            assert stdout is subprocess.PIPE
+            assert stderr is subprocess.PIPE
+            assert creationflags == remote._worker_subprocess_creationflags()  # noqa: SLF001
+            self.returncode = None
+
+        def communicate(self, input):  # noqa: A002, ANN001
+            assert input == b'{"job_id": "job-1"}'
+            started.set()
+            killed.wait(1)
+            self.returncode = -9
+            return b"", b"terminated"
+
+        def kill(self):
+            killed.set()
+
+    monkeypatch.setattr(remote.shutil, "which", lambda name: "/usr/bin/curl" if name == "curl" else None)
+    monkeypatch.setattr(remote.subprocess, "Popen", FakePopen)
+
+    submission = asyncio.create_task(
+        remote._worker_post_json_forever(  # noqa: SLF001
+            "https://example.test/remote/result",
+            {"job_id": "job-1"},
+            {"Authorization": "Bearer token"},
+            30,
+            "submit result",
+        )
+    )
+    assert await asyncio.to_thread(started.wait, 1)
+
+    submission.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(submission, timeout=1)
+
+    assert killed.is_set()
 
 
 def test_worker_post_json_curl_reports_non_2xx_body(monkeypatch):

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -209,6 +209,77 @@ async def test_lane_aware_worker_routes_transfer_jobs_separately(tmp_path, monke
     await interactive_call
     await transfer_call
 
+
+@pytest.mark.asyncio
+async def test_invalid_worker_poll_protocol_uses_legacy_queue(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(tmp_path / ".state"))
+    get_settings.cache_clear()
+    manager = remote.RemoteManager()
+    worker = remote.RemoteWorker(
+        name="worker-a",
+        token="token-a",
+        info={"poll_protocol_version": "future"},
+    )
+    manager.workers[worker.name] = worker
+    manager.tokens[worker.token] = worker.name
+
+    call = asyncio.create_task(
+        manager.call("worker-a", "transfer_stat", {"path": "."}, timeout_s=2)
+    )
+    await asyncio.sleep(0)
+
+    assert worker.queue.qsize() == 1
+    assert worker.transfer_queue.qsize() == 0
+    polled = await manager.poll(
+        worker.token,
+        {"protocol_version": 1, "worker_version": remote.__version__},
+    )
+    await manager.submit_result(
+        worker.token,
+        {"job_id": polled["job"]["id"], "ok": True, "data": {"type": "directory"}},
+    )
+    await call
+
+
+@pytest.mark.asyncio
+async def test_lane_upgrade_migrates_queued_transfer_jobs(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(tmp_path / ".state"))
+    get_settings.cache_clear()
+    manager = remote.RemoteManager()
+    worker = remote.RemoteWorker(
+        name="worker-a",
+        token="token-a",
+        info={"poll_protocol_version": 1},
+    )
+    manager.workers[worker.name] = worker
+    manager.tokens[worker.token] = worker.name
+
+    call = asyncio.create_task(
+        manager.call("worker-a", "transfer_stat", {"path": "."}, timeout_s=2)
+    )
+    await asyncio.sleep(0)
+    assert worker.queue.qsize() == 1
+    assert worker.transfer_queue.qsize() == 0
+
+    polled = await manager.poll(
+        worker.token,
+        {
+            "protocol_version": remote.REMOTE_WORKER_POLL_PROTOCOL_VERSION,
+            "worker_version": remote.__version__,
+            "lane": remote.REMOTE_WORKER_TRANSFER_LANE,
+        },
+    )
+
+    assert polled["job"]["tool"] == "transfer_stat"
+    assert worker.queue.qsize() == 0
+    await manager.submit_result(
+        worker.token,
+        {"job_id": polled["job"]["id"], "ok": True, "data": {"type": "directory"}},
+    )
+    await call
+
 @pytest.mark.asyncio
 async def test_join_script_loads_vendored_worker_dependencies(tmp_path, monkeypatch):
     monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
@@ -632,15 +703,16 @@ async def test_worker_result_submission_sends_heartbeats_while_retrying(monkeypa
     def fake_post(url, payload, request_headers=None, timeout=None):
         nonlocal result_attempts
         assert request_headers == headers
-        assert timeout == 30
         if url.endswith("/result"):
+            assert timeout == remote._worker_result_request_timeout_s(result)  # noqa: SLF001
             assert payload == result
             result_attempts += 1
             if result_attempts < 3:
                 raise RuntimeError(f"temporary result failure {result_attempts}")
             return {"ok": True, "data": {"accepted": True}}
         assert url.endswith("/heartbeat")
-        assert payload == {}
+        assert timeout == 30
+        assert payload == {"job_id": "job-1"}
         heartbeat_calls.append(url)
         return {"ok": True, "data": {"accepted": True}}
 
@@ -661,6 +733,52 @@ async def test_worker_result_submission_sends_heartbeats_while_retrying(monkeypa
     heartbeat_count = len(heartbeat_calls)
     await asyncio.sleep(0.02)
     assert len(heartbeat_calls) == heartbeat_count
+
+
+def test_worker_result_request_timeout_scales_with_payload_size():
+    small = {"job_id": "job-1", "ok": True, "data": {"stdout": "ok"}}
+    large = {"job_id": "job-1", "ok": True, "data": {"stdout": "x" * (1400 * 1024)}}
+
+    assert remote._worker_result_request_timeout_s(small) == 30  # noqa: SLF001
+    assert 30 < remote._worker_result_request_timeout_s(large) <= 120  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_worker_result_submission_stops_when_controller_cancels(monkeypatch):
+    result_attempts = 0
+    heartbeat_calls = []
+    result = {"job_id": "job-1", "ok": True, "data": {"stdout": "x"}}
+    headers = {"Authorization": "Bearer token"}
+
+    def fake_post(url, payload, request_headers=None, timeout=None):
+        nonlocal result_attempts
+        assert request_headers == headers
+        if url.endswith("/result"):
+            result_attempts += 1
+            raise RuntimeError("slow result upload")
+        assert url.endswith("/heartbeat")
+        assert timeout == 30
+        assert payload == {"job_id": "job-1"}
+        heartbeat_calls.append(payload)
+        return {"ok": True, "data": {"accepted": True, "cancelled": True}}
+
+    monkeypatch.setattr(remote, "_worker_post_json", fake_post)
+    monkeypatch.setattr(remote, "_WORKER_RETRY_INITIAL_DELAY_S", 0.05)
+    monkeypatch.setattr(remote, "_WORKER_RETRY_MAX_DELAY_S", 0.05)
+
+    response = await remote._submit_worker_result_with_heartbeat(  # noqa: SLF001
+        result,
+        "https://example.test",
+        headers,
+        0.005,
+    )
+
+    assert response == {"ok": True, "data": {"accepted": False, "cancelled": True}}
+    assert result_attempts >= 1
+    assert heartbeat_calls == [{"job_id": "job-1"}]
+    attempts_after_cancel = result_attempts
+    await asyncio.sleep(0.06)
+    assert result_attempts == attempts_after_cancel
 
 
 @pytest.mark.asyncio

--- a/tests/test_remote_complete.py
+++ b/tests/test_remote_complete.py
@@ -114,6 +114,7 @@ def test_controller_registration_resume_rename_revoke_and_defaults(tmp_path, mon
     )
     assert registration["name"] == "alice@host"
     assert registration["poll_timeout_s"] == 1
+    assert registration["poll_protocol_version"] == remote.REMOTE_WORKER_POLL_PROTOCOL_VERSION
     token = registration["token"]
 
     with pytest.raises(ValueError, match="invalid invite"):
@@ -127,6 +128,7 @@ def test_controller_registration_resume_rename_revoke_and_defaults(tmp_path, mon
     )
     assert resumed["name"] == "alice@host"
     assert resumed["poll_timeout_s"] == 1
+    assert resumed["poll_protocol_version"] == remote.REMOTE_WORKER_POLL_PROTOCOL_VERSION
     assert manager.workers["alice@host"].workdir == "/new"
     with pytest.raises(ValueError, match="belongs"):
         asyncio.run(manager.resume_worker(token, {"name": "other"}))

--- a/tests/test_remote_list_machines.py
+++ b/tests/test_remote_list_machines.py
@@ -1,5 +1,10 @@
 from local_shell_mcp import __version__
-from local_shell_mcp.remote import RemoteManager, RemoteWorker, worker_info
+from local_shell_mcp.remote import (
+    REMOTE_WORKER_POLL_PROTOCOL_VERSION,
+    RemoteManager,
+    RemoteWorker,
+    worker_info,
+)
 from local_shell_mcp.settings import get_settings
 
 
@@ -35,6 +40,7 @@ def test_worker_info_reports_runtime_version(tmp_path, monkeypatch):
     info = worker_info(str(tmp_path))
 
     assert info["lsm_version"] == __version__
+    assert info["poll_protocol_version"] == REMOTE_WORKER_POLL_PROTOCOL_VERSION
 
 
 def test_list_machines_serializes_concurrent_registry_mutations(tmp_path, monkeypatch):

--- a/tests/test_remote_transfer_tools.py
+++ b/tests/test_remote_transfer_tools.py
@@ -39,8 +39,11 @@ class FakeRemoteManager:
         tool: str,
         args: dict[str, Any],
         timeout_s: int | None = None,
+        *,
+        lane: str | None = None,
     ) -> dict[str, Any]:
         del machine, timeout_s
+        assert lane == "transfer"
         try:
             if tool == "transfer_stat":
                 data = transfer_stat(args["path"], args.get("sha256", True))
@@ -183,6 +186,34 @@ async def test_remote_copy_file_streams_between_workers(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_remote_cleanup_file_stays_on_transfer_lane(monkeypatch):
+    captured = {}
+
+    class Manager:
+        async def call(self, machine, tool, args, timeout_s=None, *, lane=None):
+            captured.update(
+                machine=machine,
+                tool=tool,
+                args=args,
+                timeout_s=timeout_s,
+                lane=lane,
+            )
+            return {"ok": True, "message": "", "data": {"deleted": True}}
+
+    monkeypatch.setattr(tools, "remote_manager", Manager)
+
+    await tools._remote_cleanup_file("worker-a", "/tmp/archive.tar.gz")  # noqa: SLF001
+
+    assert captured == {
+        "machine": "worker-a",
+        "tool": "delete_file_or_dir",
+        "args": {"path": "/tmp/archive.tar.gz", "recursive": False},
+        "timeout_s": None,
+        "lane": "transfer",
+    }
+
+
+@pytest.mark.asyncio
 async def test_remote_upload_recovers_lost_chunk_acknowledgement(tmp_path, monkeypatch):
     root = _workspace(tmp_path, monkeypatch)
     (root / "src-machine").mkdir()
@@ -195,8 +226,8 @@ async def test_remote_upload_recovers_lost_chunk_acknowledgement(tmp_path, monke
             self.drop_next_ack = True
             self.upload_calls = 0
 
-        async def call(self, machine, tool, args, timeout_s=None):
-            result = await super().call(machine, tool, args, timeout_s)
+        async def call(self, machine, tool, args, timeout_s=None, *, lane=None):
+            result = await super().call(machine, tool, args, timeout_s, lane=lane)
             if tool == "transfer_upload_url":
                 self.upload_calls += 1
                 if self.drop_next_ack:

--- a/tests/test_remote_worker_cli.py
+++ b/tests/test_remote_worker_cli.py
@@ -60,6 +60,7 @@ async def test_run_worker_overrides_stale_scope(tmp_path, monkeypatch):
     monkeypatch.setattr(cli.remote, "_read_worker_identity", lambda server, name=None: None)
     monkeypatch.setattr(cli.remote, "_write_worker_identity", lambda data: None)
     calls = 0
+    poll_payloads = []
 
     async def fake_post(*args, **kwargs):
         nonlocal calls
@@ -68,6 +69,7 @@ async def test_run_worker_overrides_stale_scope(tmp_path, monkeypatch):
         assert os.environ["LOCAL_SHELL_MCP_ALLOW_FULL_CONTAINER"] == "true"
         if calls == 1:
             return {"ok": True, "data": {"token": "access", "name": "worker"}}
+        poll_payloads.append(args[1])
         raise RuntimeError("stop polling")
 
     monkeypatch.setattr(cli.remote, "_worker_post_json_forever", fake_post)
@@ -75,6 +77,9 @@ async def test_run_worker_overrides_stale_scope(tmp_path, monkeypatch):
         await cli.remote.run_worker(
             "https://example.test", "invite", workdir=str(tmp_path)
         )
+
+    assert len(poll_payloads) == 1
+    assert "lane" not in poll_payloads[0]
 
 
 @pytest.mark.asyncio
@@ -93,7 +98,12 @@ async def test_run_worker_reports_version_and_applies_poll_upgrade(tmp_path, mon
         if url.endswith("/remote/register"):
             return {
                 "ok": True,
-                "data": {"token": "access", "name": "worker", "poll_timeout_s": 17},
+                "data": {
+                    "token": "access",
+                    "name": "worker",
+                    "poll_timeout_s": 17,
+                    "poll_protocol_version": cli.remote.REMOTE_WORKER_POLL_PROTOCOL_VERSION,
+                },
             }
         if upgrade_called:
             raise RuntimeError("stop polling")
@@ -156,7 +166,14 @@ async def test_run_worker_transfer_does_not_block_interactive_jobs(tmp_path, mon
 
     async def fake_post(url, payload, headers=None, timeout=None, operation="request"):
         if url.endswith("/remote/register"):
-            return {"ok": True, "data": {"token": "access", "name": "worker"}}
+            return {
+                "ok": True,
+                "data": {
+                    "token": "access",
+                    "name": "worker",
+                    "poll_protocol_version": cli.remote.REMOTE_WORKER_POLL_PROTOCOL_VERSION,
+                },
+            }
         if url.endswith("/remote/poll"):
             lane = payload["lane"]
             if lane not in served_lanes:

--- a/tests/test_remote_worker_cli.py
+++ b/tests/test_remote_worker_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 
@@ -85,6 +86,7 @@ async def test_run_worker_reports_version_and_applies_poll_upgrade(tmp_path, mon
     monkeypatch.setattr(cli.remote, "_read_worker_identity", lambda server, name=None: None)
     monkeypatch.setattr(cli.remote, "_write_worker_identity", lambda data: None)
     calls = []
+    upgrade_called = False
 
     async def fake_post(url, payload, headers=None, timeout=None, operation="request"):
         calls.append((url, payload, headers, timeout, operation))
@@ -93,6 +95,8 @@ async def test_run_worker_reports_version_and_applies_poll_upgrade(tmp_path, mon
                 "ok": True,
                 "data": {"token": "access", "name": "worker", "poll_timeout_s": 17},
             }
+        if upgrade_called:
+            raise RuntimeError("stop polling")
         return {
             "ok": True,
             "data": {
@@ -102,25 +106,93 @@ async def test_run_worker_reports_version_and_applies_poll_upgrade(tmp_path, mon
         }
 
     async def fake_upgrade(server, target_version):
+        nonlocal upgrade_called
         assert server == "https://example.test"
         assert target_version == "9.9.9"
-        raise SystemExit(0)
+        upgrade_called = True
+        raise RuntimeError("upgrade failed")
 
     monkeypatch.setattr(cli.remote, "_worker_post_json_forever", fake_post)
     monkeypatch.setattr(cli.remote, "_upgrade_worker_runtime", fake_upgrade)
+    monkeypatch.setattr(cli.remote, "_worker_retry_delay", lambda attempt: 0)
 
-    with pytest.raises(SystemExit):
+    with pytest.raises(RuntimeError, match="stop polling"):
         await cli.remote.run_worker(
             "https://example.test", "invite", workdir=str(tmp_path)
         )
 
+    assert upgrade_called is True
     assert calls[1][3] == 27
     poll_payload = calls[1][1]
     assert poll_payload == {
         "protocol_version": cli.remote.REMOTE_WORKER_POLL_PROTOCOL_VERSION,
         "worker_version": cli.remote.__version__,
         "poll_timeout_s": 17,
+        "lane": "interactive",
     }
+
+
+@pytest.mark.asyncio
+async def test_run_worker_transfer_does_not_block_interactive_jobs(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_ALLOW_FULL_CONTAINER", "false")
+    monkeypatch.setattr(cli.remote, "worker_capabilities", lambda: [])
+    monkeypatch.setattr(cli.remote, "worker_info", lambda workdir: {})
+    monkeypatch.setattr(cli.remote, "_read_worker_identity", lambda server, name=None: None)
+    monkeypatch.setattr(cli.remote, "_write_worker_identity", lambda data: None)
+
+    transfer_started = asyncio.Event()
+    interactive_result_submitted = asyncio.Event()
+    served_lanes = set()
+    submitted_results = []
+
+    async def fake_execute(tool, args):
+        if tool == "transfer_upload_url":
+            transfer_started.set()
+            await asyncio.Event().wait()
+        assert tool == "run_shell"
+        assert transfer_started.is_set()
+        return {"exit_code": 0, "stdout": "ok\n"}
+
+    async def fake_post(url, payload, headers=None, timeout=None, operation="request"):
+        if url.endswith("/remote/register"):
+            return {"ok": True, "data": {"token": "access", "name": "worker"}}
+        if url.endswith("/remote/poll"):
+            lane = payload["lane"]
+            if lane not in served_lanes:
+                served_lanes.add(lane)
+                if lane == "transfer":
+                    return {
+                        "ok": True,
+                        "data": {
+                            "job": {
+                                "id": "transfer",
+                                "tool": "transfer_upload_url",
+                                "args": {},
+                            },
+                        },
+                    }
+                return {
+                    "ok": True,
+                    "data": {"job": {"id": "interactive", "tool": "run_shell", "args": {}}},
+                }
+            await asyncio.wait_for(interactive_result_submitted.wait(), timeout=1)
+            raise RuntimeError("stop polling")
+        if url.endswith("/remote/result"):
+            submitted_results.append(payload)
+            if payload.get("job_id") == "interactive":
+                interactive_result_submitted.set()
+            return {"ok": True, "data": {"accepted": True}}
+        raise AssertionError(url)
+
+    monkeypatch.setattr(cli.remote, "execute_worker_tool", fake_execute)
+    monkeypatch.setattr(cli.remote, "_worker_post_json_forever", fake_post)
+
+    with pytest.raises(RuntimeError, match="stop polling"):
+        await cli.remote.run_worker("https://example.test", "invite", workdir=str(tmp_path))
+
+    assert interactive_result_submitted.is_set()
+    assert [result["job_id"] for result in submitted_results] == ["interactive"]
 
 
 @pytest.mark.asyncio

--- a/ui/src/live-workspace-utils.test.ts
+++ b/ui/src/live-workspace-utils.test.ts
@@ -149,7 +149,7 @@ describe("live workspace utilities", () => {
 
     const activateStart = source.indexOf("function activateLiveConfig")
     const activateEnd = source.indexOf("const credentialRefreshes", activateStart)
-    const activateSource = source.slice(activateStart, activateEnd)
+    const activateSource = source.slice(activateStart, activateEnd).replace(/\r\n/g, "\n")
     expect(activateSource).toContain("if (channelChanged) {\n    resetActivityForChannelBoundary()")
     expect(activateSource).not.toContain("if (channelChanged || sessionChanged) {\n    resetActivityForChannelBoundary()")
   })


### PR DESCRIPTION
## Summary
- split lane-capable remote workers into independent interactive and transfer poll queues while preserving serial execution within each lane
- keep protocol-v1 workers on the legacy queue, defensively handle malformed protocol metadata, and migrate already-queued transfer jobs when a worker upgrades to the lane protocol
- route transfer-owned cleanup through the transfer lane instead of falling back to interactive work
- make worker result-upload timeouts scale with payload size so large/slow results do not restart every 30 seconds
- include `job_id` in result-submission heartbeats so controller cancellation stops stale result retries and releases the lane
- expose per-lane queue depths and add regression coverage for lane isolation, upgrade migration, cleanup routing, slow large results, and cancelled submissions

## Why
A stalled transfer could previously head-of-line block later interactive remote commands. During live reproduction on `unist2`, a second failure mode was also observed: a ~1.4 MB result uploading at ~27 KB/s exceeded the fixed 30s request timeout, restarted from byte zero indefinitely, and kept the worker nominally online via anonymous heartbeats. This PR addresses both failure modes.

## Validation
- `python -m pytest -q` — 906 passed, 1 skipped
- focused remote regression suite — 85 passed
- `ruff check .`
- `git diff --check`
- patch-only credential scan — clean