### PR TITLE
chore: release v4.3.1

### DIFF
--- a/dsh/index.js
+++ b/dsh/index.js
@@ -206,7 +206,7 @@ export async function apply(ctx, rawConfig = {}) {
 
   async function connectClient(label, onClose, configure, extraHeaders) {
     const client = new Client(
-      { name: `local-shell-mcp-dsh-${label}`, version: '4.3.0' },
+      { name: `local-shell-mcp-dsh-${label}`, version: '4.3.1' },
       { capabilities: {} },
     )
     if (configure) configure(client)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-shell-mcp-dsh",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "DeepSeek Harness bridge for the full local-shell-mcp tool surface and per-session Live Workspace.",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "local-shell-mcp"
-version = "4.3.0"
+version = "4.3.1"
 description = "A ChatGPT-compatible OAuth MCP server that gives AI coding agents controlled shell, filesystem, remote-worker, and Playwright access inside a local container."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/local_shell_mcp/__init__.py
+++ b/src/local_shell_mcp/__init__.py
@@ -1,3 +1,3 @@
 """local-shell-mcp."""
 
-__version__ = "4.3.0"
+__version__ = "4.3.1"


### PR DESCRIPTION
Bump release version metadata from 4.3.0 to 4.3.1 and prepare the stable v4.3.1 release.