### PR TITLE
fix: harden remote directory transfer lifecycle

### DIFF
--- a/src/local_shell_mcp/fs_ops.py
+++ b/src/local_shell_mcp/fs_ops.py
@@ -155,6 +155,28 @@ def _is_direct_temp_path(path: Path) -> bool:
         return False
 
 
+def acquire_temp_file_lease(path: Path) -> bool:
+    """Create or refresh a temp-file lease, raising if the marker cannot be written.
+
+    Returns ``True`` only when this call created the marker, which lets callers roll
+    back a lease they introduced if a following publication step fails.
+    """
+
+    if not _is_direct_temp_path(path):
+        return False
+    marker = _temp_file_lease_marker(path)
+    while True:
+        try:
+            marker.touch(exist_ok=False)
+        except FileExistsError:
+            try:
+                os.utime(marker, None)
+            except FileNotFoundError:
+                continue
+            return False
+        return True
+
+
 def refresh_temp_file_lease(path: Path, *, create: bool = True) -> None:
     """Keep a temp file out of pruning while another process may still be using it."""
 
@@ -164,7 +186,7 @@ def refresh_temp_file_lease(path: Path, *, create: bool = True) -> None:
     if not create and not marker.exists():
         return
     try:
-        marker.touch(exist_ok=True)
+        acquire_temp_file_lease(path)
     except OSError:
         return
 

--- a/src/local_shell_mcp/fs_ops.py
+++ b/src/local_shell_mcp/fs_ops.py
@@ -9,6 +9,7 @@ import os
 import shutil
 import tempfile
 import threading
+import time
 from collections.abc import Iterator
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
@@ -21,6 +22,8 @@ BINARY_CHECK_BYTES = 8192
 BINARY_CONTROL_RATIO = 0.30
 BINARY_PREVIEW_BYTES = 256
 BINARY_MESSAGE = "Refusing to read binary file as text"
+_TEMP_FILE_LEASE_SUFFIX = ".local-shell-mcp-active"
+_TEMP_FILE_LEASE_TTL_S = 300.0
 
 
 class FileConflictError(RuntimeError):
@@ -141,6 +144,40 @@ def temp_dir() -> Path:
     return path
 
 
+def _temp_file_lease_marker(path: Path) -> Path:
+    return path.with_name(path.name + _TEMP_FILE_LEASE_SUFFIX)
+
+
+def _is_direct_temp_path(path: Path) -> bool:
+    try:
+        return path.parent.resolve(strict=False) == temp_dir().resolve(strict=False)
+    except OSError:
+        return False
+
+
+def refresh_temp_file_lease(path: Path, *, create: bool = True) -> None:
+    """Keep a temp file out of pruning while another process may still be using it."""
+
+    if not _is_direct_temp_path(path):
+        return
+    marker = _temp_file_lease_marker(path)
+    if not create and not marker.exists():
+        return
+    try:
+        marker.touch(exist_ok=True)
+    except OSError:
+        return
+
+
+def release_temp_file_lease(path: Path) -> None:
+    if not _is_direct_temp_path(path):
+        return
+    try:
+        _temp_file_lease_marker(path).unlink(missing_ok=True)
+    except OSError:
+        return
+
+
 def prune_temp_dir() -> None:
     settings = get_settings()
     path = temp_dir()
@@ -149,8 +186,31 @@ def prune_temp_dir() -> None:
     except OSError:
         return
 
-    entries: list[tuple[float, int, Path]] = []
+    now = time.time()
+    active_paths: set[Path] = set()
+    candidates: list[Path] = []
     for item in files:
+        if not item.name.endswith(_TEMP_FILE_LEASE_SUFFIX):
+            candidates.append(item)
+            continue
+        try:
+            age_s = max(0.0, now - item.stat().st_mtime)
+        except OSError:
+            continue
+        if age_s <= _TEMP_FILE_LEASE_TTL_S:
+            target_name = item.name[: -len(_TEMP_FILE_LEASE_SUFFIX)]
+            if target_name:
+                active_paths.add(item.with_name(target_name))
+            continue
+        try:
+            item.unlink()
+        except OSError:
+            continue
+
+    entries: list[tuple[float, int, Path]] = []
+    for item in candidates:
+        if item in active_paths:
+            continue
         try:
             stat = item.stat()
         except OSError:
@@ -690,6 +750,7 @@ def delete_path(path: str, recursive: bool = False) -> dict:
             raise PathNotFoundError(p)
         if p.is_symlink():
             p.unlink()
+            release_temp_file_lease(p)
             return {"path": relative_display(p), "deleted": "link"}
         if p.is_dir():
             if not recursive:
@@ -697,5 +758,6 @@ def delete_path(path: str, recursive: bool = False) -> dict:
             shutil.rmtree(p)
             return {"path": relative_display(p), "deleted": "directory"}
         p.unlink()
+        release_temp_file_lease(p)
         return {"path": relative_display(p), "deleted": "file"}
 

--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -82,10 +82,10 @@ from .transfer_ops import (
     transfer_begin_write,
     transfer_finish_write,
     transfer_mark_complete_write,
-    transfer_pack_dir,
+    transfer_pack_dir_async,
     transfer_read_chunk,
     transfer_stat,
-    transfer_unpack_archive,
+    transfer_unpack_archive_async,
     transfer_write_chunk,
 )
 from .version import version_info as get_version_info
@@ -122,8 +122,6 @@ REMOTE_NON_CANCELLABLE_WORKER_TOOLS = frozenset(
         "transfer_write_chunk",
         "transfer_finish_write",
         "transfer_abort_write",
-        "transfer_pack_dir",
-        "transfer_unpack_archive",
         "transfer_upload_url",
         "transfer_download_url",
         "transfer_open_receiver",
@@ -1832,13 +1830,10 @@ async def _execute_transfer_worker_tool(tool: str, args: dict[str, Any]) -> Any:
         return await asyncio.to_thread(transfer_alloc_temp_path, args.get("suffix", ".bin"))
 
     if tool == "transfer_pack_dir":
-        return await asyncio.to_thread(
-            transfer_pack_dir, args["path"], args.get("compression", "gz")
-        )
+        return await transfer_pack_dir_async(args["path"], args.get("compression", "gz"))
 
     if tool == "transfer_unpack_archive":
-        return await asyncio.to_thread(
-            transfer_unpack_archive,
+        return await transfer_unpack_archive_async(
             args["archive_path"],
             args["dst_path"],
             args.get("overwrite", True),

--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -2048,7 +2048,7 @@ async def _copy_packed_dir_to_remote(
                 "cleanup_archive": True,
             },
         )
-    except Exception:
+    except (asyncio.CancelledError, Exception):
         await _remote_cleanup_file(dst_machine, dst_archive.get("path", ""))
         raise
     finally:

--- a/src/local_shell_mcp/tools.py
+++ b/src/local_shell_mcp/tools.py
@@ -111,9 +111,9 @@ from .transfer_ops import (
     DEFAULT_TRANSFER_CHUNK_BYTES,
     normalize_chunk_size,
     transfer_alloc_temp_path,
-    transfer_pack_dir,
+    transfer_pack_dir_async,
     transfer_stat,
-    transfer_unpack_archive,
+    transfer_unpack_archive_async,
 )
 from .version import version_info as get_version_info
 
@@ -2120,8 +2120,8 @@ async def _copy_remote_dir_to_local(
             total_bytes=pack["bytes"],
             chunks=copy_result["chunks"],
         )
-        unpack = await asyncio.to_thread(
-            transfer_unpack_archive, archive["path"], destination_path, overwrite, True
+        unpack = await transfer_unpack_archive_async(
+            archive["path"], destination_path, overwrite, True
         )
     finally:
         with suppress(Exception):
@@ -2146,7 +2146,7 @@ async def _copy_local_dir_to_remote(
     progress: TransferProgress | None = None,
 ) -> dict:
     await _report_transfer_progress(progress, phase="packing", bytes_transferred=0)
-    pack = await asyncio.to_thread(transfer_pack_dir, source_path, "gz")
+    pack = await transfer_pack_dir_async(source_path, "gz")
     return await _copy_packed_dir_to_remote(
         pack,
         None,

--- a/src/local_shell_mcp/transfer_ops.py
+++ b/src/local_shell_mcp/transfer_ops.py
@@ -14,12 +14,14 @@ import tempfile
 import threading
 import time
 import uuid
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
 from .fs_ops import (
     _path_lock,
     _path_locks,
+    acquire_temp_file_lease,
     prune_temp_dir,
     refresh_temp_file_lease,
     relative_display,
@@ -52,15 +54,27 @@ class _LeaseRefreshingReader:
         self._cancel_event = cancel_event
         self._last_refresh = 0.0
 
-    def read(self, size: int = -1) -> bytes:
+    def _before_io(self) -> None:
         _raise_if_cancelled(self._cancel_event)
         now = time.monotonic()
         if now - self._last_refresh >= _TEMP_LEASE_REFRESH_INTERVAL_S:
             refresh_temp_file_lease(self._lease_path, create=False)
             self._last_refresh = now
+
+    def read(self, size: int = -1) -> bytes:
+        self._before_io()
         data = self._handle.read(size)
         _raise_if_cancelled(self._cancel_event)
         return data
+
+    def seek(self, offset: int, whence: int = os.SEEK_SET) -> int:
+        self._before_io()
+        result = self._handle.seek(offset, whence)
+        _raise_if_cancelled(self._cancel_event)
+        return result
+
+    def tell(self) -> int:
+        return self._handle.tell()
 
 
 def _copy_stream(
@@ -97,7 +111,17 @@ def _snapshot_transferable_tree(
     snapshot: dict[str, tuple[Any, ...]] = {}
 
     def visit(directory: Path) -> None:
-        for child in sorted(directory.iterdir(), key=lambda item: item.name):
+        children: list[Path] = []
+        iterator = directory.iterdir()
+        while True:
+            _raise_if_cancelled(cancel_event)
+            try:
+                child = next(iterator)
+            except StopIteration:
+                break
+            children.append(child)
+        children.sort(key=lambda item: item.name)
+        for child in children:
             _raise_if_cancelled(cancel_event)
             relative = child.relative_to(path).as_posix()
             signature = _entry_signature(child)
@@ -109,16 +133,46 @@ def _snapshot_transferable_tree(
     return snapshot
 
 
-async def _run_cancellable_transfer(function: Any, *args: Any) -> dict[str, Any]:
+async def _run_cancellable_transfer(
+    function: Any,
+    *args: Any,
+    cancelled_result_cleanup: Callable[[dict[str, Any]], None] | None = None,
+) -> dict[str, Any]:
     cancel_event = threading.Event()
     worker = asyncio.create_task(asyncio.to_thread(function, *args, cancel_event))
     try:
         return await asyncio.shield(worker)
     except asyncio.CancelledError:
         cancel_event.set()
-        with contextlib.suppress(Exception):
-            await asyncio.shield(worker)
+        try:
+            result = await asyncio.shield(worker)
+        except Exception:
+            pass
+        else:
+            if cancelled_result_cleanup is not None:
+                with contextlib.suppress(Exception):
+                    cancelled_result_cleanup(result)
         raise
+
+
+def _archive_path_from_result(result: dict[str, Any]) -> Path | None:
+    value = result.get("archive_path")
+    if not isinstance(value, str) or not value:
+        return None
+    path = Path(value)
+    if not path.is_absolute():
+        path = get_settings().workspace_root / path
+    return path
+
+
+def _cleanup_cancelled_pack_result(result: dict[str, Any]) -> None:
+    archive = _archive_path_from_result(result)
+    if archive is None:
+        return
+    try:
+        archive.unlink(missing_ok=True)
+    finally:
+        release_temp_file_lease(archive)
 
 
 def normalize_chunk_size(chunk_size: int | None = None) -> int:
@@ -452,11 +506,16 @@ def transfer_finish_write(
             raise ValueError("file sha256 mismatch")
         if not bool(metadata.get("overwrite", True)) and os.path.lexists(dst):
             raise FileExistsError(str(dst))
-        os.replace(tmp, dst)
+        destination_lease_created = acquire_temp_file_lease(dst)
+        try:
+            os.replace(tmp, dst)
+        except Exception:
+            if destination_lease_created:
+                release_temp_file_lease(dst)
+            raise
         metadata_path.unlink(missing_ok=True)
         release_temp_file_lease(tmp)
         release_temp_file_lease(metadata_path)
-        refresh_temp_file_lease(dst)
     return {
         "path": relative_display(dst),
         "bytes": size,
@@ -553,7 +612,12 @@ def transfer_pack_dir(
 
 
 async def transfer_pack_dir_async(path: str, compression: str = "gz") -> dict[str, Any]:
-    return await _run_cancellable_transfer(transfer_pack_dir, path, compression)
+    return await _run_cancellable_transfer(
+        transfer_pack_dir,
+        path,
+        compression,
+        cancelled_result_cleanup=_cleanup_cancelled_pack_result,
+    )
 
 
 def _safe_members(
@@ -626,29 +690,31 @@ def transfer_unpack_archive(
     members: list[tarfile.TarInfo] = []
     committed = False
     try:
-        with tarfile.open(archive, "r:*") as tar:
-            members = _safe_members(tar, staging, cancel_event, archive)
-            for member in members:
-                _raise_if_cancelled(cancel_event)
-                target = staging / member.name
-                if member.isdir():
-                    target.mkdir(parents=True, exist_ok=True)
-                    continue
-                if member.isfile():
-                    target.parent.mkdir(parents=True, exist_ok=True)
-                    source = tar.extractfile(member)
-                    if source is None:
-                        raise ValueError(f"archive member has no file data: {member.name}")
-                    with source, target.open("xb") as out:
-                        _copy_stream(
-                            source,
-                            out,
-                            lease_path=archive,
-                            cancel_event=cancel_event,
-                        )
-                    os.chmod(target, member.mode & 0o777)
-                    continue
-                raise ValueError(f"unsupported archive member type: {member.name}")
+        with archive.open("rb") as archive_handle:
+            archive_reader = _LeaseRefreshingReader(archive_handle, archive, cancel_event)
+            with tarfile.open(fileobj=archive_reader, mode="r:*") as tar:
+                members = _safe_members(tar, staging, cancel_event, archive)
+                for member in members:
+                    _raise_if_cancelled(cancel_event)
+                    target = staging / member.name
+                    if member.isdir():
+                        target.mkdir(parents=True, exist_ok=True)
+                        continue
+                    if member.isfile():
+                        target.parent.mkdir(parents=True, exist_ok=True)
+                        source = tar.extractfile(member)
+                        if source is None:
+                            raise ValueError(f"archive member has no file data: {member.name}")
+                        with source, target.open("xb") as out:
+                            _copy_stream(
+                                source,
+                                out,
+                                lease_path=archive,
+                                cancel_event=cancel_event,
+                            )
+                        os.chmod(target, member.mode & 0o777)
+                        continue
+                    raise ValueError(f"unsupported archive member type: {member.name}")
 
         _raise_if_cancelled(cancel_event)
         with _path_lock(dst):

--- a/src/local_shell_mcp/transfer_ops.py
+++ b/src/local_shell_mcp/transfer_ops.py
@@ -42,6 +42,21 @@ def _raise_if_cancelled(cancel_event: threading.Event | None) -> None:
         raise InterruptedError("transfer operation was cancelled")
 
 
+def _poll_transfer_activity(
+    cancel_event: threading.Event | None,
+    lease_path: Path | None,
+    last_refresh_at: float,
+) -> float:
+    _raise_if_cancelled(cancel_event)
+    if lease_path is None:
+        return last_refresh_at
+    now = time.monotonic()
+    if now - last_refresh_at >= _TEMP_LEASE_REFRESH_INTERVAL_S:
+        refresh_temp_file_lease(lease_path, create=False)
+        return now
+    return last_refresh_at
+
+
 class _LeaseRefreshingReader:
     def __init__(
         self,
@@ -55,11 +70,11 @@ class _LeaseRefreshingReader:
         self._last_refresh = 0.0
 
     def _before_io(self) -> None:
-        _raise_if_cancelled(self._cancel_event)
-        now = time.monotonic()
-        if now - self._last_refresh >= _TEMP_LEASE_REFRESH_INTERVAL_S:
-            refresh_temp_file_lease(self._lease_path, create=False)
-            self._last_refresh = now
+        self._last_refresh = _poll_transfer_activity(
+            self._cancel_event,
+            self._lease_path,
+            self._last_refresh,
+        )
 
     def read(self, size: int = -1) -> bytes:
         self._before_io()
@@ -107,14 +122,24 @@ def _entry_signature(path: Path) -> tuple[Any, ...]:
 def _snapshot_transferable_tree(
     path: Path,
     cancel_event: threading.Event | None = None,
+    lease_path: Path | None = None,
 ) -> dict[str, tuple[Any, ...]]:
     snapshot: dict[str, tuple[Any, ...]] = {}
+    last_lease_refresh = 0.0
+
+    def poll() -> None:
+        nonlocal last_lease_refresh
+        last_lease_refresh = _poll_transfer_activity(
+            cancel_event,
+            lease_path,
+            last_lease_refresh,
+        )
 
     def visit(directory: Path) -> None:
         children: list[Path] = []
         iterator = directory.iterdir()
         while True:
-            _raise_if_cancelled(cancel_event)
+            poll()
             try:
                 child = next(iterator)
             except StopIteration:
@@ -122,7 +147,7 @@ def _snapshot_transferable_tree(
             children.append(child)
         children.sort(key=lambda item: item.name)
         for child in children:
-            _raise_if_cancelled(cancel_event)
+            poll()
             relative = child.relative_to(path).as_posix()
             signature = _entry_signature(child)
             snapshot[relative] = signature
@@ -572,9 +597,14 @@ def transfer_pack_dir(
     archive.parent.mkdir(parents=True, exist_ok=True)
     refresh_temp_file_lease(archive)
     try:
+        last_lease_refresh = 0.0
         with tarfile.open(archive, mode) as tar:
             for relative, signature in snapshot.items():
-                _raise_if_cancelled(cancel_event)
+                last_lease_refresh = _poll_transfer_activity(
+                    cancel_event,
+                    archive,
+                    last_lease_refresh,
+                )
                 source = src / relative
                 if _entry_signature(source) != signature:
                     raise RuntimeError(
@@ -594,7 +624,7 @@ def transfer_pack_dir(
                         "source directory changed during packing; retry after writes finish"
                     )
         _raise_if_cancelled(cancel_event)
-        if _snapshot_transferable_tree(src, cancel_event) != snapshot:
+        if _snapshot_transferable_tree(src, cancel_event, archive) != snapshot:
             raise RuntimeError("source directory changed during packing; retry after writes finish")
         size = archive.stat().st_size
         digest = _sha256_file(archive, cancel_event=cancel_event)

--- a/src/local_shell_mcp/transfer_ops.py
+++ b/src/local_shell_mcp/transfer_ops.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import binascii
 import contextlib
@@ -10,6 +11,8 @@ import shutil
 import stat
 import tarfile
 import tempfile
+import threading
+import time
 import uuid
 from pathlib import Path
 from typing import Any
@@ -18,7 +21,9 @@ from .fs_ops import (
     _path_lock,
     _path_locks,
     prune_temp_dir,
+    refresh_temp_file_lease,
     relative_display,
+    release_temp_file_lease,
     resolve_path,
     temp_dir,
 )
@@ -27,6 +32,93 @@ from .settings import get_settings
 DEFAULT_TRANSFER_CHUNK_BYTES = 1024 * 1024
 MAX_TRANSFER_CHUNK_BYTES = 4 * 1024 * 1024
 _TRANSFER_TMP_MARKER = "local-shell-mcp-transfer"
+_TEMP_LEASE_REFRESH_INTERVAL_S = 1.0
+
+
+def _raise_if_cancelled(cancel_event: threading.Event | None) -> None:
+    if cancel_event is not None and cancel_event.is_set():
+        raise InterruptedError("transfer operation was cancelled")
+
+
+class _LeaseRefreshingReader:
+    def __init__(
+        self,
+        handle: Any,
+        lease_path: Path,
+        cancel_event: threading.Event | None = None,
+    ) -> None:
+        self._handle = handle
+        self._lease_path = lease_path
+        self._cancel_event = cancel_event
+        self._last_refresh = 0.0
+
+    def read(self, size: int = -1) -> bytes:
+        _raise_if_cancelled(self._cancel_event)
+        now = time.monotonic()
+        if now - self._last_refresh >= _TEMP_LEASE_REFRESH_INTERVAL_S:
+            refresh_temp_file_lease(self._lease_path, create=False)
+            self._last_refresh = now
+        data = self._handle.read(size)
+        _raise_if_cancelled(self._cancel_event)
+        return data
+
+
+def _copy_stream(
+    source: Any,
+    destination: Any,
+    *,
+    lease_path: Path,
+    cancel_event: threading.Event | None = None,
+) -> None:
+    reader = _LeaseRefreshingReader(source, lease_path, cancel_event)
+    while True:
+        chunk = reader.read(DEFAULT_TRANSFER_CHUNK_BYTES)
+        if not chunk:
+            return
+        destination.write(chunk)
+
+
+def _entry_signature(path: Path) -> tuple[Any, ...]:
+    info = path.lstat()
+    mode = info.st_mode
+    if stat.S_ISLNK(mode):
+        raise ValueError(f"directory transfer does not support symlinks: {relative_display(path)}")
+    if stat.S_ISDIR(mode):
+        return ("dir",)
+    if stat.S_ISREG(mode):
+        return ("file", info.st_size, info.st_mtime_ns, info.st_ino)
+    raise ValueError(f"directory transfer does not support special files: {relative_display(path)}")
+
+
+def _snapshot_transferable_tree(
+    path: Path,
+    cancel_event: threading.Event | None = None,
+) -> dict[str, tuple[Any, ...]]:
+    snapshot: dict[str, tuple[Any, ...]] = {}
+
+    def visit(directory: Path) -> None:
+        for child in sorted(directory.iterdir(), key=lambda item: item.name):
+            _raise_if_cancelled(cancel_event)
+            relative = child.relative_to(path).as_posix()
+            signature = _entry_signature(child)
+            snapshot[relative] = signature
+            if signature[0] == "dir":
+                visit(child)
+
+    visit(path)
+    return snapshot
+
+
+async def _run_cancellable_transfer(function: Any, *args: Any) -> dict[str, Any]:
+    cancel_event = threading.Event()
+    worker = asyncio.create_task(asyncio.to_thread(function, *args, cancel_event))
+    try:
+        return await asyncio.shield(worker)
+    except asyncio.CancelledError:
+        cancel_event.set()
+        with contextlib.suppress(Exception):
+            await asyncio.shield(worker)
+        raise
 
 
 def normalize_chunk_size(chunk_size: int | None = None) -> int:
@@ -36,19 +128,27 @@ def normalize_chunk_size(chunk_size: int | None = None) -> int:
     return min(requested, MAX_TRANSFER_CHUNK_BYTES)
 
 
-def _sha256_file(path: Path, chunk_size: int = DEFAULT_TRANSFER_CHUNK_BYTES) -> str:
+def _sha256_file(
+    path: Path,
+    chunk_size: int = DEFAULT_TRANSFER_CHUNK_BYTES,
+    cancel_event: threading.Event | None = None,
+) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as fh:
         while True:
+            _raise_if_cancelled(cancel_event)
+            refresh_temp_file_lease(path, create=False)
             chunk = fh.read(chunk_size)
             if not chunk:
                 break
             digest.update(chunk)
+    _raise_if_cancelled(cancel_event)
     return digest.hexdigest()
 
 
 def transfer_stat(path: str, sha256: bool = True) -> dict[str, Any]:
     p = resolve_path(path, must_exist=True)
+    refresh_temp_file_lease(p, create=False)
     stat = p.stat()
     if p.is_file():
         result: dict[str, Any] = {
@@ -79,6 +179,7 @@ def transfer_read_chunk(
     path: str, offset: int = 0, chunk_size: int | None = None
 ) -> dict[str, Any]:
     p = resolve_path(path, must_exist=True)
+    refresh_temp_file_lease(p, create=False)
     if not p.is_file():
         raise IsADirectoryError(str(p))
     size = p.stat().st_size
@@ -115,6 +216,7 @@ def _transfer_metadata_path(tmp: Path) -> Path:
 def _write_transfer_metadata(tmp: Path, metadata: dict[str, Any]) -> None:
     path = _transfer_metadata_path(tmp)
     temporary = path.with_name(path.name + f".{uuid.uuid4().hex}.tmp")
+    refresh_temp_file_lease(temporary)
     try:
         temporary.write_text(json.dumps(metadata, indent=2, sort_keys=True), encoding="utf-8")
         with contextlib.suppress(OSError):
@@ -122,6 +224,7 @@ def _write_transfer_metadata(tmp: Path, metadata: dict[str, Any]) -> None:
         os.replace(temporary, path)
     finally:
         temporary.unlink(missing_ok=True)
+        release_temp_file_lease(temporary)
 
 
 def _read_transfer_metadata(tmp: Path) -> dict[str, Any]:
@@ -190,6 +293,8 @@ def transfer_begin_write(
         tmp = _transfer_temp_path(dst, transfer_id)
         with tmp.open("xb"):
             pass
+        refresh_temp_file_lease(tmp)
+        refresh_temp_file_lease(_transfer_metadata_path(tmp))
         try:
             _write_transfer_metadata(
                 tmp,
@@ -202,6 +307,8 @@ def transfer_begin_write(
             )
         except Exception:
             tmp.unlink(missing_ok=True)
+            release_temp_file_lease(tmp)
+            release_temp_file_lease(_transfer_metadata_path(tmp))
             raise
     return {
         "path": relative_display(dst),
@@ -241,6 +348,8 @@ def _write_transfer_payload(
     payload: bytes,
     digest: str,
 ) -> dict[str, Any]:
+    refresh_temp_file_lease(tmp, create=False)
+    refresh_temp_file_lease(_transfer_metadata_path(tmp), create=False)
     with _path_lock(tmp):
         if not tmp.exists():
             raise FileNotFoundError(str(tmp))
@@ -291,6 +400,8 @@ def transfer_mark_complete_write(path: str, transfer_id: str) -> dict[str, Any]:
 
     dst = resolve_path(path, follow_final_symlink=False)
     tmp = _transfer_temp_path(dst, transfer_id)
+    refresh_temp_file_lease(tmp, create=False)
+    refresh_temp_file_lease(_transfer_metadata_path(tmp), create=False)
     with _path_lock(tmp):
         if not tmp.exists():
             raise FileNotFoundError(str(tmp))
@@ -317,6 +428,8 @@ def transfer_finish_write(
     dst = resolve_path(path, follow_final_symlink=False)
     tmp = _transfer_temp_path(dst, transfer_id)
     metadata_path = _transfer_metadata_path(tmp)
+    refresh_temp_file_lease(tmp, create=False)
+    refresh_temp_file_lease(metadata_path, create=False)
     with _path_locks([dst, tmp]):
         if not tmp.exists():
             raise FileNotFoundError(str(tmp))
@@ -341,6 +454,9 @@ def transfer_finish_write(
             raise FileExistsError(str(dst))
         os.replace(tmp, dst)
         metadata_path.unlink(missing_ok=True)
+        release_temp_file_lease(tmp)
+        release_temp_file_lease(metadata_path)
+        refresh_temp_file_lease(dst)
     return {
         "path": relative_display(dst),
         "bytes": size,
@@ -359,6 +475,8 @@ def transfer_abort_write(path: str, transfer_id: str) -> dict[str, Any]:
             tmp.unlink()
             deleted = True
         metadata_path.unlink(missing_ok=True)
+        release_temp_file_lease(tmp)
+        release_temp_file_lease(metadata_path)
     return {
         "path": relative_display(dst),
         "temp_path": relative_display(tmp),
@@ -376,61 +494,87 @@ def transfer_alloc_temp_path(suffix: str = ".bin") -> dict[str, Any]:
     return {"path": relative_display(path)}
 
 
-def _assert_transferable_tree(path: Path) -> None:
-    if path.is_symlink():
-        raise ValueError(f"directory transfer does not support symlinks: {relative_display(path)}")
-    for child in path.rglob("*"):
-        if child.is_symlink():
-            raise ValueError(
-                f"directory transfer does not support symlinks: {relative_display(child)}"
-            )
-        mode = child.lstat().st_mode
-        if not (stat.S_ISREG(mode) or stat.S_ISDIR(mode)):
-            raise ValueError(
-                f"directory transfer does not support special files: {relative_display(child)}"
-            )
-
-
-def transfer_pack_dir(path: str, compression: str = "gz") -> dict[str, Any]:
+def transfer_pack_dir(
+    path: str,
+    compression: str = "gz",
+    cancel_event: threading.Event | None = None,
+) -> dict[str, Any]:
     prune_temp_dir()
     if compression not in {"gz", "none"}:
         raise ValueError("compression must be 'gz' or 'none'")
     src = resolve_path(path, must_exist=True)
     if not src.is_dir():
         raise NotADirectoryError(str(src))
-    _assert_transferable_tree(src)
+    _raise_if_cancelled(cancel_event)
+    snapshot = _snapshot_transferable_tree(src, cancel_event)
     suffix = ".tar.gz" if compression == "gz" else ".tar"
     mode = "w:gz" if compression == "gz" else "w"
     archive = temp_dir() / f"transfer-pack-{uuid.uuid4().hex}{suffix}"
     archive.parent.mkdir(parents=True, exist_ok=True)
+    refresh_temp_file_lease(archive)
     try:
         with tarfile.open(archive, mode) as tar:
-            for child in src.iterdir():
-                tar.add(child, arcname=child.name, recursive=True)
+            for relative, signature in snapshot.items():
+                _raise_if_cancelled(cancel_event)
+                source = src / relative
+                if _entry_signature(source) != signature:
+                    raise RuntimeError(
+                        "source directory changed during packing; retry after writes finish"
+                    )
+                info = tar.gettarinfo(str(source), arcname=relative)
+                if signature[0] == "dir":
+                    tar.addfile(info)
+                    continue
+                with source.open("rb") as handle:
+                    tar.addfile(
+                        info,
+                        _LeaseRefreshingReader(handle, archive, cancel_event),
+                    )
+                if _entry_signature(source) != signature:
+                    raise RuntimeError(
+                        "source directory changed during packing; retry after writes finish"
+                    )
+        _raise_if_cancelled(cancel_event)
+        if _snapshot_transferable_tree(src, cancel_event) != snapshot:
+            raise RuntimeError("source directory changed during packing; retry after writes finish")
         size = archive.stat().st_size
+        digest = _sha256_file(archive, cancel_event=cancel_event)
     except Exception:
         archive.unlink(missing_ok=True)
+        release_temp_file_lease(archive)
         raise
     return {
         "path": relative_display(src),
         "archive_path": relative_display(archive),
         "bytes": size,
-        "sha256": _sha256_file(archive),
+        "sha256": digest,
         "compression": compression,
     }
 
 
-def _safe_members(tar: tarfile.TarFile, dst: Path) -> list[tarfile.TarInfo]:
+async def transfer_pack_dir_async(path: str, compression: str = "gz") -> dict[str, Any]:
+    return await _run_cancellable_transfer(transfer_pack_dir, path, compression)
+
+
+def _safe_members(
+    tar: tarfile.TarFile,
+    dst: Path,
+    cancel_event: threading.Event | None = None,
+    lease_path: Path | None = None,
+) -> list[tarfile.TarInfo]:
     settings = get_settings()
     base = dst.resolve(strict=False)
-    members = tar.getmembers()
     max_entries = max(1, settings.max_transfer_archive_entries)
-    if len(members) > max_entries:
-        raise ValueError(f"archive contains {len(members)} entries; max is {max_entries}")
     total_bytes = 0
     seen_paths: set[str] = set()
     safe: list[tarfile.TarInfo] = []
+    members = iter(tar) if hasattr(tar, "__iter__") else iter(tar.getmembers())
     for member in members:
+        _raise_if_cancelled(cancel_event)
+        if lease_path is not None:
+            refresh_temp_file_lease(lease_path, create=False)
+        if len(safe) >= max_entries:
+            raise ValueError(f"archive contains more than {max_entries} entries")
         member_path = Path(member.name)
         if member_path.is_absolute() or ".." in member_path.parts:
             raise ValueError(f"unsafe archive member path: {member.name}")
@@ -468,10 +612,13 @@ def transfer_unpack_archive(
     dst_path: str,
     overwrite: bool = True,
     cleanup_archive: bool = True,
+    cancel_event: threading.Event | None = None,
 ) -> dict[str, Any]:
     archive = resolve_path(archive_path, must_exist=True)
     if not archive.is_file():
         raise FileNotFoundError(str(archive))
+    refresh_temp_file_lease(archive, create=False)
+    _raise_if_cancelled(cancel_event)
     dst = resolve_path(dst_path, follow_final_symlink=False)
     dst.parent.mkdir(parents=True, exist_ok=True)
     staging = Path(tempfile.mkdtemp(prefix=f".{dst.name}.unpack-", dir=str(dst.parent)))
@@ -480,8 +627,9 @@ def transfer_unpack_archive(
     committed = False
     try:
         with tarfile.open(archive, "r:*") as tar:
-            members = _safe_members(tar, staging)
+            members = _safe_members(tar, staging, cancel_event, archive)
             for member in members:
+                _raise_if_cancelled(cancel_event)
                 target = staging / member.name
                 if member.isdir():
                     target.mkdir(parents=True, exist_ok=True)
@@ -492,11 +640,17 @@ def transfer_unpack_archive(
                     if source is None:
                         raise ValueError(f"archive member has no file data: {member.name}")
                     with source, target.open("xb") as out:
-                        shutil.copyfileobj(source, out)
+                        _copy_stream(
+                            source,
+                            out,
+                            lease_path=archive,
+                            cancel_event=cancel_event,
+                        )
                     os.chmod(target, member.mode & 0o777)
                     continue
                 raise ValueError(f"unsupported archive member type: {member.name}")
 
+        _raise_if_cancelled(cancel_event)
         with _path_lock(dst):
             exists = os.path.lexists(dst)
             if (
@@ -538,6 +692,8 @@ def transfer_unpack_archive(
                 cleanup_errors.append(f"could not remove transfer archive {archive}: {exc}")
             else:
                 archive_deleted = not archive.exists()
+                if archive_deleted:
+                    release_temp_file_lease(archive)
         return {
             "path": relative_display(dst),
             "archive_path": relative_display(archive),
@@ -557,3 +713,18 @@ def transfer_unpack_archive(
             if os.path.lexists(backup):
                 with contextlib.suppress(OSError):
                     _remove_existing_path(backup)
+
+
+async def transfer_unpack_archive_async(
+    archive_path: str,
+    dst_path: str,
+    overwrite: bool = True,
+    cleanup_archive: bool = True,
+) -> dict[str, Any]:
+    return await _run_cancellable_transfer(
+        transfer_unpack_archive,
+        archive_path,
+        dst_path,
+        overwrite,
+        cleanup_archive,
+    )

--- a/tests/test_audit_regressions.py
+++ b/tests/test_audit_regressions.py
@@ -449,6 +449,10 @@ async def test_failed_remote_directory_pull_removes_local_archive(tmp_path, monk
     async def fake_cleanup(*args, **kwargs):
         del args, kwargs
 
+    async def fake_unpack(*args, **kwargs):
+        del args, kwargs
+        raise ValueError("unpack failed")
+
     monkeypatch.setattr(tools_module, "_remote_transfer_data", fake_remote_data)
     monkeypatch.setattr(
         tools_module, "transfer_alloc_temp_path", lambda suffix: {"path": archive.name}
@@ -456,8 +460,8 @@ async def test_failed_remote_directory_pull_removes_local_archive(tmp_path, monk
     monkeypatch.setattr(tools_module, "_copy_remote_file_to_local", fake_copy)
     monkeypatch.setattr(
         tools_module,
-        "transfer_unpack_archive",
-        lambda *args, **kwargs: (_ for _ in ()).throw(ValueError("unpack failed")),
+        "transfer_unpack_archive_async",
+        fake_unpack,
     )
     monkeypatch.setattr(tools_module, "_remote_cleanup_file", fake_cleanup)
 

--- a/tests/test_remote_complete.py
+++ b/tests/test_remote_complete.py
@@ -296,6 +296,8 @@ async def test_every_worker_tool_dispatch_branch(monkeypatch, tmp_path):
         "grep",
         "playwright_run_script",
         "_apply_patch_text",
+        "transfer_pack_dir_async",
+        "transfer_unpack_archive_async",
     ):
         monkeypatch.setattr(remote, name, async_value)
     for name in (
@@ -313,8 +315,6 @@ async def test_every_worker_tool_dispatch_branch(monkeypatch, tmp_path):
         "transfer_finish_write",
         "transfer_abort_write",
         "transfer_alloc_temp_path",
-        "transfer_pack_dir",
-        "transfer_unpack_archive",
         "_worker_upload_url",
         "_worker_download_url",
     ):
@@ -592,6 +592,31 @@ async def test_remote_mutation_timeout_and_claimed_cancellation_cleanup(
     assert job_id not in manager.pending
     assert job_id not in manager.pending_machines
     assert job_id not in manager.claimed_jobs
+
+
+@pytest.mark.asyncio
+async def test_claimed_directory_pack_is_cancelled_by_controller(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    manager = remote.RemoteManager()
+    manager._registry_loaded = True
+    worker = remote.RemoteWorker("node", "token", last_seen=100)
+    manager.workers["node"] = worker
+    manager.tokens["token"] = "node"
+    monkeypatch.setattr(remote, "_utc", lambda: 100.0)
+
+    task = asyncio.create_task(
+        manager.call("node", "transfer_pack_dir", {"path": "large"}, timeout_s=10)
+    )
+    polled = await manager.poll("token")
+    job_id = polled["job"]["id"]
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert job_id not in manager.pending
+    assert job_id in manager.cancelled_jobs
+    heartbeat = await manager.heartbeat("token", {"job_id": job_id})
+    assert heartbeat["cancelled"] is True
 
 
 def test_worker_upload_protocol_and_generated_execution_edges(tmp_path, monkeypatch):

--- a/tests/test_remote_transfer_tools.py
+++ b/tests/test_remote_transfer_tools.py
@@ -214,6 +214,41 @@ async def test_remote_cleanup_file_stays_on_transfer_lane(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_cancelled_remote_unpack_cleans_destination_archive(monkeypatch):
+    cleaned: list[tuple[str, str]] = []
+
+    async def transfer(machine, tool, args, timeout_s=None):
+        del timeout_s
+        if tool == "transfer_alloc_temp_path":
+            return {"path": "remote-transfer.tar.gz"}
+        if tool == "transfer_unpack_archive":
+            raise asyncio.CancelledError
+        raise AssertionError((machine, tool, args))
+
+    async def copy_local(*args, **kwargs):
+        del args, kwargs
+        return {"chunks": 1}
+
+    async def cleanup(machine, path):
+        cleaned.append((machine, path))
+
+    monkeypatch.setattr(tools, "_remote_transfer_data", transfer)
+    monkeypatch.setattr(tools, "_copy_local_file_to_remote", copy_local)
+    monkeypatch.setattr(tools, "_remote_cleanup_file", cleanup)
+
+    pack = {
+        "path": "src",
+        "archive_path": "source.tar.gz",
+        "bytes": 1,
+        "sha256": "digest",
+    }
+    with pytest.raises(asyncio.CancelledError):
+        await tools._copy_packed_dir_to_remote(pack, None, "worker-a", "dst", True, None)
+
+    assert cleaned == [("worker-a", "remote-transfer.tar.gz")]
+
+
+@pytest.mark.asyncio
 async def test_remote_upload_recovers_lost_chunk_acknowledgement(tmp_path, monkeypatch):
     root = _workspace(tmp_path, monkeypatch)
     (root / "src-machine").mkdir()

--- a/tests/test_storage_complete.py
+++ b/tests/test_storage_complete.py
@@ -158,6 +158,32 @@ def test_filesystem_mutation_and_temp_cleanup_edges(tmp_path, monkeypatch):
         assert fs.delete_path("link")["deleted"] == "link"
 
 
+def test_temp_pruning_preserves_active_cross_process_lease(tmp_path, monkeypatch):
+    _configure(
+        tmp_path,
+        monkeypatch,
+        LOCAL_SHELL_MCP_MAX_TMP_FILES=1,
+        LOCAL_SHELL_MCP_MAX_TMP_BYTES=1,
+    )
+    temp = fs.temp_dir()
+    active = temp / "active.bin"
+    stale = temp / "stale.bin"
+    active.write_bytes(b"active-data")
+    stale.write_bytes(b"stale-data")
+    fs.refresh_temp_file_lease(active)
+    fs.refresh_temp_file_lease(stale)
+    stale_marker = fs._temp_file_lease_marker(stale)
+    old = time.time() - fs._TEMP_FILE_LEASE_TTL_S - 1
+    os.utime(stale_marker, (old, old))
+
+    fs.prune_temp_dir()
+
+    assert active.exists()
+    assert fs._temp_file_lease_marker(active).exists()
+    assert not stale.exists()
+    assert not stale_marker.exists()
+
+
 def test_download_store_urls_coercion_and_corruption(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
     assert downloads._snapshot_name("token").endswith(".bin")

--- a/tests/test_transfer_ops.py
+++ b/tests/test_transfer_ops.py
@@ -7,6 +7,7 @@ import threading
 
 import pytest
 
+import local_shell_mcp.fs_ops as fs_module
 import local_shell_mcp.tools as tools_module
 import local_shell_mcp.transfer_ops as transfer_module
 from local_shell_mcp.settings import get_settings
@@ -253,6 +254,33 @@ def test_directory_pack_cancellation_removes_active_archive(tmp_path, monkeypatc
     assert not list(temp.glob("transfer-pack-*.local-shell-mcp-active"))
 
 
+def test_directory_snapshot_polls_cancellation_while_enumerating(tmp_path, monkeypatch):
+    root = _workspace(tmp_path, monkeypatch)
+    source = root / "src"
+    source.mkdir()
+    for name in ("a.txt", "b.txt", "c.txt"):
+        (source / name).write_text(name, encoding="utf-8")
+    cancel_event = threading.Event()
+    original_iterdir = transfer_module.Path.iterdir
+    yielded = 0
+
+    def cancelling_iterdir(path):
+        nonlocal yielded
+        for child in original_iterdir(path):
+            if path == source:
+                yielded += 1
+                if yielded == 1:
+                    cancel_event.set()
+            yield child
+
+    monkeypatch.setattr(transfer_module.Path, "iterdir", cancelling_iterdir)
+
+    with pytest.raises(InterruptedError, match="cancelled"):
+        transfer_module._snapshot_transferable_tree(source, cancel_event)
+
+    assert yielded == 1
+
+
 @pytest.mark.asyncio
 async def test_async_pack_cancellation_waits_for_thread_cleanup(tmp_path, monkeypatch):
     _workspace(tmp_path, monkeypatch)
@@ -278,6 +306,44 @@ async def test_async_pack_cancellation_waits_for_thread_cleanup(tmp_path, monkey
         await task
 
     assert stopped.is_set()
+
+
+@pytest.mark.asyncio
+async def test_async_pack_cancellation_cleans_late_success_result(tmp_path, monkeypatch):
+    _workspace(tmp_path, monkeypatch)
+    archive = transfer_module.temp_dir() / "late-success.tar"
+    started = threading.Event()
+    release = threading.Event()
+
+    def nearly_finished_pack(path, compression, cancel_event):
+        archive.write_bytes(b"packed")
+        transfer_module.refresh_temp_file_lease(archive)
+        started.set()
+        assert release.wait(2)
+        return {
+            "path": path,
+            "archive_path": transfer_module.relative_display(archive),
+            "bytes": archive.stat().st_size,
+            "sha256": "unused",
+            "compression": compression,
+        }
+
+    monkeypatch.setattr(transfer_module, "transfer_pack_dir", nearly_finished_pack)
+    task = asyncio.create_task(transfer_module.transfer_pack_dir_async("src", "none"))
+    for _ in range(100):
+        if started.is_set():
+            break
+        await asyncio.sleep(0.01)
+    assert started.is_set()
+
+    task.cancel()
+    await asyncio.sleep(0)
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert not archive.exists()
+    assert not fs_module._temp_file_lease_marker(archive).exists()
 
 
 def test_unpack_failure_preserves_existing_destination(tmp_path, monkeypatch):
@@ -312,6 +378,58 @@ def test_transfer_overwrite_false_rechecks_destination_at_finish(tmp_path, monke
 
     assert destination.read_text(encoding="utf-8") == "important"
     transfer_abort_write("dest.txt", begin["transfer_id"])
+
+
+def test_transfer_finish_leases_temp_destination_before_publish(tmp_path, monkeypatch):
+    _workspace(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_TMP_FILES", "1")
+    monkeypatch.setenv("LOCAL_SHELL_MCP_MAX_TMP_BYTES", "1")
+    get_settings.cache_clear()
+    destination = transfer_module.temp_dir() / "published.bin"
+    destination_path = transfer_module.relative_display(destination)
+    begin = transfer_begin_write(destination_path, expected_bytes=3)
+    transfer_write_chunk(destination_path, begin["transfer_id"], 0, "bmV3")
+    original_replace = transfer_module.os.replace
+    pruned_after_publish = False
+
+    def replace_then_prune(source, target):
+        nonlocal pruned_after_publish
+        result = original_replace(source, target)
+        if transfer_module.Path(target) == destination:
+            transfer_module.prune_temp_dir()
+            pruned_after_publish = True
+        return result
+
+    monkeypatch.setattr(transfer_module.os, "replace", replace_then_prune)
+
+    result = transfer_finish_write(destination_path, begin["transfer_id"], expected_bytes=3)
+
+    assert pruned_after_publish is True
+    assert result["completed"] is True
+    assert destination.read_bytes() == b"new"
+    assert fs_module._temp_file_lease_marker(destination).exists()
+
+
+def test_transfer_finish_removes_new_destination_lease_if_publish_fails(tmp_path, monkeypatch):
+    _workspace(tmp_path, monkeypatch)
+    destination = transfer_module.temp_dir() / "failed.bin"
+    destination_path = transfer_module.relative_display(destination)
+    begin = transfer_begin_write(destination_path, expected_bytes=3)
+    transfer_write_chunk(destination_path, begin["transfer_id"], 0, "bmV3")
+    original_replace = transfer_module.os.replace
+
+    def fail_final_replace(source, target):
+        if transfer_module.Path(target) == destination:
+            raise OSError("publish failed")
+        return original_replace(source, target)
+
+    monkeypatch.setattr(transfer_module.os, "replace", fail_final_replace)
+
+    with pytest.raises(OSError, match="publish failed"):
+        transfer_finish_write(destination_path, begin["transfer_id"], expected_bytes=3)
+
+    assert not fs_module._temp_file_lease_marker(destination).exists()
+    transfer_abort_write(destination_path, begin["transfer_id"])
 
 
 def test_transfer_chunk_cannot_exceed_declared_size(tmp_path, monkeypatch):
@@ -387,3 +505,45 @@ def test_unpack_reports_post_commit_cleanup_failure_without_rolling_back(tmp_pat
     assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
     assert not (destination / "old.txt").exists()
     assert list(root.glob(".dst.backup-*"))
+
+
+def test_unpack_polls_cancellation_inside_tar_iteration(tmp_path, monkeypatch):
+    root = _workspace(tmp_path, monkeypatch)
+    archive = root / "payload.tar.gz"
+    archive.write_bytes(b"placeholder")
+    cancel_event = threading.Event()
+    saw_wrapped_reader = False
+
+    class CancellingTar:
+        def __init__(self, fileobj):
+            self.fileobj = fileobj
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def __iter__(self):
+            nonlocal saw_wrapped_reader
+            saw_wrapped_reader = isinstance(self.fileobj, transfer_module._LeaseRefreshingReader)
+            cancel_event.set()
+            self.fileobj.read(1)
+            return iter(())
+
+    def fake_tar_open(*args, **kwargs):
+        return CancellingTar(kwargs.get("fileobj"))
+
+    monkeypatch.setattr(transfer_module.tarfile, "open", fake_tar_open)
+
+    with pytest.raises(InterruptedError, match="cancelled"):
+        transfer_unpack_archive(
+            "payload.tar.gz",
+            "dst",
+            overwrite=True,
+            cleanup_archive=False,
+            cancel_event=cancel_event,
+        )
+
+    assert saw_wrapped_reader is True
+    assert not list(root.glob(".dst.unpack-*"))

--- a/tests/test_transfer_ops.py
+++ b/tests/test_transfer_ops.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 import io
 import tarfile
+import threading
 
 import pytest
 
@@ -202,6 +204,80 @@ def test_directory_pack_rejects_symlinks_before_archive_creation(tmp_path, monke
 
     with pytest.raises(ValueError, match="does not support symlinks"):
         transfer_pack_dir("src")
+
+
+def test_directory_pack_detects_concurrent_source_mutation(tmp_path, monkeypatch):
+    root = _workspace(tmp_path, monkeypatch)
+    source = root / "src" / "payload.bin"
+    source.parent.mkdir()
+    source.write_bytes(b"a" * (128 * 1024))
+    original_read = transfer_module._LeaseRefreshingReader.read
+    mutated = False
+
+    def mutate_after_read(self, size=-1):
+        nonlocal mutated
+        data = original_read(self, size)
+        if data and not mutated:
+            mutated = True
+            with source.open("ab") as handle:
+                handle.write(b"changed")
+        return data
+
+    monkeypatch.setattr(transfer_module._LeaseRefreshingReader, "read", mutate_after_read)
+
+    with pytest.raises(RuntimeError, match="source directory changed during packing"):
+        transfer_pack_dir("src", compression="none")
+
+    assert not list((root / ".local-shell-mcp" / "tmp").glob("transfer-pack-*"))
+
+
+def test_directory_pack_cancellation_removes_active_archive(tmp_path, monkeypatch):
+    root = _workspace(tmp_path, monkeypatch)
+    source = root / "src" / "payload.bin"
+    source.parent.mkdir()
+    source.write_bytes(b"a" * (128 * 1024))
+    cancel_event = threading.Event()
+    original_read = transfer_module._LeaseRefreshingReader.read
+
+    def cancel_on_first_read(self, size=-1):
+        cancel_event.set()
+        return original_read(self, size)
+
+    monkeypatch.setattr(transfer_module._LeaseRefreshingReader, "read", cancel_on_first_read)
+
+    with pytest.raises(InterruptedError, match="cancelled"):
+        transfer_pack_dir("src", compression="none", cancel_event=cancel_event)
+
+    temp = root / ".local-shell-mcp" / "tmp"
+    assert not list(temp.glob("transfer-pack-*"))
+    assert not list(temp.glob("transfer-pack-*.local-shell-mcp-active"))
+
+
+@pytest.mark.asyncio
+async def test_async_pack_cancellation_waits_for_thread_cleanup(tmp_path, monkeypatch):
+    _workspace(tmp_path, monkeypatch)
+    started = threading.Event()
+    stopped = threading.Event()
+
+    def blocking_pack(path, compression, cancel_event):
+        started.set()
+        assert cancel_event.wait(2)
+        stopped.set()
+        raise InterruptedError("transfer operation was cancelled")
+
+    monkeypatch.setattr(transfer_module, "transfer_pack_dir", blocking_pack)
+    task = asyncio.create_task(transfer_module.transfer_pack_dir_async("src", "none"))
+    for _ in range(100):
+        if started.is_set():
+            break
+        await asyncio.sleep(0.01)
+    assert started.is_set()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert stopped.is_set()
 
 
 def test_unpack_failure_preserves_existing_destination(tmp_path, monkeypatch):

--- a/tests/test_transfer_ops.py
+++ b/tests/test_transfer_ops.py
@@ -4,6 +4,7 @@ import asyncio
 import io
 import tarfile
 import threading
+from pathlib import Path
 
 import pytest
 
@@ -252,6 +253,36 @@ def test_directory_pack_cancellation_removes_active_archive(tmp_path, monkeypatc
     temp = root / ".local-shell-mcp" / "tmp"
     assert not list(temp.glob("transfer-pack-*"))
     assert not list(temp.glob("transfer-pack-*.local-shell-mcp-active"))
+
+
+def test_directory_pack_refreshes_archive_lease_for_directory_entries(tmp_path, monkeypatch):
+    root = _workspace(tmp_path, monkeypatch)
+    source = root / "src"
+    (source / "a" / "b" / "c").mkdir(parents=True)
+    original_refresh = transfer_module.refresh_temp_file_lease
+    refreshes: list[tuple[Path, bool]] = []
+    clock = 0.0
+
+    def advancing_monotonic():
+        nonlocal clock
+        clock += transfer_module._TEMP_LEASE_REFRESH_INTERVAL_S + 1.0
+        return clock
+
+    def record_refresh(path, *, create=True):
+        refreshes.append((path, create))
+        original_refresh(path, create=create)
+
+    monkeypatch.setattr(transfer_module.time, "monotonic", advancing_monotonic)
+    monkeypatch.setattr(transfer_module, "refresh_temp_file_lease", record_refresh)
+    monkeypatch.setattr(transfer_module, "_sha256_file", lambda *args, **kwargs: "digest")
+
+    pack = transfer_pack_dir("src", compression="none")
+    archive = transfer_module.resolve_path(pack["archive_path"], must_exist=True)
+    activity_refreshes = [
+        path for path, create in refreshes if path == archive and create is False
+    ]
+
+    assert len(activity_refreshes) >= 2
 
 
 def test_directory_snapshot_polls_cancellation_while_enumerating(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- make remote directory pack/unpack cooperatively cancellable instead of shielding them as non-cancellable worker operations
- protect active transfer temp files from shared tmp pruning with cross-process leases refreshed throughout pack/hash/read/write/unpack operations
- detect source-directory mutation during packing and fail/clean up instead of returning a race-dependent archive
- extend cancellation checks to large directory and archive-member enumeration paths
- add regression coverage for cancellation, active temp pruning, mutation detection, cleanup, and remote worker behavior

## Motivation
A large directory transfer can currently leave the transfer worker busy after the controller-side job is stopped. In a shared NFS workspace, `prune_temp_dir()` can also unlink an archive that is still open and being written. The resulting worker can keep heartbeating while the transfer lane remains occupied, and a directory being written concurrently can produce an inconsistent archive.

## Validation
- `ruff check .`
- `git diff --check`
- focused transfer/remote regression suite: `92 passed`
- full test suite: `915 passed, 1 skipped`
- HTTP smoke: passed
- authenticated MCP smoke: passed
- OpenTUI PTY smoke: passed
- Human UI browser smoke: passed
- coverage gates: `93.18%` total, every measured module >= `90%`
