### PR TITLE
docs: add dsh.so security badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 [![Docs](https://img.shields.io/badge/docs-fwerkor.github.io%2Flocal--shell--mcp-7c3aed?logo=materialformkdocs&logoColor=white)](https://fwerkor.github.io/local-shell-mcp/)
 [![CI](https://github.com/fwerkor/local-shell-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/fwerkor/local-shell-mcp/actions/workflows/ci.yml)
+[![dsh.so security](https://www.dsh.so/badge/local-shell-mcp.svg)](https://www.dsh.so/artifact/local-shell-mcp)
 [![Release](https://img.shields.io/github/v/release/fwerkor/local-shell-mcp?sort=semver)](https://github.com/fwerkor/local-shell-mcp/releases)
 [![Python](https://img.shields.io/badge/python-3.11%2B-3776ab?logo=python&logoColor=white)](https://github.com/fwerkor/local-shell-mcp)
 [![Docker](https://img.shields.io/badge/docker-ready-2496ed?logo=docker&logoColor=white)](https://github.com/fwerkor/local-shell-mcp/pkgs/container/local-shell-mcp)

--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ Read the dedicated [ChatGPT connector guide](https://fwerkor.github.io/local-she
 
 ## DeepSeek Harness plugin
 
+[![dsh.so install](https://www.dsh.so/badge/install/local-shell-mcp.svg)](https://www.dsh.so/artifact/local-shell-mcp)
+
 The repository root is also a DSH plugin bundle. With a normal LSM HTTP/MCP service running on the same host, install it directly into a DSH profile:
 
 ```bash


### PR DESCRIPTION
## Summary
- add the dsh.so risk/security report badge to the main README badge group
- add the dsh.so install-verification badge to the DeepSeek Harness plugin section
- link both badges to the local-shell-mcp artifact report

Both badge endpoints and the artifact target were verified. The risk badge uses the same 20px Shields-style layout as the existing top-level badges, so it remains in the main badge group.