### PR TITLE
fix: bound job_list results

### DIFF
--- a/docs/reference/tools.ar.md
+++ b/docs/reference/tools.ar.md
@@ -1,4 +1,4 @@
-<!-- i18n-source-sha256: 784cf8286b0aba665f54b0b14b7467047ff618447663c4b354d92176796c4001 -->
+<!-- i18n-source-sha256: 63f9fb40c4fd1c085e87c30ed221598cccacef1a6fb4aeb2bb4f1db520590ada -->
 # مرجع الأدوات
 
 تُبنى هذه الصفحة من MCP tool schemas الفعلية. شغّل `python scripts/generate-tools-reference.py` بعد تغيير public tool surface لتحديث English reference.
@@ -277,11 +277,12 @@ OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, 
 
 ### `job_list`
 
-يسرد jobs المتتبعة محليًا أو على machine بعيدة.
+يسرد jobs المتتبعة محليًا أو على machine بعيدة. تُعرض jobs النشطة أولًا، وتُقيّد قيمة `limit` إلى النطاق 1-1000.
 
 | المعامل | النوع | مطلوب/default | الوصف |
 |---|---|---|---|
 | `include_finished` | `boolean` | `true` |  |
+| `limit` | `integer` | `100` |  |
 | `machine` | `string \| null` | `null` |  |
 | `logical_session_id` | `string \| null` | required | Logical Session لاستدعاء الأداة هذا. مرّر session_id الذي أعاده session_manage أثناء العمل على المهمة. استخدم null فقط عندما لا توجد Logical Session نشطة. |
 

--- a/docs/reference/tools.de.md
+++ b/docs/reference/tools.de.md
@@ -1,4 +1,4 @@
-<!-- i18n-source-sha256: 784cf8286b0aba665f54b0b14b7467047ff618447663c4b354d92176796c4001 -->
+<!-- i18n-source-sha256: 63f9fb40c4fd1c085e87c30ed221598cccacef1a6fb4aeb2bb4f1db520590ada -->
 # Tool-Referenz
 
 Diese Seite wird aus den tatsächlichen MCP-Tool-Schemas aufgebaut. Führen Sie nach Änderungen an der öffentlichen Tool-Oberfläche `python scripts/generate-tools-reference.py` aus, um die English-Referenz zu aktualisieren.
@@ -277,11 +277,12 @@ Wenn `machine` angegeben ist, benötigt der Aufruf zusätzlich `remote:use` und 
 
 ### `job_list`
 
-Listet getrackte Jobs lokal oder auf einer Remote-Maschine.
+Listet getrackte Jobs lokal oder auf einer Remote-Maschine. Aktive Jobs werden zuerst zurückgegeben; `limit` wird auf 1-1000 begrenzt.
 
 | Parameter | Typ | Erforderlich/default | Beschreibung |
 |---|---|---|---|
 | `include_finished` | `boolean` | `true` |  |
+| `limit` | `integer` | `100` |  |
 | `machine` | `string \| null` | `null` |  |
 | `logical_session_id` | `string \| null` | required | Logical Session für diesen Tool-Aufruf. Übergeben Sie während der Arbeit an der Task die von session_manage zurückgegebene session_id. Verwenden Sie null nur, wenn keine Logical Session aktiv ist. |
 

--- a/docs/reference/tools.es.md
+++ b/docs/reference/tools.es.md
@@ -1,4 +1,4 @@
-<!-- i18n-source-sha256: 784cf8286b0aba665f54b0b14b7467047ff618447663c4b354d92176796c4001 -->
+<!-- i18n-source-sha256: 63f9fb40c4fd1c085e87c30ed221598cccacef1a6fb4aeb2bb4f1db520590ada -->
 # Referencia de herramientas
 
 Esta página se construye a partir de los schemas reales de las tools MCP. Ejecute `python scripts/generate-tools-reference.py` después de cambiar la superficie pública de tools para actualizar la referencia English.
@@ -277,11 +277,12 @@ Cuando se proporciona `machine`, la llamada también requiere `remote:use` y se 
 
 ### `job_list`
 
-Lista jobs trackeados localmente o en una máquina remota.
+Lista jobs trackeados localmente o en una máquina remota. Los jobs activos se devuelven primero; `limit` se limita al rango 1-1000.
 
 | Parámetro | Tipo | Requerido/default | Descripción |
 |---|---|---|---|
 | `include_finished` | `boolean` | `true` |  |
+| `limit` | `integer` | `100` |  |
 | `machine` | `string \| null` | `null` |  |
 | `logical_session_id` | `string \| null` | required | Logical Session para esta llamada de herramienta. Mientras trabajes en la tarea, pasa el session_id devuelto por session_manage. Usa null solo cuando no haya una Logical Session activa. |
 

--- a/docs/reference/tools.fr.md
+++ b/docs/reference/tools.fr.md
@@ -1,4 +1,4 @@
-<!-- i18n-source-sha256: 784cf8286b0aba665f54b0b14b7467047ff618447663c4b354d92176796c4001 -->
+<!-- i18n-source-sha256: 63f9fb40c4fd1c085e87c30ed221598cccacef1a6fb4aeb2bb4f1db520590ada -->
 # Référence des outils
 
 Cette page est construite à partir des schémas MCP réels. Exécutez `python scripts/generate-tools-reference.py` après toute modification de la surface publique des tools pour mettre à jour la référence English.
@@ -277,11 +277,12 @@ Lorsque `machine` est fourni, l’appel requiert aussi `remote:use` et s’exéc
 
 ### `job_list`
 
-Liste les jobs trackés localement ou sur une machine distante.
+Liste les jobs trackés localement ou sur une machine distante. Les jobs actifs sont renvoyés en premier ; `limit` est borné entre 1 et 1000.
 
 | Paramètre | Type | Requis/default | Description |
 |---|---|---|---|
 | `include_finished` | `boolean` | `true` |  |
+| `limit` | `integer` | `100` |  |
 | `machine` | `string \| null` | `null` |  |
 | `logical_session_id` | `string \| null` | required | Logical Session de cet appel d’outil. Pendant le travail sur la tâche, transmettez le session_id renvoyé par session_manage. Utilisez null uniquement lorsqu’aucune Logical Session n’est active. |
 

--- a/docs/reference/tools.hi.md
+++ b/docs/reference/tools.hi.md
@@ -1,4 +1,4 @@
-<!-- i18n-source-sha256: 784cf8286b0aba665f54b0b14b7467047ff618447663c4b354d92176796c4001 -->
+<!-- i18n-source-sha256: 63f9fb40c4fd1c085e87c30ed221598cccacef1a6fb4aeb2bb4f1db520590ada -->
 # Tools reference
 
 यह page वास्तविक MCP tool schemas से बनती है। Public tool surface बदलने के बाद English reference update करने के लिए `python scripts/generate-tools-reference.py` चलाएँ।
@@ -277,11 +277,12 @@ OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, 
 
 ### `job_list`
 
-Local या remote machine पर tracked jobs सूचीबद्ध करती है।
+Local या remote machine पर tracked jobs सूचीबद्ध करती है। Active jobs पहले लौटाए जाते हैं; `limit` को 1-1000 के बीच सीमित किया जाता है।
 
 | Parameter | Type | Required/default | Description |
 |---|---|---|---|
 | `include_finished` | `boolean` | `true` |  |
+| `limit` | `integer` | `100` |  |
 | `machine` | `string \| null` | `null` |  |
 | `logical_session_id` | `string \| null` | required | इस tool call के लिए Logical Session। task पर काम करते समय session_manage से मिला session_id दें। null केवल तब दें जब कोई Logical Session सक्रिय न हो। |
 

--- a/docs/reference/tools.id.md
+++ b/docs/reference/tools.id.md
@@ -1,4 +1,4 @@
-<!-- i18n-source-sha256: 784cf8286b0aba665f54b0b14b7467047ff618447663c4b354d92176796c4001 -->
+<!-- i18n-source-sha256: 63f9fb40c4fd1c085e87c30ed221598cccacef1a6fb4aeb2bb4f1db520590ada -->
 # Referensi tools
 
 Page ini dibangun dari MCP tool schemas yang sebenarnya. Jalankan `python scripts/generate-tools-reference.py` setelah mengubah public tool surface untuk memperbarui English reference.
@@ -277,11 +277,12 @@ Saat `machine` diberikan, call juga memerlukan `remote:use` dan dijalankan melal
 
 ### `job_list`
 
-Mencantumkan tracked jobs secara lokal atau pada remote machine.
+Mencantumkan tracked jobs secara lokal atau pada remote machine. Job aktif dikembalikan lebih dulu; `limit` dibatasi ke rentang 1-1000.
 
 | Parameter | Type | Required/default | Description |
 |---|---|---|---|
 | `include_finished` | `boolean` | `true` |  |
+| `limit` | `integer` | `100` |  |
 | `machine` | `string \| null` | `null` |  |
 | `logical_session_id` | `string \| null` | required | Logical Session untuk pemanggilan tool ini. Saat mengerjakan task, berikan session_id yang dikembalikan session_manage. Gunakan null hanya ketika tidak ada Logical Session aktif. |
 

--- a/docs/reference/tools.it.md
+++ b/docs/reference/tools.it.md
@@ -1,4 +1,4 @@
-<!-- i18n-source-sha256: 784cf8286b0aba665f54b0b14b7467047ff618447663c4b354d92176796c4001 -->
+<!-- i18n-source-sha256: 63f9fb40c4fd1c085e87c30ed221598cccacef1a6fb4aeb2bb4f1db520590ada -->
 # Riferimento strumenti
 
 Questa pagina è costruita dagli effettivi schema MCP. Esegui `python scripts/generate-tools-reference.py` dopo modifiche alla superficie pubblica degli strumenti per aggiornare il riferimento English.
@@ -277,11 +277,12 @@ Quando viene fornito `machine`, la chiamata richiede anche `remote:use` e viene 
 
 ### `job_list`
 
-Elenca job tracciati localmente o su macchina remota.
+Elenca job tracciati localmente o su macchina remota. I job attivi vengono restituiti per primi; `limit` è limitato all’intervallo 1-1000.
 
 | Parametro | Tipo | Obbligatorio/default | Descrizione |
 |---|---|---|---|
 | `include_finished` | `boolean` | `true` |  |
+| `limit` | `integer` | `100` |  |
 | `machine` | `string \| null` | `null` |  |
 | `logical_session_id` | `string \| null` | required | Logical Session per questa chiamata tool. Durante il lavoro sul task, passa il session_id restituito da session_manage. Usa null solo quando non è attiva alcuna Logical Session. |
 

--- a/docs/reference/tools.ja.md
+++ b/docs/reference/tools.ja.md
@@ -1,4 +1,4 @@
-<!-- i18n-source-sha256: 784cf8286b0aba665f54b0b14b7467047ff618447663c4b354d92176796c4001 -->
+<!-- i18n-source-sha256: 63f9fb40c4fd1c085e87c30ed221598cccacef1a6fb4aeb2bb4f1db520590ada -->
 # Tools reference
 
 このページは実際の MCP tool schema から構成されます。Public tool surface を変更した後は `python scripts/generate-tools-reference.py` を実行して English reference を更新します。
@@ -277,11 +277,12 @@ OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, 
 
 ### `job_list`
 
-Local または remote machine の tracked jobs を列挙します。
+Local または remote machine の tracked jobs を列挙します。Active job を先に返し、`limit` は 1-1000 の範囲に制限されます。
 
 | Parameter | Type | Required/default | Description |
 |---|---|---|---|
 | `include_finished` | `boolean` | `true` |  |
+| `limit` | `integer` | `100` |  |
 | `machine` | `string \| null` | `null` |  |
 | `logical_session_id` | `string \| null` | required | この tool call に属する Logical Session です。task を処理している間は session_manage が返した session_id を渡します。active な Logical Session がない場合だけ null を使います。 |
 

--- a/docs/reference/tools.ko.md
+++ b/docs/reference/tools.ko.md
@@ -1,4 +1,4 @@
-<!-- i18n-source-sha256: 784cf8286b0aba665f54b0b14b7467047ff618447663c4b354d92176796c4001 -->
+<!-- i18n-source-sha256: 63f9fb40c4fd1c085e87c30ed221598cccacef1a6fb4aeb2bb4f1db520590ada -->
 # Tools reference
 
 이 페이지는 실제 MCP tool schema에서 구성됩니다. Public tool surface를 변경한 뒤 `python scripts/generate-tools-reference.py`를 실행해 English reference를 갱신하십시오.
@@ -277,11 +277,12 @@ OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, 
 
 ### `job_list`
 
-Local 또는 remote machine의 tracked jobs를 나열합니다.
+Local 또는 remote machine의 tracked jobs를 나열합니다. Active job을 먼저 반환하며 `limit`은 1-1000 범위로 제한됩니다.
 
 | Parameter | Type | Required/default | Description |
 |---|---|---|---|
 | `include_finished` | `boolean` | `true` |  |
+| `limit` | `integer` | `100` |  |
 | `machine` | `string \| null` | `null` |  |
 | `logical_session_id` | `string \| null` | required | 이 tool call이 속한 Logical Session입니다. task를 수행하는 동안 session_manage가 반환한 session_id를 전달합니다. active Logical Session이 없을 때만 null을 사용합니다. |
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -276,11 +276,12 @@ When `machine` is supplied, the call additionally requires `remote:use` and runs
 
 ### `job_list`
 
-List tracked jobs locally or on a remote machine.
+List tracked jobs locally or on a remote machine. Active jobs are returned first; limit is clamped to 1-1000.
 
 | Parameter | Type | Required/default | Description |
 |---|---|---|---|
 | `include_finished` | `boolean` | `true` |  |
+| `limit` | `integer` | `100` |  |
 | `machine` | `string \| null` | `null` |  |
 | `logical_session_id` | `string \| null` | required | Logical Session for this tool call. Pass the session_id returned by session_manage while working in that task. Use null only when no Logical Session is active. This is the same durable session_id used by session_manage. |
 

--- a/docs/reference/tools.pl.md
+++ b/docs/reference/tools.pl.md
@@ -1,4 +1,4 @@
-<!-- i18n-source-sha256: 784cf8286b0aba665f54b0b14b7467047ff618447663c4b354d92176796c4001 -->
+<!-- i18n-source-sha256: 63f9fb40c4fd1c085e87c30ed221598cccacef1a6fb4aeb2bb4f1db520590ada -->
 # Referencja tools
 
 Ta page jest budowana z rzeczywistych MCP tool schemas. Po zmianie public tool surface uruchom `python scripts/generate-tools-reference.py`, aby zaktualizować English reference.
@@ -277,11 +277,12 @@ Gdy podano `machine`, wywołanie wymaga również `remote:use` i działa przez p
 
 ### `job_list`
 
-Listuje tracked jobs lokalnie lub na remote machine.
+Listuje tracked jobs lokalnie lub na remote machine. Aktywne joby są zwracane jako pierwsze; `limit` jest ograniczany do zakresu 1-1000.
 
 | Parameter | Type | Required/default | Description |
 |---|---|---|---|
 | `include_finished` | `boolean` | `true` |  |
+| `limit` | `integer` | `100` |  |
 | `machine` | `string \| null` | `null` |  |
 | `logical_session_id` | `string \| null` | required | Logical Session dla tego wywołania narzędzia. Podczas pracy nad zadaniem przekazuj session_id zwrócony przez session_manage. Używaj null tylko wtedy, gdy nie ma aktywnej Logical Session. |
 

--- a/docs/reference/tools.pt-BR.md
+++ b/docs/reference/tools.pt-BR.md
@@ -1,4 +1,4 @@
-<!-- i18n-source-sha256: 784cf8286b0aba665f54b0b14b7467047ff618447663c4b354d92176796c4001 -->
+<!-- i18n-source-sha256: 63f9fb40c4fd1c085e87c30ed221598cccacef1a6fb4aeb2bb4f1db520590ada -->
 # Referência de ferramentas
 
 Esta página é construída a partir dos schemas MCP reais. Execute `python scripts/generate-tools-reference.py` após alterar a superfície pública de tools para atualizar a referência English.
@@ -277,11 +277,12 @@ Quando `machine` é fornecido, a chamada também exige `remote:use` e é executa
 
 ### `job_list`
 
-Lista jobs trackeados localmente ou em máquina remota.
+Lista jobs trackeados localmente ou em máquina remota. Jobs ativos são retornados primeiro; `limit` é limitado ao intervalo de 1-1000.
 
 | Parâmetro | Tipo | Obrigatório/default | Descrição |
 |---|---|---|---|
 | `include_finished` | `boolean` | `true` |  |
+| `limit` | `integer` | `100` |  |
 | `machine` | `string \| null` | `null` |  |
 | `logical_session_id` | `string \| null` | required | Logical Session desta chamada de tool. Enquanto trabalha na tarefa, passe o session_id retornado por session_manage. Use null somente quando não houver Logical Session ativa. |
 

--- a/docs/reference/tools.ru.md
+++ b/docs/reference/tools.ru.md
@@ -1,4 +1,4 @@
-<!-- i18n-source-sha256: 784cf8286b0aba665f54b0b14b7467047ff618447663c4b354d92176796c4001 -->
+<!-- i18n-source-sha256: 63f9fb40c4fd1c085e87c30ed221598cccacef1a6fb4aeb2bb4f1db520590ada -->
 # Справочник tools
 
 Эта страница строится из фактических MCP tool schemas. После изменения public tool surface запустите `python scripts/generate-tools-reference.py`, чтобы обновить English reference.
@@ -277,11 +277,12 @@ OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, 
 
 ### `job_list`
 
-Перечисляет tracked jobs локально или на remote machine.
+Перечисляет tracked jobs локально или на remote machine. Активные jobs возвращаются первыми; `limit` ограничивается диапазоном 1-1000.
 
 | Parameter | Type | Required/default | Description |
 |---|---|---|---|
 | `include_finished` | `boolean` | `true` |  |
+| `limit` | `integer` | `100` |  |
 | `machine` | `string \| null` | `null` |  |
 | `logical_session_id` | `string \| null` | required | Logical Session для этого вызова инструмента. Во время работы над задачей передавайте session_id, возвращённый session_manage. Используйте null только когда активной Logical Session нет. |
 

--- a/docs/reference/tools.tr.md
+++ b/docs/reference/tools.tr.md
@@ -1,4 +1,4 @@
-<!-- i18n-source-sha256: 784cf8286b0aba665f54b0b14b7467047ff618447663c4b354d92176796c4001 -->
+<!-- i18n-source-sha256: 63f9fb40c4fd1c085e87c30ed221598cccacef1a6fb4aeb2bb4f1db520590ada -->
 # Tools referansı
 
 Bu page gerçek MCP tool schemas üzerinden oluşturulur. Public tool surface değiştiğinde English reference güncellemek için `python scripts/generate-tools-reference.py` çalıştırın.
@@ -277,11 +277,12 @@ OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, 
 
 ### `job_list`
 
-Local veya remote machine üzerinde tracked jobs listeler.
+Local veya remote machine üzerinde tracked jobs listeler. Active joblar önce döndürülür; `limit` 1-1000 aralığıyla sınırlandırılır.
 
 | Parameter | Type | Required/default | Description |
 |---|---|---|---|
 | `include_finished` | `boolean` | `true` |  |
+| `limit` | `integer` | `100` |  |
 | `machine` | `string \| null` | `null` |  |
 | `logical_session_id` | `string \| null` | required | Bu tool çağrısının Logical Sessionı. Görev üzerinde çalışırken session_manage tarafından döndürülen session_id değerini iletin. null yalnızca etkin Logical Session yokken kullanılmalıdır. |
 

--- a/docs/reference/tools.vi.md
+++ b/docs/reference/tools.vi.md
@@ -1,4 +1,4 @@
-<!-- i18n-source-sha256: 784cf8286b0aba665f54b0b14b7467047ff618447663c4b354d92176796c4001 -->
+<!-- i18n-source-sha256: 63f9fb40c4fd1c085e87c30ed221598cccacef1a6fb4aeb2bb4f1db520590ada -->
 # Tham chiếu tools
 
 Page này được xây từ MCP tool schemas thực tế. Chạy `python scripts/generate-tools-reference.py` sau khi thay đổi public tool surface để cập nhật English reference.
@@ -277,11 +277,12 @@ Khi cung cấp `machine`, call cũng cần `remote:use` và chạy qua giao th�
 
 ### `job_list`
 
-Liệt kê tracked jobs local hoặc trên remote machine.
+Liệt kê tracked jobs local hoặc trên remote machine. Các job đang hoạt động được trả về trước; `limit` được giới hạn trong khoảng 1-1000.
 
 | Parameter | Type | Required/default | Description |
 |---|---|---|---|
 | `include_finished` | `boolean` | `true` |  |
+| `limit` | `integer` | `100` |  |
 | `machine` | `string \| null` | `null` |  |
 | `logical_session_id` | `string \| null` | required | Logical Session cho lần gọi tool này. Khi làm việc trên task, truyền session_id do session_manage trả về. Chỉ dùng null khi không có Logical Session hoạt động. |
 

--- a/docs/reference/tools.zh-Hant.md
+++ b/docs/reference/tools.zh-Hant.md
@@ -1,4 +1,4 @@
-<!-- i18n-source-sha256: 784cf8286b0aba665f54b0b14b7467047ff618447663c4b354d92176796c4001 -->
+<!-- i18n-source-sha256: 63f9fb40c4fd1c085e87c30ed221598cccacef1a6fb4aeb2bb4f1db520590ada -->
 # 工具參考
 
 本頁由實際 MCP tool schema 產生。公開工具介面變更後，執行 `python scripts/generate-tools-reference.py` 更新 English 參考頁。
@@ -277,11 +277,12 @@ OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, 
 
 ### `job_list`
 
-列出本機或 remote machine 上被追蹤的 jobs。
+列出本機或 remote machine 上被追蹤的 jobs。活動中的 jobs 會優先回傳；`limit` 會限制在 1-1000 範圍內。
 
 | 參數 | 類型 | 必填/預設值 | 說明 |
 |---|---|---|---|
 | `include_finished` | `boolean` | `true` |  |
+| `limit` | `integer` | `100` |  |
 | `machine` | `string \| null` | `null` |  |
 | `logical_session_id` | `string \| null` | required | 這次工具呼叫所屬的 Logical Session。處理該任務時，傳入 session_manage 回傳的 session_id。只有在沒有活動 Logical Session 時才使用 null。 |
 

--- a/docs/reference/tools.zh.md
+++ b/docs/reference/tools.zh.md
@@ -1,4 +1,4 @@
-<!-- i18n-source-sha256: 784cf8286b0aba665f54b0b14b7467047ff618447663c4b354d92176796c4001 -->
+<!-- i18n-source-sha256: 63f9fb40c4fd1c085e87c30ed221598cccacef1a6fb4aeb2bb4f1db520590ada -->
 # 工具参考
 
 本页由实际 MCP tool schema 生成。公开工具接口变更后，运行 `python scripts/generate-tools-reference.py` 更新 English 参考页。
@@ -277,11 +277,12 @@ OAuth scopes: `shell:read, shell:write, shell:execute, browser:use, file:share, 
 
 ### `job_list`
 
-列出本地或 remote machine 上被跟踪的 jobs。
+列出本地或 remote machine 上被跟踪的 jobs。活动中的 jobs 会优先返回；`limit` 会限制在 1-1000 范围内。
 
 | 参数 | 类型 | 必填/默认值 | 说明 |
 |---|---|---|---|
 | `include_finished` | `boolean` | `true` |  |
+| `limit` | `integer` | `100` |  |
 | `machine` | `string \| null` | `null` |  |
 | `logical_session_id` | `string \| null` | required | 这次工具调用所属的 Logical Session。处理该任务时，传入 session_manage 返回的 session_id。只有在没有活动 Logical Session 时才使用 null。 |
 

--- a/src/local_shell_mcp/jobs.py
+++ b/src/local_shell_mcp/jobs.py
@@ -39,6 +39,8 @@ JOB_STORE_VERSION = 2
 JOB_STORE_LEGACY_VERSIONS = {1}
 JOB_STORE_LOCK_TIMEOUT_S = 2.0
 JOB_STORE_LOCK_RETRY_INTERVAL_S = 0.05
+JOB_LIST_DEFAULT_LIMIT = 100
+JOB_LIST_MAX_LIMIT = 1_000
 MANAGED_JOB_STORE_RETRY_ATTEMPTS = 2
 MANAGED_DEFERRED_UPDATE_VERSION = 1
 MANAGED_DEFERRED_APPLIED_KEY = "managed_deferred_update_ids"
@@ -1190,7 +1192,11 @@ async def start_job(command: str, cwd: str = ".", name: str | None = None) -> di
         _ACTIVE_JOB_OPERATIONS.discard(operation_id)
 
 
-async def list_jobs(include_finished: bool = True) -> dict[str, Any]:
+async def list_jobs(
+    include_finished: bool = True,
+    limit: int = JOB_LIST_DEFAULT_LIMIT,
+) -> dict[str, Any]:
+    limit = max(1, min(int(limit), JOB_LIST_MAX_LIMIT))
     active = (
         set()
         if get_settings().disable_local
@@ -1207,17 +1213,32 @@ async def list_jobs(include_finished: bool = True) -> dict[str, Any]:
             if get_settings().disable_local
             else jobs
         )
-        rows = [
-            _public_job(job)
+        candidates = [
+            job
             for job in visible_jobs
             if include_finished or job.get("status") not in TERMINAL_STATUSES
         ]
+        candidates.sort(
+            key=lambda job: (
+                job.get("status") not in TERMINAL_STATUSES,
+                float(job.get("created_at") or 0),
+            ),
+            reverse=True,
+        )
+        total = len(candidates)
+        rows = [_public_job(job) for job in candidates[:limit]]
         counts: dict[str, int] = {}
         for job in visible_jobs:
             status = str(job.get("status") or "unknown")
             counts[status] = counts.get(status, 0) + 1
-    rows.sort(key=lambda item: float(item.get("created_at") or 0), reverse=True)
-    return {"jobs": rows, "counts": counts}
+    returned = len(rows)
+    return {
+        "jobs": rows,
+        "counts": counts,
+        "total": total,
+        "returned": returned,
+        "truncated": returned < total,
+    }
 
 
 async def tail_job(job_id: str, lines: int = 200) -> dict[str, Any]:

--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -50,7 +50,7 @@ from .fs_ops import (
     write_content,
     write_text,
 )
-from .jobs import list_jobs, retry_job, start_job, stop_job, tail_job
+from .jobs import JOB_LIST_DEFAULT_LIMIT, list_jobs, retry_job, start_job, stop_job, tail_job
 from .models import ok_result as _ok
 from .patch_ops import git_apply_command, git_apply_prefix, normalize_patch_text
 from .peer_transfer import close_peer_receiver, open_peer_receiver
@@ -1698,7 +1698,10 @@ async def _execute_job_worker_tool(tool: str, args: dict[str, Any]) -> Any:
         return await start_job(args["command"], args.get("cwd", "."), args.get("name"))
 
     if tool == "job_list":
-        return await list_jobs(args.get("include_finished", True))
+        return await list_jobs(
+            args.get("include_finished", True),
+            args.get("limit", JOB_LIST_DEFAULT_LIMIT),
+        )
 
     if tool == "job_tail":
         return await tail_job(args["job_id"], args.get("lines", 200))

--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -47,6 +47,7 @@ from .fs_ops import (
 )
 from .image_ops import ImageFile, assert_view_image_size, read_image
 from .jobs import (
+    JOB_LIST_DEFAULT_LIMIT,
     ManagedJobContext,
     list_jobs,
     register_managed_job_handler,
@@ -2690,17 +2691,18 @@ def _register_job_tools(mcp: FastMCP, settings: Any, read_only_tool: ToolAnnotat
     @mcp.tool(structured_output=True, annotations=read_only_tool, meta=shell_read_meta)
     async def job_list(
         include_finished: bool = True,
+        limit: int = JOB_LIST_DEFAULT_LIMIT,
         machine: str | None = None,
     ) -> ToolResult:
-        """List tracked jobs locally or on a remote machine."""
+        """List tracked jobs locally or on a remote machine. Active jobs are returned first; limit is clamped to 1-1000."""
         if machine:
             return await _remote_call(
                 settings,
                 machine,
                 "job_list",
-                {"include_finished": include_finished},
+                {"include_finished": include_finished, "limit": limit},
             )
-        return await _tool_call(list_jobs, include_finished)
+        return await _tool_call(list_jobs, include_finished, limit)
 
     @mcp.tool(structured_output=True, annotations=read_only_tool, meta=shell_read_meta)
     async def job_tail(

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -806,6 +806,90 @@ def test_concurrent_job_starts_preserve_every_record(tmp_path, monkeypatch):
     assert listed["counts"] == {"running": 8}
 
 
+def test_job_list_limit_prioritizes_active_jobs_and_reports_truncation(tmp_path, monkeypatch):
+    state_dir = tmp_path / ".state"
+    state_dir.mkdir()
+    monkeypatch.setenv("LOCAL_SHELL_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOCAL_SHELL_MCP_STATE_DIR", str(state_dir))
+    get_settings.cache_clear()
+
+    rows = [
+        {
+            "job_id": "finished-newest",
+            "status": "succeeded",
+            "command": "true",
+            "cwd": ".",
+            "created_at": 40.0,
+            "updated_at": 40.0,
+            "attempts": 1,
+        },
+        {
+            "job_id": "active-newer",
+            "status": "running",
+            "command": "sleep 10",
+            "cwd": ".",
+            "session_id": "session-newer",
+            "created_at": 30.0,
+            "updated_at": 30.0,
+            "attempts": 1,
+        },
+        {
+            "job_id": "finished-older",
+            "status": "failed",
+            "command": "false",
+            "cwd": ".",
+            "created_at": 20.0,
+            "updated_at": 20.0,
+            "attempts": 1,
+        },
+        {
+            "job_id": "active-older",
+            "status": "running",
+            "command": "sleep 10",
+            "cwd": ".",
+            "session_id": "session-older",
+            "created_at": 10.0,
+            "updated_at": 10.0,
+            "attempts": 1,
+        },
+    ]
+    (state_dir / jobs_module.JOB_STORE_FILE_NAME).write_text(
+        json.dumps({"version": jobs_module.JOB_STORE_VERSION, "jobs": rows}),
+        encoding="utf-8",
+    )
+
+    async def active_shells():
+        return {
+            "sessions": [
+                {"session_id": "session-newer"},
+                {"session_id": "session-older"},
+            ]
+        }
+
+    monkeypatch.setattr(jobs_module, "list_shells", active_shells)
+
+    listed = asyncio.run(list_jobs(limit=2))
+    assert [job["job_id"] for job in listed["jobs"]] == [
+        "active-newer",
+        "active-older",
+    ]
+    assert listed["total"] == 4
+    assert listed["returned"] == 2
+    assert listed["truncated"] is True
+    assert listed["counts"] == {"succeeded": 1, "running": 2, "failed": 1}
+
+    monkeypatch.setattr(jobs_module, "JOB_LIST_MAX_LIMIT", 1)
+    capped = asyncio.run(list_jobs(limit=999))
+    assert capped["returned"] == 1
+    assert capped["truncated"] is True
+
+    active_only = asyncio.run(list_jobs(include_finished=False, limit=1))
+    assert [job["job_id"] for job in active_only["jobs"]] == ["active-newer"]
+    assert active_only["total"] == 2
+    assert active_only["returned"] == 1
+    assert active_only["truncated"] is True
+
+
 def test_finished_job_history_and_attempt_files_are_bounded(tmp_path, monkeypatch):
     state_dir = tmp_path / ".local-shell-mcp"
     runtime_dir = state_dir / "jobs"

--- a/tests/test_remote_complete.py
+++ b/tests/test_remote_complete.py
@@ -331,7 +331,7 @@ async def test_every_worker_tool_dispatch_branch(monkeypatch, tmp_path):
         "shell_kill": {"session_id": "s"},
         "shell_list": {},
         "job_start": {"command": "true"},
-        "job_list": {},
+        "job_list": {"include_finished": False, "limit": 7},
         "job_tail": {"job_id": "j"},
         "job_stop": {"job_id": "j"},
         "job_retry": {"job_id": "j"},
@@ -364,6 +364,8 @@ async def test_every_worker_tool_dispatch_branch(monkeypatch, tmp_path):
     for tool, args in cases.items():
         result = await remote.execute_worker_tool(tool, {**args, "_human": True})
         assert result is not None, tool
+        if tool == "job_list":
+            assert result["args"] == [False, 7]
 
     with pytest.raises(ValueError, match="unsupported"):
         await remote.execute_worker_tool("unknown", {})

--- a/tests/test_tools_complete.py
+++ b/tests/test_tools_complete.py
@@ -230,7 +230,7 @@ async def test_all_public_tool_wrappers_local_and_remote(tmp_path, monkeypatch):
         "shell_stop": {"session_id": "s"},
         "shell_list": {},
         "job_start": {"command": "true", "purpose": "test"},
-        "job_list": {},
+        "job_list": {"include_finished": False, "limit": 7},
         "job_tail": {"job_id": "j"},
         "job_stop": {"job_id": "j"},
         "job_retry": {"job_id": "j", "purpose": "test"},
@@ -299,7 +299,7 @@ async def test_all_public_tool_wrappers_local_and_remote(tmp_path, monkeypatch):
         "shell_stop": {"session_id": "s"},
         "shell_list": {},
         "job_start": {"command": "true"},
-        "job_list": {},
+        "job_list": {"include_finished": False, "limit": 7},
         "job_tail": {"job_id": "j"},
         "job_stop": {"job_id": "j"},
         "job_retry": {"job_id": "j"},
@@ -323,6 +323,8 @@ async def test_all_public_tool_wrappers_local_and_remote(tmp_path, monkeypatch):
         assert result["ok"] is True, name
     assert len(fake_remote.calls) == len(remote_cases) - 1
     assert all(tool != "view_image" for _, tool, _, _ in fake_remote.calls)
+    job_list_call = next(call for call in fake_remote.calls if call[1] == "job_list")
+    assert job_list_call[2] == {"include_finished": False, "limit": 7}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a bounded `job_list(limit=...)` with a default of 100 and a hard maximum of 1000 rows
- prioritize active jobs before finished history, while preserving newest-first order within each group
- return `total`, `returned`, and `truncated` metadata and forward `limit` through remote workers
- update the generated tool reference section and all 16 localized references

## Validation
- `PYTHONPATH="$PWD/src" pytest -q` — 910 passed, 1 skipped
- `PYTHONPATH="$PWD/src" ruff check .`
- `python scripts/check-doc-i18n.py`
- coverage gate — 93.06% total, every module >= 90%
