### PR TITLE
fix: bound graceful shutdown for supervised restarts

### DIFF
--- a/src/local_shell_mcp/main.py
+++ b/src/local_shell_mcp/main.py
@@ -4,6 +4,9 @@ import argparse
 import os
 import sys
 
+# Long-lived MCP connections must not prevent process supervisors from observing exit.
+_GRACEFUL_SHUTDOWN_TIMEOUT_S = 10
+
 
 def _with_oauth_routes(inner_app):  # noqa: ANN001
     from contextlib import asynccontextmanager
@@ -111,6 +114,7 @@ def run_mcp() -> None:
             host=settings.host,
             port=settings.port,
             forwarded_allow_ips=settings.forwarded_allow_ips,
+            timeout_graceful_shutdown=_GRACEFUL_SHUTDOWN_TIMEOUT_S,
         )
         return
     if hasattr(mcp, "sse_app"):
@@ -125,6 +129,7 @@ def run_mcp() -> None:
             host=settings.host,
             port=settings.port,
             forwarded_allow_ips=settings.forwarded_allow_ips,
+            timeout_graceful_shutdown=_GRACEFUL_SHUTDOWN_TIMEOUT_S,
         )
         return
 
@@ -148,6 +153,7 @@ def run_http() -> None:
         host=settings.host,
         port=settings.port,
         forwarded_allow_ips=settings.forwarded_allow_ips,
+        timeout_graceful_shutdown=_GRACEFUL_SHUTDOWN_TIMEOUT_S,
     )
 
 

--- a/tests/test_main_complete.py
+++ b/tests/test_main_complete.py
@@ -78,7 +78,12 @@ def test_run_mcp_streamable_and_sse(monkeypatch):
     main_module.run_mcp()
     assert runs.pop() == (
         ("wrapped", streamable),
-        {"host": "127.0.0.1", "port": 9876, "forwarded_allow_ips": "10.0.0.2"},
+        {
+            "host": "127.0.0.1",
+            "port": 9876,
+            "forwarded_allow_ips": "10.0.0.2",
+            "timeout_graceful_shutdown": 10,
+        },
     )
 
     class FakeApp:
@@ -99,6 +104,7 @@ def test_run_mcp_streamable_and_sse(monkeypatch):
             "host": "127.0.0.1",
             "port": 9876,
             "forwarded_allow_ips": "10.0.0.2",
+            "timeout_graceful_shutdown": 10,
         }
         assert len(app.middleware) == expected_middleware_count
 
@@ -154,7 +160,12 @@ def test_run_http(monkeypatch):
         ("validate", settings),
         (
             "http-app",
-            {"host": "127.0.0.1", "port": 9876, "forwarded_allow_ips": "10.0.0.2"},
+            {
+                "host": "127.0.0.1",
+                "port": 9876,
+                "forwarded_allow_ips": "10.0.0.2",
+                "timeout_graceful_shutdown": 10,
+            },
         ),
     ]
 


### PR DESCRIPTION
## Summary

- bound Uvicorn graceful shutdown to 10 seconds for MCP Streamable HTTP, SSE, and HTTP modes
- prevent long-lived MCP connections from keeping PID 1 alive indefinitely after SIGTERM, so Docker/systemd supervisors can observe exit and restart the service
- cover the timeout argument in the existing server startup tests

## Context

A supervised Docker deployment could enter a state where SIGTERM stopped serving requests but the process remained alive waiting indefinitely for active connections. Because PID 1 never exited, Docker restart policy was never triggered.

## Validation

- `python -m ruff check .`
- `PYTHONPATH=src python -m pytest -q` — 899 passed, 1 skipped
