### PR TITLE
fix(remote): expose worker CLI immediately after persistence

### DIFF
--- a/src/local_shell_mcp/remote.py
+++ b/src/local_shell_mcp/remote.py
@@ -572,7 +572,7 @@ class RemoteManager:
             "ttl_s": ttl,
             "join_url": join_url,
             "command": command,
-            "persistent_command": command + " --persist",
+            "persistent_command": command + ' --persist && export PATH="${LOCAL_SHELL_MCP_WORKER_BIN_DIR:-$HOME/.local/bin}:$PATH"',
             "powershell_join_url": powershell_join_url,
             "powershell_command": powershell_command,
             "powershell_persistent_command": powershell_command + " -Persist",

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -40,7 +40,7 @@ async def test_remote_invites_use_requested_origin_prune_expired_entries_and_val
 
     assert result["join_url"] == "https://control.example.test/join"
     assert "https://control.example.test/join" in result["command"]
-    assert result["persistent_command"].endswith(" --persist")
+    assert result["persistent_command"] == result["command"] + ' --persist && export PATH="${LOCAL_SHELL_MCP_WORKER_BIN_DIR:-$HOME/.local/bin}:$PATH"'
     assert result["powershell_join_url"] == "https://control.example.test/join.ps1"
     assert "https://control.example.test/join.ps1" in result["powershell_command"]
     assert result["powershell_persistent_command"].endswith(" -Persist")


### PR DESCRIPTION
After a successful POSIX remote-worker persistence install, update PATH in the invoking shell immediately so local-shell-mcp is available without reopening the terminal.\n\nAlso keeps support for LOCAL_SHELL_MCP_WORKER_BIN_DIR and updates invite command coverage.\n\nTests: 45 passed (remote invite/state/service subset).