### PR TITLE
fix: isolate audit compression from remote workers

### DIFF
--- a/src/local_shell_mcp/audit.py
+++ b/src/local_shell_mcp/audit.py
@@ -18,16 +18,13 @@ from contextvars import ContextVar
 from pathlib import Path
 from typing import Any
 
-try:
-    import zstandard as zstd
-except ImportError:
-    # Remote worker bundles intentionally omit ABI-specific native dependencies.
-    zstd = None
-
 from .settings import get_settings
 from .state_store import get_state_store, state_lock
 
 _AUDIT_ENABLED: ContextVar[bool] = ContextVar("local_shell_mcp_audit_enabled", default=True)
+_AUDIT_ARCHIVE_ENABLED: ContextVar[bool] = ContextVar(
+    "local_shell_mcp_audit_archive_enabled", default=True
+)
 _AUDIT_CALL_ID: ContextVar[str] = ContextVar("local_shell_mcp_audit_call_id", default="")
 _AUDIT_CALL_STATE: ContextVar[dict[str, Any] | None] = ContextVar(
     "local_shell_mcp_audit_call_state", default=None
@@ -885,7 +882,7 @@ def _write_file_archive(
     parsed: list[tuple[bytes, dict[str, Any] | None, set[str]]],
     indexes: list[int],
 ) -> dict[str, Any] | None:
-    if not indexes or zstd is None:
+    if not indexes:
         return None
     start_ts, end_ts = _archive_time_bounds(parsed, indexes)
     key = _archive_key(start_ts, end_ts)
@@ -896,10 +893,12 @@ def _write_file_archive(
     remaining_payload_bytes = _AUDIT_ARCHIVE_MAX_PAYLOAD_MATERIALIZATION_BYTES
     try:
         descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        from . import audit_archive_codec
+
         with (
             os.fdopen(descriptor, "wb") as destination,
-            zstd.ZstdCompressor(level=_AUDIT_ARCHIVE_ZSTD_LEVEL).stream_writer(
-                destination, closefd=False
+            audit_archive_codec.stream_writer(
+                destination, level=_AUDIT_ARCHIVE_ZSTD_LEVEL
             ) as compressor,
         ):
             for index in indexes:
@@ -928,15 +927,17 @@ def _write_file_archive(
 def _write_state_archive(
     parsed: list[tuple[bytes, dict[str, Any] | None, set[str]]], indexes: list[int]
 ) -> dict[str, Any] | None:
-    if not indexes or zstd is None:
+    if not indexes:
         return None
     start_ts, end_ts = _archive_time_bounds(parsed, indexes)
     key = _archive_key(start_ts, end_ts)
+    from . import audit_archive_codec
+
     destination = io.BytesIO()
     raw_bytes = 0
     remaining_payload_bytes = _AUDIT_ARCHIVE_MAX_PAYLOAD_MATERIALIZATION_BYTES
-    with zstd.ZstdCompressor(level=_AUDIT_ARCHIVE_ZSTD_LEVEL).stream_writer(
-        destination, closefd=False
+    with audit_archive_codec.stream_writer(
+        destination, level=_AUDIT_ARCHIVE_ZSTD_LEVEL
     ) as compressor:
         for index in indexes:
             raw_line, record, _payload_ids = parsed[index]
@@ -1031,15 +1032,13 @@ def _enforce_audit_storage_limit(
         return _prune_payload_store(log_path)
 
     archived_indexes = _archived_source_indexes(parsed, selected)
-    if max_archive_bytes > 0 and archived_indexes:
+    if _AUDIT_ARCHIVE_ENABLED.get() and max_archive_bytes > 0 and archived_indexes:
+        from . import audit_archive_codec
+
         try:
             archive = _write_file_archive(log_path, parsed, archived_indexes)
-        except OSError:
+        except (OSError, audit_archive_codec.ZstdError):
             return False
-        except Exception as exc:
-            if zstd is not None and isinstance(exc, zstd.ZstdError):
-                return False
-            raise
         if archive is not None:
             archive_entries.append(archive)
             try:
@@ -1079,7 +1078,7 @@ def _enforce_state_audit_storage_limit(
     archive_entries = _load_state_archive_index()
     if selected is not None:
         archived_indexes = _archived_source_indexes(parsed, selected)
-        if max_archive_bytes > 0 and archived_indexes:
+        if _AUDIT_ARCHIVE_ENABLED.get() and max_archive_bytes > 0 and archived_indexes:
             archive = _write_state_archive(parsed, archived_indexes)
             if archive is not None:
                 archive_entries.append(archive)
@@ -1140,6 +1139,15 @@ def suppress_audit() -> Iterator[None]:
         yield
     finally:
         _AUDIT_ENABLED.reset(token)
+
+
+@contextmanager
+def suppress_audit_archives() -> Iterator[None]:
+    token = _AUDIT_ARCHIVE_ENABLED.set(False)
+    try:
+        yield
+    finally:
+        _AUDIT_ARCHIVE_ENABLED.reset(token)
 
 
 @contextmanager

--- a/src/local_shell_mcp/audit_archive_codec.py
+++ b/src/local_shell_mcp/audit_archive_codec.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import BinaryIO
+
+import zstandard as zstd
+
+ZstdError = zstd.ZstdError
+
+
+def stream_writer(destination: BinaryIO, *, level: int):
+    return zstd.ZstdCompressor(level=level).stream_writer(destination, closefd=False)

--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -2633,9 +2633,10 @@ async def run_worker(
     workdir: str | None = None,
     persist: bool = False,
 ) -> None:
+    from .audit import suppress_audit_archives
     from .remote_worker_service import worker_run_lock
 
-    with worker_run_lock():
+    with worker_run_lock(), suppress_audit_archives():
         await _run_worker_locked(server, invite, name, workdir, persist)
 
 

--- a/src/local_shell_mcp/remote_worker_cli.py
+++ b/src/local_shell_mcp/remote_worker_cli.py
@@ -139,18 +139,21 @@ def _load_config_or_migrate() -> dict[str, Any]:
 
 
 async def run_enrolled_worker() -> None:
+    from .audit import suppress_audit_archives
+
     config = _load_config_or_migrate()
     identity = remote._read_worker_identity(
         str(config["server"]), str(config.get("name") or "")
     )  # noqa: SLF001
     if not identity:
         raise RuntimeError("worker identity is missing or invalid; run the join command again")
-    await remote.run_worker(
-        str(config["server"]),
-        "",
-        str(config.get("name") or "") or None,
-        str(config.get("workdir") or "") or None,
-    )
+    with suppress_audit_archives():
+        await remote.run_worker(
+            str(config["server"]),
+            "",
+            str(config.get("name") or "") or None,
+            str(config.get("workdir") or "") or None,
+        )
 
 
 def _worker_run_exec_argv() -> list[str]:

--- a/src/local_shell_mcp/remote_worker_cli.py
+++ b/src/local_shell_mcp/remote_worker_cli.py
@@ -139,21 +139,18 @@ def _load_config_or_migrate() -> dict[str, Any]:
 
 
 async def run_enrolled_worker() -> None:
-    from .audit import suppress_audit_archives
-
     config = _load_config_or_migrate()
     identity = remote._read_worker_identity(
         str(config["server"]), str(config.get("name") or "")
     )  # noqa: SLF001
     if not identity:
         raise RuntimeError("worker identity is missing or invalid; run the join command again")
-    with suppress_audit_archives():
-        await remote.run_worker(
-            str(config["server"]),
-            "",
-            str(config.get("name") or "") or None,
-            str(config.get("workdir") or "") or None,
-        )
+    await remote.run_worker(
+        str(config["server"]),
+        "",
+        str(config.get("name") or "") or None,
+        str(config.get("workdir") or "") or None,
+    )
 
 
 def _worker_run_exec_argv() -> list[str]:

--- a/tests/test_audit_ui_complete.py
+++ b/tests/test_audit_ui_complete.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 import local_shell_mcp.audit as audit_module
+import local_shell_mcp.audit_archive_codec as audit_archive_codec
 from local_shell_mcp.settings import get_settings
 
 
@@ -799,22 +800,6 @@ def test_audit_retention_bounds_log_and_external_payload_bytes(tmp_path, monkeyp
     assert audit_module.get_audit_entry(second_entry["id"])["payload"] == second
 
 
-def test_audit_retention_trims_without_zstandard(tmp_path, monkeypatch):
-    _configure(tmp_path, monkeypatch)
-    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_LOG_BYTES", "2500")
-    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_ARCHIVE_BYTES", "1200")
-    monkeypatch.setattr(audit_module, "zstd", None)
-    get_settings.cache_clear()
-
-    for index in range(40):
-        audit_module.audit("no_zstd_event", index=index, detail="x" * 120)
-
-    log_path = get_settings().audit_log_path
-    assert log_path.stat().st_size <= 2500
-    assert audit_module._load_file_archive_index(log_path) == []
-    assert not list((tmp_path / audit_module._AUDIT_ARCHIVE_DIRECTORY).glob("*.jsonl.zst"))
-
-
 def test_audit_archive_budget_prunes_oldest_compressed_files(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
     monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_AUDIT_LOG_BYTES", "2500")
@@ -960,7 +945,7 @@ def test_archive_payload_materialization_budget_is_shared_across_batch(tmp_path,
 
     assert archive is not None
     archive_path = audit_module._archive_file_path(log_path, archive["key"])
-    with audit_module.zstd.ZstdDecompressor().stream_reader(archive_path.open("rb")) as reader:
+    with audit_archive_codec.zstd.ZstdDecompressor().stream_reader(archive_path.open("rb")) as reader:
         envelopes = [json.loads(line) for line in reader.read().splitlines()]
     assert envelopes[0]["payloads"]["payload"] == "x" * 16
     assert envelopes[1]["payloads"]["payload"]["error"] == "Audit payload is unavailable"

--- a/tests/test_remote_worker_cli.py
+++ b/tests/test_remote_worker_cli.py
@@ -3,12 +3,36 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import subprocess
+import sys
 
 import pytest
 
+from local_shell_mcp import audit as audit_module
 from local_shell_mcp import remote_worker_cli as cli
 from local_shell_mcp import remote_worker_service as service
 from local_shell_mcp import remote_worker_state as state
+
+
+def test_worker_cli_import_does_not_require_zstandard():
+    script = r'''
+import builtins
+import sys
+
+real_import = builtins.__import__
+
+
+def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+    if name == "zstandard":
+        raise ModuleNotFoundError("zstandard must not be imported by the worker startup path")
+    return real_import(name, globals, locals, fromlist, level)
+
+
+builtins.__import__ = guarded_import
+import local_shell_mcp.remote_worker_cli  # noqa: F401
+assert "local_shell_mcp.audit_archive_codec" not in sys.modules
+'''
+    subprocess.run([sys.executable, "-c", script], check=True, env=os.environ.copy())
 
 
 def _configure(tmp_path, monkeypatch):
@@ -295,11 +319,13 @@ async def test_run_enrolled_worker_and_migrate_legacy_identity(tmp_path, monkeyp
     calls = []
 
     async def fake_run(server, invite, name=None, workdir=None, persist=False):
+        assert audit_module._AUDIT_ARCHIVE_ENABLED.get() is False  # noqa: SLF001
         calls.append((server, invite, name, workdir, persist))
 
     monkeypatch.setattr(cli.remote, "run_worker", fake_run)
     await cli.run_enrolled_worker()
     assert calls == [("https://example.test", "", "worker-a", str(tmp_path), False)]
+    assert audit_module._AUDIT_ARCHIVE_ENABLED.get() is True  # noqa: SLF001
     assert state.worker_config_path().exists()
 
 

--- a/tests/test_remote_worker_cli.py
+++ b/tests/test_remote_worker_cli.py
@@ -5,6 +5,7 @@ import json
 import os
 import subprocess
 import sys
+from contextlib import nullcontext
 
 import pytest
 
@@ -319,13 +320,11 @@ async def test_run_enrolled_worker_and_migrate_legacy_identity(tmp_path, monkeyp
     calls = []
 
     async def fake_run(server, invite, name=None, workdir=None, persist=False):
-        assert audit_module._AUDIT_ARCHIVE_ENABLED.get() is False  # noqa: SLF001
         calls.append((server, invite, name, workdir, persist))
 
     monkeypatch.setattr(cli.remote, "run_worker", fake_run)
     await cli.run_enrolled_worker()
     assert calls == [("https://example.test", "", "worker-a", str(tmp_path), False)]
-    assert audit_module._AUDIT_ARCHIVE_ENABLED.get() is True  # noqa: SLF001
     assert state.worker_config_path().exists()
 
 
@@ -336,6 +335,20 @@ async def test_run_enrolled_worker_rejects_missing_identity(tmp_path, monkeypatc
     monkeypatch.setattr(cli.remote, "_read_worker_identity", lambda server, name=None: None)
     with pytest.raises(RuntimeError, match="join command again"):
         await cli.run_enrolled_worker()
+
+
+def test_legacy_worker_cli_suppresses_audit_archives(monkeypatch):
+    monkeypatch.setattr(service, "worker_run_lock", nullcontext)
+    observed = []
+
+    async def fake_locked(server, invite, name=None, workdir=None, persist=False):
+        observed.append(audit_module._AUDIT_ARCHIVE_ENABLED.get())  # noqa: SLF001
+
+    monkeypatch.setattr(cli.remote, "_run_worker_locked", fake_locked)
+    cli.remote.run_worker_cli(["--server", "https://example.test", "--invite", "x"])
+
+    assert observed == [False]
+    assert audit_module._AUDIT_ARCHIVE_ENABLED.get() is True  # noqa: SLF001
 
 
 def test_cli_legacy_and_lifecycle_dispatch(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- isolate native `zstandard` usage in a dedicated audit archive codec loaded only when compression is actually used
- keep remote-worker audit event emission lightweight while suppressing compressed archive creation in the worker execution context
- add a regression test that blocks `zstandard` imports and verifies the worker CLI startup path still imports successfully

## Why this follows #218
#218 prevented the immediate worker crash by making the import optional. This follow-up removes the architectural coupling instead: remote workers do not need or load the zstd archive implementation.

## Validation
- focused worker/audit tests: 88 passed, 1 skipped
- full suite: 908 passed, 1 skipped
- `python -m ruff check .`: passed
- `git diff --check`: passed