### PR TITLE
fix: allow remote workers without zstandard

### DIFF
--- a/src/local_shell_mcp/audit.py
+++ b/src/local_shell_mcp/audit.py
@@ -18,7 +18,11 @@ from contextvars import ContextVar
 from pathlib import Path
 from typing import Any
 
-import zstandard as zstd
+try:
+    import zstandard as zstd
+except ImportError:
+    # Remote worker bundles intentionally omit ABI-specific native dependencies.
+    zstd = None
 
 from .settings import get_settings
 from .state_store import get_state_store, state_lock
@@ -881,7 +885,7 @@ def _write_file_archive(
     parsed: list[tuple[bytes, dict[str, Any] | None, set[str]]],
     indexes: list[int],
 ) -> dict[str, Any] | None:
-    if not indexes:
+    if not indexes or zstd is None:
         return None
     start_ts, end_ts = _archive_time_bounds(parsed, indexes)
     key = _archive_key(start_ts, end_ts)
@@ -924,7 +928,7 @@ def _write_file_archive(
 def _write_state_archive(
     parsed: list[tuple[bytes, dict[str, Any] | None, set[str]]], indexes: list[int]
 ) -> dict[str, Any] | None:
-    if not indexes:
+    if not indexes or zstd is None:
         return None
     start_ts, end_ts = _archive_time_bounds(parsed, indexes)
     key = _archive_key(start_ts, end_ts)
@@ -1030,8 +1034,12 @@ def _enforce_audit_storage_limit(
     if max_archive_bytes > 0 and archived_indexes:
         try:
             archive = _write_file_archive(log_path, parsed, archived_indexes)
-        except (OSError, zstd.ZstdError):
+        except OSError:
             return False
+        except Exception as exc:
+            if zstd is not None and isinstance(exc, zstd.ZstdError):
+                return False
+            raise
         if archive is not None:
             archive_entries.append(archive)
             try:

--- a/tests/test_audit_ui_complete.py
+++ b/tests/test_audit_ui_complete.py
@@ -799,6 +799,22 @@ def test_audit_retention_bounds_log_and_external_payload_bytes(tmp_path, monkeyp
     assert audit_module.get_audit_entry(second_entry["id"])["payload"] == second
 
 
+def test_audit_retention_trims_without_zstandard(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_LOG_BYTES", "2500")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_ARCHIVE_BYTES", "1200")
+    monkeypatch.setattr(audit_module, "zstd", None)
+    get_settings.cache_clear()
+
+    for index in range(40):
+        audit_module.audit("no_zstd_event", index=index, detail="x" * 120)
+
+    log_path = get_settings().audit_log_path
+    assert log_path.stat().st_size <= 2500
+    assert audit_module._load_file_archive_index(log_path) == []
+    assert not list((tmp_path / audit_module._AUDIT_ARCHIVE_DIRECTORY).glob("*.jsonl.zst"))
+
+
 def test_audit_archive_budget_prunes_oldest_compressed_files(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
     monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_LOG_BYTES", "2500")


### PR DESCRIPTION
## Summary
- make `zstandard` optional for dependency-light remote worker bundles
- skip compressed audit archive creation when zstd is unavailable while preserving live-log retention trimming
- add regression coverage for audit retention without zstandard

## Root cause
Remote worker bundles intentionally omit ABI-specific native dependencies, but `audit.py` imported `zstandard` unconditionally. After the 4.2.0 runtime update, minimal workers crashed at import time before connecting.

## Validation
- `PYTHONPATH=src python -m pytest -q`: 908 passed, 1 skipped
- `PYTHONPATH=src python -m ruff check .`: passed
- manual import test with `zstandard` blocked: passed